### PR TITLE
Pure markdown headings

### DIFF
--- a/templates/markdown/.partials/message.md
+++ b/templates/markdown/.partials/message.md
@@ -1,9 +1,4 @@
-<h3 class="message__header">
-  {{messageName}}
-  {{#if message.deprecated}}
-  <em>Deprecated</em>
-  {{/if}}
-</h3>
+### {{#if message.deprecated}} *Deprecated*{{/if}} {{messageName}}
 {{#if message.summary}}
 {{{message.summary}}}
 

--- a/templates/markdown/.partials/message.md
+++ b/templates/markdown/.partials/message.md
@@ -1,4 +1,4 @@
-### {{#if message.deprecated}} *Deprecated*{{/if}} {{messageName}}
+### {{messageName}} {{#if message.deprecated}} (**deprecated**){{/if}} 
 {{#if message.summary}}
 {{{message.summary}}}
 

--- a/templates/markdown/.partials/topic.md
+++ b/templates/markdown/.partials/topic.md
@@ -1,6 +1,6 @@
 <a name="topic-{{topicName}}"></a>
 
-### {{~#if topic.deprecated}} *Deprecated*{{~/if}}{{~#if topic.publish}} `publish`{{~/if}}{{~#if topic.subscribe}} `subscribe`{{~/if}} {{topicName}}
+### {{~#if topic.publish}} `publish`{{~/if}}{{~#if topic.subscribe}} `subscribe`{{~/if}} {{topicName}} {{~#if topic.deprecated}} (**deprecated**){{~/if}}
 
 {{#if topic.parameters}}
 {{~> parameters params=topic.parameters topicName=topicName ~}}

--- a/templates/markdown/.partials/topic.md
+++ b/templates/markdown/.partials/topic.md
@@ -1,10 +1,6 @@
 <a name="topic-{{topicName}}"></a>
-<h3>
-{{~#if topic.deprecated}}<em>Deprecated</em>{{~/if}}
-{{~#if topic.publish}}<code>publish</code>{{~/if}}
-{{~#if topic.subscribe}}<code>subscribe</code>{{~/if}}
-{{topicName}}
-</h3>
+
+### {{~#if topic.deprecated}} *Deprecated*{{~/if}}{{~#if topic.publish}} `publish`{{~/if}}{{~#if topic.subscribe}} `subscribe`{{~/if}} {{topicName}}
 
 {{#if topic.parameters}}
 {{~> parameters params=topic.parameters topicName=topicName ~}}


### PR DESCRIPTION
Markdown template: I replaced the HTML headings with pure markdown for two reasons:

1. Markdown should contain as much markdown as possible instead of HTML.
2. If you use documentation generators for markdown such as MkDocs, it will fail to generate good table of contents as it is missing all the HTML headings. This leads to a not very useful TOC such as:

```
Table of Contents
Topics
Message
Payload
Example
Message
Payload
Example
Message
Payload
Example
Message
Payload
Example
Message
Payload
Example
...
```