### PR TITLE
Add HTML template (from asyncapi-docgen package)

### DIFF
--- a/templates/html/.helpers/handlebars.js
+++ b/templates/html/.helpers/handlebars.js
@@ -1,0 +1,41 @@
+const Handlebars = require('handlebars');
+
+Handlebars.registerHelper('concat', (str1, str2, separator) => {
+  return `${str1 || ''}${separator || ''}${str2 || ''}`;
+});
+
+Handlebars.registerHelper('tree', path => {
+  if (!path) return;
+
+  const levels = path.split('.').length;
+  let result = '';
+
+  if (levels > 0) {
+    result = '<span class="tree-space"></span>'.repeat(levels-1);
+  }
+
+  return `${result}<span class="tree-leaf"></span>`;
+});
+
+Handlebars.registerHelper('equal', (lvalue, rvalue, options) => {
+  if (arguments.length < 3)
+    throw new Error('Handlebars Helper equal needs 2 parameters');
+  if (lvalue!==rvalue) {
+    return options.inverse(this);
+  }
+
+  return options.fn(this);
+});
+
+Handlebars.registerHelper('inc', (number) => {
+  return number + 1;
+});
+
+Handlebars.registerHelper('log', (something) => {
+  console.log(require('util').inspect(something, { depth: null }));
+});
+
+Handlebars.registerHelper('contains', (array, element) => {
+  if (!array) return false;
+  return array.indexOf(element) >= 0;
+})

--- a/templates/html/.partials/content.html
+++ b/templates/html/.partials/content.html
@@ -1,0 +1,5 @@
+{{> info}}
+{{> security}}
+{{~> topics ~}}
+{{> messages}}
+{{> schemas}}

