### PR TITLE
Don't show "messages" header if there are no messages defined.

### DIFF
--- a/templates/markdown/.partials/messages.md
+++ b/templates/markdown/.partials/messages.md
@@ -1,4 +1,6 @@
+{{#unless asyncapi.__noMessages}}
 ## Messages
+{{/unless}}
 
 {{#each asyncapi.components.messages}}
 {{~>message message=. messageName=@key~}}


### PR DESCRIPTION
The TOC item is not shown, but the header was still in the markdown file. This PR makes it consistent.