### PR TITLE
Add getTemplateFile and generateTemplateFile functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,70 @@ Specify where to put the result:
 ag -o ./docs asyncapi.yaml markdown
 ```
 
+### As a module
+
+#### .generateTemplateFile(options) : String
+
+Generates a file of a given template, and returns the result as a string.
+
+##### Parameters
+
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|options|`object`|Yes|An object containing all the options.|
+|options.templateDir|`string`|No|Directory where to find the templates. Defaults to internal templates directory.|
+|options.template|`string`|Yes|Name of the template you want to use.|
+|options.file|`string`|Yes|Path to the file you want to generate.|
+|options.config|`object`|Yes|An object containing configuration options.|
+|options.config.asyncapi|`string|object`|Yes|Path to the AsyncAPI file to use
+
+##### Example
+
+```js
+const generator = require('asyncapi-generator');
+
+generator.generateTemplateFile({
+  template: 'html',
+  file: 'index.html',
+  config: {
+    asyncapi: path.resolve(__dirname, 'asyncapi.yml'),
+  }
+})
+  .then((result) => {
+    // `result` is a string containing the generated file.
+    console.log(result);
+  })
+  .catch(console.error);
+```
+
+#### .getTemplateFile(options) : String
+
+Gets a file of a given template, and returns the its content as a string.
+
+##### Parameters
+
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|options|`object`|Yes|An object containing all the options.|
+|options.templateDir|`string`|No|Directory where to find the templates. Defaults to internal templates directory.|
+|options.template|`string`|Yes|Name of the template you want to use.|
+|options.file|`string`|Yes|Path to the file you want to generate.|
+
+##### Example
+
+```js
+const generator = require('asyncapi-generator');
+
+generator.getTemplateFile({
+  template: 'html',
+  file: 'css/main.css',
+})
+  .then((content) => {
+    console.log(result);
+  })
+  .catch(console.error);
+```
+
 ## Requirements
 
 * Node.js v7.6+

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Generates a file of a given template, and returns the result as a string.
 |options.template|`string`|Yes|Name of the template you want to use.|
 |options.file|`string`|Yes|Path to the file you want to generate.|
 |options.config|`object`|Yes|An object containing configuration options.|
-|options.config.asyncapi|`string|object`|Yes|Path to the AsyncAPI file to use
+|options.config.asyncapi|`string`&#124;`object`|Yes|Path to the AsyncAPI file to use.
 
 ##### Example
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -12,6 +12,28 @@ const parse = require('./parser');
 const generator = module.exports;
 
 /**
+ * Renders the content of a file and outputs it.
+ *
+ * @private
+ * @param  {String} filePath  Path to the file you want to render.
+ * @param  {String} data      Data to pass the template during rendering.
+ * @return {Promise}
+ */
+const renderFile = (filePath, data) => new Promise((resolve, reject) => {
+  fs.readFile(filePath, 'utf8', (err, content) => {
+    if (err) return reject(err);
+
+    try {
+      const template = Handlebars.compile(content);
+      const parsed_content = template(data);
+      resolve(parsed_content);
+    } catch (e) {
+      reject(e);
+    }
+  });
+});
+
+/**
  * Generates a file.
  *
  * @private
@@ -30,12 +52,8 @@ const generateFile = options => new Promise((resolve, reject) => {
   const root = options.root;
   const data = options.data;
 
-  fs.readFile(path.resolve(root, file_name), 'utf8', (err, content) => {
-    if (err) return reject(err);
-
-    try {
-      const template = Handlebars.compile(content);
-      const parsed_content = template(data);
+  renderFile(path.resolve(root, file_name), data)
+    .then((parsed_content) => {
       const template_path = path.relative(templates_dir, path.resolve(root, file_name));
       const generated_path = path.resolve(target_dir, template_path);
 
@@ -43,10 +61,8 @@ const generateFile = options => new Promise((resolve, reject) => {
         if (err) return reject(err);
         resolve();
       });
-    } catch (e) {
-      reject(e);
-    }
-  });
+    })
+    .catch(reject);
 });
 
 /**
@@ -255,16 +271,7 @@ const bundle = async (asyncapi) => {
   return asyncapi;
 };
 
-/**
- * Outputs the result of compiling a template.
- *
- * @module generator.generate
- * @param  {Object}        config Configuration options
- * @param  {Object|String} config.asyncapi AsyncAPI JSON or a string pointing to an AsyncAPI file.
- * @param  {String}        config.target_dir Path to the directory where the files will be generated.
- * @return {Promise}
- */
-generator.generate = config => new Promise((resolve, reject) => {
+const bundleAndApplyDefaults = config => new Promise((resolve, reject) => {
   bundle(config.asyncapi)
     .then((asyncapi) => {
       config.asyncapi = beautifier(asyncapi);
@@ -289,13 +296,85 @@ generator.generate = config => new Promise((resolve, reject) => {
 
       config.templates = `${config.templates}/${config.template}`;
 
+      resolve(config);
+    })
+    .catch(reject);
+});
+
+/**
+ * Outputs the result of compiling a template.
+ *
+ * @module generator.generate
+ * @param  {Object}        config Configuration options
+ * @param  {Object|String} config.asyncapi AsyncAPI JSON or a string pointing to an AsyncAPI file.
+ * @param  {String}        config.target_dir Path to the directory where the files will be generated.
+ * @return {Promise}
+ */
+generator.generate = config => new Promise((resolve, reject) => {
+  bundleAndApplyDefaults(config)
+    .then((cfg) => {
       async function start () {
-        await registerHelpers(config);
-        await registerPartials(config);
-        await generateDirectoryStructure(config);
+        await registerHelpers(cfg);
+        await registerPartials(cfg);
+        await generateDirectoryStructure(cfg);
       }
 
       start().then(resolve).catch(reject);
     })
     .catch(reject);
+});
+
+/**
+ * Generates a file in a given template.
+ *
+ * @param  {object} options
+ * @param  {string} [templatesDir] Directory where templates are located. Defaults to internal template directory.
+ * @param  {string} template Name of the template to use.
+ * @param  {string} file Path to the template file you want to generate.
+ * @param  {object} config Configuration options.
+ * @param  {string|object} asyncapi An AsyncAPI definition.
+ * @return {Promise<string, Error>} A promise that resolves with the generated content.
+ */
+generator.generateTemplateFile = ({
+  templatesDir = path.resolve(__dirname, '../templates'),
+  template,
+  file,
+  config,
+}) => new Promise((resolve, reject) => {
+  bundleAndApplyDefaults({
+    ...config,
+    ...{
+      template,
+    }
+  })
+  .then((cfg) => {
+    async function start () {
+      await registerHelpers(cfg);
+      await registerPartials(cfg);
+      return renderFile(path.resolve(templatesDir, template, file), cfg);
+    }
+
+    return start().then(resolve).catch(reject);
+  })
+  .catch(reject);
+});
+
+/**
+ * Reads the content of a file in a given template.
+ *
+ * @param  {object} options
+ * @param  {string} [templatesDir] Directory where templates are located. Defaults to internal template directory.
+ * @param  {string} template Name of the template to use.
+ * @param  {string} file Path to the template file you want to generate.
+ * @return {Promise<string, Error>} A promise that resolves with the generated content.
+ */
+generator.getTemplateFile = ({
+  templatesDir = path.resolve(__dirname, '../templates'),
+  template,
+  file,
+}) => new Promise((resolve, reject) => {
+  fs.readFile(path.resolve(templatesDir, template, file), 'utf8', (err, content) => {
+    if (err) return reject(err);
+    resolve(content);
+  });
 });


### PR DESCRIPTION
### What?
It adds:

- [x] getTemplateFile() — A function to get the raw content of a file in a given template.
- [x] generateTemplateFile() — A function to generate a file in a given template, and return it as a string.
- [x] Documentation on how to use it.

### Why?
We need to be able to programmatically use this module in the editor.