--- a/templates/html/.partials/info.html
+++ b/templates/html/.partials/info.html
@@ -1,0 +1,81 @@
+<a name="info"></a>
+<h1>{{asyncapi.info.title}} {{asyncapi.info.version}}</h1>
+
+<p>{{{asyncapi.info.descriptionAsHTML}}}</p>
+
+{{#if asyncapi.info.termsOfService}}
+<a name="termsOfService"></a>
+<h2 class="info__terms-of-service__header">Terms of service</h2>
+<p><a href="{{asyncapi.info.termsOfService}}" target="_blank">{{asyncapi.info.termsOfService}}</a></p>
+{{/if}}
+
+{{#if asyncapi.servers}}
+  <a name="connectionDetails"></a>
+  <h2 class="info__servers__header">Connection details</h2>
+
+  <table class="table">
+    <thead class="table__head">
+      <tr class="table__head__row">
+        <th class="table__head__cell">URL</th>
+        <th class="table__head__cell">Scheme</th>
+        <th class="table__head__cell">Description</th>
+      </tr>
+    </thead>
+    <tbody class="table__body">
+    {{#each asyncapi.servers as |server|}}
+      <tr class="table__body__row">
+        <td class="table__body__cell">{{#if server.variables}}<div class="table__expand" data-index={{@index}}></div>{{/if}}{{server.url}}</td>
+        <td class="table__body__cell">{{server.scheme}}</td>
+        <td class="table__body__cell">{{{server.descriptionAsHTML}}}</td>
+      </tr>
+
+      {{#if server.variables}}
+      <tr class="table__body__row--with-nested" data-nested-index={{@index}}>
+        <td colspan="3">
+          <table class="table table--nested">
+            <thead class="table__head table--nested__head">
+              <tr>
+                <td class="table--nested__header" colspan="4">URL Variables</td>
+              </tr>
+              <tr class="table__head__row table--nested__head__row">
+                <th class="table__head__cell table--nested__head__cell">Name</th>
+                <th class="table__head__cell table--nested__head__cell">Default value</th>
+                <th class="table__head__cell table--nested__head__cell">Possible values</th>
+                <th class="table__head__cell table--nested__head__cell">Description</th>
+              </tr>
+            </thead>
+            <tbody class="table__body table--nested__body">
+              {{#each server.variables as |var|}}
+              <tr class="table__body__row table--nested__body__row">
+                <td class="table__body__cell table--nested__body__cell">{{@key}}</td>
+                <td class="table__body__cell table--nested__body__cell">
+                  {{#if var.default}}
+                    {{var.default}}
+                  {{else}}
+                    <em>None</em>
+                  {{/if}}
+                </td>
+                <td class="table__body__cell table--nested__body__cell">
+                  {{#if var.enum}}
+                  <ul class="info__server__enum-list">
+                    {{#each var.enum as |value|}}
+                    <li>{{value}}</li>
+                    {{/each}}
+                  </ul>
+                  {{else}}
+                    Any
+                  {{/if}}
+                </td>
+                <td class="table__body__cell table--nested__body__cell">{{{var.descriptionAsHTML}}}</td>
+              </tr>
+              {{/each}}
+            </tbody>
+          </table>
+        </td>
+      </tr>
+      {{/if}}
+    {{/each}}
+
+    </tbody>
+  </table>
+{{/if}}

--- a/templates/html/.partials/message.html
+++ b/templates/html/.partials/message.html
@@ -1,0 +1,48 @@
+<a name="message-{{messageName}}"></a>
+<div class="message">
+  <h3 class="message__header">
+    {{messageName}}
+    {{#if message.deprecated}}
+    <span class="operation-badge operation-badge--deprecated message__header__operation-badge">Deprecated</span>
+    {{/if}}
+  </h3>
+  {{{message.summaryAsHTML}}}
+  {{{message.descriptionAsHTML}}}
+
+  {{#if message.headers}}
+  <h4>Headers</h4>
+
+  {{> schema schema=message.headers schemaName='Message Headers' hideTitle=true}}
+  {{/if}}
+
+
+  {{#unless message.example}}
+  {{#if message.generatedHeadersExample}}
+    <h4>Example of headers <em>(generated)</em></h4>
+
+    <pre class="hljs"><code class="json">{{~message.generatedHeadersExample~}}</code></pre>
+  {{/if}}
+  {{/unless}}
+
+  <h4>Payload</h4>
+
+  {{> schema schema=message.payload schemaName='Message Payload' hideTitle=true}}
+
+  {{#if message.example}}
+  <h4>Example</h4>
+
+  <pre class="hljs"><code class="json">{{~message.formattedExample~}}</code></pre>
+  {{else}}
+    {{#if message.generatedPayloadExample}}
+    <h4>Example of payload <em>(generated)</em></h4>
+
+    <pre class="hljs"><code class="json">{{~message.generatedPayloadExample~}}</code></pre>
+    {{/if}}
+  {{/if}}
+
+{{#if operation.tags}}
+<h4>Tags</h4>
+
+{{> tags tags=operation.tags}}
+{{/if}}
+</div>

--- a/templates/html/.partials/messages.html
+++ b/templates/html/.partials/messages.html
@@ -1,0 +1,5 @@
+<h2 class="section-header">Messages</h2>
+
+{{#each asyncapi.components.messages}}
+  {{~>message message=. messageName=@key~}}
+{{/each}}

--- a/templates/html/.partials/operation.html
+++ b/templates/html/.partials/operation.html
@@ -1,0 +1,40 @@
+<div class="operation {{cssClasses}}">
+{{{operation.summaryAsHTML}}}
+{{{operation.descriptionAsHTML}}}
+
+{{#if operation.headers}}
+<h4>Headers</h4>
+
+{{> schema schema=operation.headers schemaName='Message Headers' hideTitle=true}}
+
+{{#unless operation.example}}
+{{#if operation.generatedHeadersExample}}
+  <h4>Example of headers <em>(generated)</em></h4>
+
+  <pre class="hljs"><code class="json">{{~operation.generatedHeadersExample~}}</code></pre>
+{{/if}}
+{{/unless}}
+{{/if}}
+
+<h4>Payload</h4>
+
+{{> schema schema=operation.payload schemaName='Message Payload' hideTitle=true}}
+
+{{#if operation.example}}
+<h4>Example</h4>
+
+<pre class="hljs"><code class="json">{{~operation.formattedExample~}}</code></pre>
+{{else}}
+  {{#if operation.generatedPayloadExample}}
+  <h4>Example of payload <em>(generated)</em></h4>
+
+  <pre class="hljs"><code class="json">{{~operation.generatedPayloadExample~}}</code></pre>
+  {{/if}}
+{{/if}}
+
+{{#if operation.tags}}
+<h4>Tags</h4>
+
+{{> tags tags=operation.tags}}
+{{/if}}
+</div>

--- a/templates/html/.partials/parameters.html
+++ b/templates/html/.partials/parameters.html
@@ -1,0 +1,18 @@
+<a name="parameters-{{topicName}}"></a>
+<div class="parameters">
+  {{#unless hideTitle}}
+  <h4>Topic Parameters</h4>
+  {{/unless}}
+
+  {{#each params as |param|}}
+    {{#if param.name}}
+    <h4>{{param.name}}</h4>
+    {{/if}}
+
+    {{#if param.descriptionAsHTML}}
+    <p>{{{param.descriptionAsHTML}}}</p>
+    {{/if}}
+
+    {{~> schema schema=param.schema schemaName=param.name hideTitle=true ~}}
+  {{/each}}
+</div>

--- a/templates/html/.partials/schema-prop.html
+++ b/templates/html/.partials/schema-prop.html
@@ -1,0 +1,35 @@
+<tr class="table__body__row">
+  <td class="table__body__cell">{{{tree path}}}{{propName}} {{#if required}}<span class="required-badge">(Required)</span>{{/if}}</td>
+  <td class="table__body__cell">{{prop.title}}</td>
+  <td class="table__body__cell">
+    {{prop.type}}
+    {{#if prop.anyOf}}anyOf{{/if}}
+    {{#if prop.oneOf}}oneOf{{/if}}
+    {{#if prop.items.type}}({{prop.items.type}}){{/if}}
+  </td>
+  <td class="table__body__cell">{{prop.format}}</td>
+  <td class="table__body__cell">{{prop.default}}</td>
+  <td class="table__body__cell">{{prop.description}}</td>
+</tr>
+{{#if prop.anyOf}}
+  {{#each prop.anyOf}}
+    {{> schemaProp prop=. propName=@key path=(concat ../path @key '.') required=(contains ../prop.required @key)}}
+  {{/each}}
+{{/if}}
+{{#if prop.oneOf}}
+  {{#each prop.oneOf}}
+    {{> schemaProp prop=. propName=@key path=(concat ../path @key '.') required=(contains ../prop.required @key)}}
+  {{/each}}
+{{/if}}
+{{#if prop.properties}}
+  {{#each prop.properties}}
+  {{> schemaProp prop=. propName=@key path=(concat ../path @key '.') required=(contains ../prop.required @key)}}
+  {{/each}}
+{{/if}}
+{{#if prop.items}}
+  {{#if prop.items.properties}}
+    {{#each prop.items.properties}}
+    {{> schemaProp prop=. propName=@key path=(concat ../path @key '.') required=(contains ../prop.items.required @key)}}
+    {{/each}}
+  {{/if}}
+{{/if}}

--- a/templates/html/.partials/schema.html
+++ b/templates/html/.partials/schema.html
@@ -1,0 +1,38 @@
+<a name="schema-{{schemaName}}"></a>
+<div class="schema">
+  {{#unless hideTitle}}
+  <h4>{{schemaName}}</h4>
+  {{/unless}}
+
+  <table class="table">
+    <thead class="table__head">
+      <tr class="table__head__row">
+        <th class="table__head__cell">Name</th>
+        <th class="table__head__cell">Title</th>
+        <th class="table__head__cell">Type</th>
+        <th class="table__head__cell">Format</th>
+        <th class="table__head__cell">Default</th>
+        <th class="table__head__cell">Description</th>
+      </tr>
+    </thead>
+    <tbody class="table__body">
+      {{#each schema.properties}}
+        {{> schemaProp prop=. propName=@key required=(contains ../schema.required @key)}}
+      {{else}}
+        {{> schemaProp prop=schema propName=schemaName required=(contains ../schema.required @key)}}
+      {{/each}}
+    </tbody>
+  </table>
+
+{{#if schema.example}}
+<h4>Example</h4>
+
+<pre class="hljs"><code class="json">{{~schema.formattedExample~}}</code></pre>
+{{else}}
+  {{#if schema.generatedExample}}
+  <h4>Example <em>(generated)</em></h4>
+
+  <pre class="hljs"><code class="json">{{~schema.generatedExample~}}</code></pre>
+  {{/if}}
+{{/if}}
+</div>

--- a/templates/html/.partials/schemas.html
+++ b/templates/html/.partials/schemas.html
@@ -1,0 +1,5 @@
+<h2 class="section-header">Schemas</h2>
+
+{{#each asyncapi.components.schemas}}
+  {{~>schema schema=. schemaName=@key~}}
+{{/each}}

--- a/templates/html/.partials/security.html
+++ b/templates/html/.partials/security.html
@@ -1,0 +1,30 @@
+{{#if asyncapi._security}}
+<a name="security"></a>
+<h2 class="security__header">Security</h2>
+
+<table class="table">
+  <thead class="table__head">
+    <tr class="table__head__row">
+      <th class="table__head__cell">Type</th>
+      <th class="table__head__cell">In</th>
+      <th class="table__head__cell">Name</th>
+      <th class="table__head__cell">Scheme</th>
+      <th class="table__head__cell">Format</th>
+      <th class="table__head__cell">Description</th>
+    </tr>
+  </thead>
+  <tbody class="table__body">
+  {{#each asyncapi._security as |security|}}
+    <tr class="table__body__row">
+      <td class="table__body__cell">{{security.type}}</td>
+      <td class="table__body__cell">{{security.in}}</td>
+      <td class="table__body__cell">{{security.name}}</td>
+      <td class="table__body__cell">{{security.scheme}}</td>
+      <td class="table__body__cell">{{security.bearerFormat}}</td>
+      <td class="table__body__cell">{{{security.descriptionAsHTML}}}</td>
+    </tr>
+  {{/each}}
+
+  </tbody>
+</table>
+{{/if}}

--- a/templates/html/.partials/tags.html
+++ b/templates/html/.partials/tags.html
@@ -1,0 +1,7 @@
+<div class="tags">
+{{#each tags}}
+  <div class="tags__tag">{{./name}}</div>
+{{else}}
+  <div class="tags__no-tags">No tags</div>
+{{/each}}
+</div>

--- a/templates/html/.partials/topic.html
+++ b/templates/html/.partials/topic.html
@@ -1,0 +1,49 @@
+<div class="topic">
+  <a name="topic-{{topicName}}"></a>
+  <h3 class="topic__header">
+    {{#if topic.deprecated}}
+    <span class="operation-badge operation-badge--deprecated topic__header__operation-badge">Deprecated</span>
+    {{/if}}
+
+    {{#if topic.publish}}
+    <span class="operation-badge operation-badge--publish topic__header__operation-badge">Publish</span>
+    {{/if}}
+
+    {{#if topic.subscribe}}
+    <span class="operation-badge operation-badge--subscribe topic__header__operation-badge">Subscribe</span>
+    {{/if}}
+
+    {{topicName}}
+  </h3>
+
+  {{#if topic.parameters}}
+  {{~> parameters params=topic.parameters topicName=topicName ~}}
+  {{/if}}
+
+  <h4>Message</h4>
+
+  {{#if topic.publish.oneOf}}
+  <p>You can send one of the following messages:</p>
+  {{/if}}
+  {{#if topic.subscribe.oneOf}}
+  <p>You can send one of the following messages:</p>
+  {{/if}}
+
+  {{~#each topic.publish.oneOf as |op index| ~}}
+    <h4>Message #{{inc index}}</h4>
+    {{~> operation operation=op cssClasses='operation--indented'~}}
+  {{else}}
+    {{~#if topic.publish ~}}
+      {{~> operation operation=topic.publish~}}
+    {{~/if~}}
+  {{~/each~}}
+
+  {{~#each topic.subscribe.oneOf as |op index| ~}}
+    <h4>Message #{{inc index}}</h4>
+    {{~> operation operation=op cssClasses='operation--indented'~}}
+  {{else}}
+    {{~#if topic.subscribe ~}}
+      {{~> operation operation=topic.subscribe~}}
+    {{~/if~}}
+  {{~/each~}}
+</div>

--- a/templates/html/.partials/topics.html
+++ b/templates/html/.partials/topics.html
@@ -1,0 +1,5 @@
+<h2 class="section-header">Topics</h2>
+
+{{#each asyncapi.topics}}
+  {{~>topic topic=. topicName=@key ~}}
+{{/each}}

--- a/templates/html/css/main.css
+++ b/templates/html/css/main.css
@@ -1,0 +1,294 @@
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Helvetica Neue', Helvetica, Arial, Verdana, sans-serif;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+  -webkit-font-smoothing: antialiased;
+  font-smoothing: antialiased;
+}
+
+.navigation {
+  position: fixed;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 300px;
+  background: #263238;
+  overflow: auto;
+  padding-bottom: 60px;
+}
+
+.navigation__logo {
+  padding: 20px 10px;
+  margin-bottom: 10px;
+  background-color: #263238;
+  color: #fff;
+  text-align: center;
+  border-bottom: #212b31 2px solid;
+}
+.navigation__logo__image {
+  max-height: 100px;
+}
+.navigation__logo__name {
+  font-size: 18px;
+}
+
+.navigation__header {
+  display: block;
+  color: #fff;
+  margin-top: 50px;
+  margin-bottom: 20px;
+  font-weight: bold;
+  font-size: 18px;
+  padding-left: 20px;
+}
+
+.navigation__list {
+  list-style: none;
+  padding-left: 0;
+}
+
+.navigation__list__item-text {
+  display: block;
+  color: #ccc;
+  text-decoration: none;
+  padding: 7px 7px 7px 20px;
+  font-size: 14px;
+}
+
+.navigation__list__item-text--link:hover {
+  background-color: #3e515b;
+}
+
+.navigation__list__item-text--link--active {
+  background-color: #3e515b;
+}
+
+.navigation__list__item__topic-indicator {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+}
+.navigation__list__item__topic-indicator--publish {
+  background: #d4e157;
+}
+.navigation__list__item__topic-indicator--subscribe {
+  background: #039be5;
+}
+.navigation__list__item__topic-indicator--deprecated {
+  background: #ffa726;
+}
+
+.documentation {
+  position: absolute;
+  left: 300px;
+  top: 0;
+  right: 0;
+  padding: 20px 40px;
+}
+
+.info__terms-of-service__header {
+  font-size: 20px;
+}
+
+.info__server__enum-list {
+  padding-left: 1em;
+  margin: 0;
+}
+
+.security__header {
+  font-size: 20px;
+}
+
+.section-header {
+  border-bottom: #333 2px solid;
+  padding-bottom: 10px;
+  margin: 40px 0;
+}
+
+.topic {
+  margin-bottom: 60px;
+}
+.topic__header {
+  font-size: 20px;
+}
+.topic__header__operation-badge {
+  display: block;
+  float: left;
+  margin-top: -2px;
+  margin-right: 10px;
+}
+
+.operation--indented {
+  padding-left: 15px;
+  border-left: #263238 2px solid;
+}
+
+.operation-badge {
+  display: inline-block;
+  font-size: 12px;
+  border-radius: 5px;
+  padding: 3px 10px;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.operation-badge--publish {
+  background: #d4e157;
+  color: #333;
+}
+.operation-badge--subscribe {
+  background: #039be5;
+  color: white;
+}
+.operation-badge--deprecated {
+  background: #ffa726;
+  color: white;
+}
+
+.required-badge {
+  display: inline-block;
+  font-weight: bold;
+  font-size: 12px;
+  background-color: #666;
+  color: white;
+  border-radius: 3px;
+  padding: 0 5px;
+  margin-left: 5px;
+  float: right;
+}
+
+.table {
+  margin: 0 0 40px 0;
+  width: 100%;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+  border-spacing: 0;
+}
+.table__head__row {
+  font-weight: 900;
+  color: #ffffff;
+  background: #00796b;
+}
+.table__head__cell {
+  padding: 6px 12px;
+  text-align: left;
+}
+.table__body__row {
+  background: #f6f6f6;
+}
+.table__body__row:nth-of-type(odd) {
+  background: #e9e9e9;
+}
+.table__body__cell {
+  padding: 6px 12px;
+  vertical-align: top;
+}
+.table__body__cell p {
+  margin-top: 0;
+}
+.table__expand {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 7px solid black;
+  margin-right: 10px;
+  transition: .5s ease;
+  cursor: pointer;
+}
+.table__expand--open {
+  transform: rotate(90deg);
+}
+.table__body__row--with-nested .table--nested {
+  display: block;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 1s ease;
+}
+.table__body__row--with-nested--expanded .table--nested {
+  max-height: 300px;
+}
+.table--nested {
+  margin: 0;
+  width: 100%;
+  box-shadow: none;
+  border-spacing: 0;
+  font-size: 13px;
+}
+.table--nested__header {
+  background-color: #37474f;
+  color: #eee;
+  font-weight: bold;
+  text-align: center;
+  padding: 5px 0;
+}
+.table--nested__head__row {
+  background-color: #455a64;
+  color: #eee;
+}
+.table--nested__head__cell {
+  width: 20%;
+}
+.table--nested__body__row {
+  background: #78909c;
+  color: #333;
+}
+.table--nested__body__row:nth-of-type(odd) {
+  background: #90a4ae;
+}
+
+.tree-space {
+  display: inline-block;
+  width: 15px;
+}
+.tree-leaf {
+  display: inline-block;
+  position: relative;
+  width: 25px;
+}
+.tree-leaf::before {
+  content: ' ';
+  position: absolute;
+  top: -15px;
+  width: 10px;
+  height: 10px;
+  border-left: #aaa 1px solid;
+  border-bottom: #aaa 1px solid;
+  border-radius: 0 0 0 3px;
+}
+
+.tags__tag {
+  display: inline-block;
+  background-color: #607d8b;
+  padding: 3px 7px;
+  border-radius: 5px;
+}
+.tags__no-tags {
+  font-style: italic;
+}
+
+.message {
+  margin-bottom: 60px;
+}
+
+.schema {
+  margin-bottom: 30px;
+}
+
+code {
+  padding: 3px 5px;
+  background-color: #eee;
+  word-break: break-all;
+}
+
+pre code {
+  display: block;
+}

--- a/templates/html/index.html
+++ b/templates/html/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{asyncapi.info.title}} {{asyncapi.info.version}} documentation</title>
+  <link rel="stylesheet" href="css/main.css" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/atom-one-dark.min.css" />
+</head>
+<body>
+  <div class="navigation">
+    <div class="navigation__logo">
+      {{#if asyncapi.info.x-logo}}
+      <img class="navigation__logo__image" src="{{asyncapi.info.x-logo}}" alt="{{asyncapi.info.title}} logo">
+      {{/if}}
+      <h1 class="navigation__logo__name">{{asyncapi.info.title}}</h1>
+      <div class="navigation__logo__version">{{asyncapi.info.version}}</div>
+    </div>
+    <h2 class="navigation__header">Introduction</h2>
+    <ul class="navigation__list">
+      <li clas="navigation__list__item">
+        <a class="navigation__list__item-text navigation__list__item-text--link" href="#info">Basic Information</a>
+      </li>
+      {{#if asyncapi.info.termsOfService}}
+      <li clas="navigation__list__item">
+        <a class="navigation__list__item-text navigation__list__item-text--link" href="#termsOfService">Terms of Service</a>
+      </li>
+      {{/if}}
+      {{#if asyncapi.servers}}
+      <li clas="navigation__list__item">
+        <a class="navigation__list__item-text navigation__list__item-text--link" href="#connectionDetails">Connection Details</a>
+      </li>
+      {{/if}}
+    </ul>
+
+    <h2 class="navigation__header">Topics</h2>
+    <ul class="navigation__list">
+      {{#each asyncapi.topics}}
+      <li class="navigation__list__item">
+        <a class="navigation__list__item-text navigation__list__item-text--link" href="#topic-{{@key}}">
+          {{#if ./deprecated}}<span class="navigation__list__item__topic-indicator navigation__list__item__topic-indicator--deprecated" title="Deprecated"></span>{{/if}}
+          {{#if ./publish}}<span class="navigation__list__item__topic-indicator navigation__list__item__topic-indicator--publish" title="Publish"></span>{{/if}}
+          {{#if ./subscribe}}<span class="navigation__list__item__topic-indicator navigation__list__item__topic-indicator--subscribe" title="Subscribe"></span>{{/if}}
+          {{@key}}
+        </a>
+      </li>
+      {{/each}}
+    </ul>
+
+    <h2 class="navigation__header">Messages</h2>
+    <ul class="navigation__list">
+      {{#each asyncapi.components.messages}}
+      <li clas="navigation__list__item">
+        <a class="navigation__list__item-text navigation__list__item-text--link" href="#message-{{@key}}">{{@key}}</a>
+      </li>
+      {{/each}}
+    </ul>
+
+    <h2 class="navigation__header">Schemas</h2>
+    <ul class="navigation__list">
+      {{#each asyncapi.components.schemas}}
+      <li clas="navigation__list__item">
+        <a class="navigation__list__item-text navigation__list__item-text--link" href="#schema-{{@key}}">{{@key}}</a>
+      </li>
+      {{/each}}
+    </ul>
+  </div>
+  <div class="documentation">
+    {{~> content ~}}
+  </div>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js" type="application/javascript"></script>
+  <script type="application/javascript">
+    function removeCurrentLinkSelection () {
+      var links = document.querySelectorAll('.navigation__list__item-text--link');
+      if (!links) return;
+
+      for (var i=0; i < links.length; i++) {
+        links[i].classList.remove('navigation__list__item-text--link--active');
+      }
+    }
+
+    function selectCurrentLink () {
+      removeCurrentLinkSelection();
+
+      var hash = window.location.hash;
+      if (!hash) return;
+
+      var link = document.querySelector("a[href='"+hash+"']");
+      if (!link) return;
+
+      link.classList.add('navigation__list__item-text--link--active');
+    }
+
+    function highlightCode () {
+      var blocks = document.querySelectorAll('.hljs code');
+
+      for(var i=0; i < blocks.length; i++) {
+        hljs.highlightBlock(blocks[i]);
+      }
+    }
+
+    function bindExpandButtons () {
+      var buttons = document.querySelectorAll('.table__expand');
+
+      for(var i=0; i < buttons.length; i++) {
+        buttons[i].addEventListener('click', function (e) {
+          var tableRow = document.querySelector('[data-nested-index="' + e.target.attributes['data-index'].value + '"]');
+          tableRow.classList.toggle('table__body__row--with-nested--expanded');
+          e.target.classList.toggle('table__expand--open');
+        });
+      }
+    }
+
+    window.addEventListener('hashchange', selectCurrentLink);
+    window.addEventListener('load', selectCurrentLink);
+    window.addEventListener('load', highlightCode);
+    window.addEventListener('load', bindExpandButtons);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### What?
It adds a template for HTML documentation generation. The template is exactly the same you can find at https://github.com/asyncapi/docgen.

### Why?
The idea is to migrate both, `docgen` and `node-codegen`, to this package because it provides much more flexibility and we'll have to maintain only one package.