### PR TITLE
Clean-up HTML / Markdown

### DIFF
--- a/templates/markdown/.partials/info.md
+++ b/templates/markdown/.partials/info.md
@@ -8,67 +8,64 @@
 <a name="servers"></a>
 ## Connection details
 
-<table class="table">
-  <thead class="table__head">
-    <tr class="table__head__row">
-      <th class="table__head__cell">URL</th>
-      <th class="table__head__cell">Scheme</th>
-      <th class="table__head__cell">Description</th>
+<table>
+  <thead>
+    <tr>
+      <th>URL</th>
+      <th>Scheme</th>
+      <th>Description</th>
     </tr>
   </thead>
-  <tbody class="table__body">
+  <tbody>
   {{#each asyncapi.servers as |server|}}
-    <tr class="table__body__row">
-      <td class="table__body__cell">{{#if server.variables}}<div class="table__expand" data-index={{@index}}></div>{{/if}}{{server.url}}</td>
-      <td class="table__body__cell">{{server.scheme}}</td>
-      <td class="table__body__cell">{{{server.description}}}</td>
+    <tr>
+      <td>{{server.url}}</td>
+      <td>{{server.scheme}}</td>
+      <td>{{{server.description}}}</td>
     </tr>
 
     {{#if server.variables}}
-    <tr class="table__body__row--with-nested" data-nested-index={{@index}}>
+    <tr>
       <td colspan="3">
-        <details>
-          <summary>Show more</summary>
-          <table class="table table--nested">
-            <thead class="table__head table--nested__head">
-              <tr>
-                <td class="table--nested__header" colspan="4">URL Variables</td>
-              </tr>
-              <tr class="table__head__row table--nested__head__row">
-                <th class="table__head__cell table--nested__head__cell">Name</th>
-                <th class="table__head__cell table--nested__head__cell">Default value</th>
-                <th class="table__head__cell table--nested__head__cell">Possible values</th>
-                <th class="table__head__cell table--nested__head__cell">Description</th>
-              </tr>
-            </thead>
-            <tbody class="table__body table--nested__body">
-              {{#each server.variables as |var|}}
-              <tr class="table__body__row table--nested__body__row">
-                <td class="table__body__cell table--nested__body__cell">{{@key}}</td>
-                <td class="table__body__cell table--nested__body__cell">
-                  {{#if var.default}}
-                    {{var.default}}
-                  {{else}}
-                    <em>None</em>
-                  {{/if}}
-                </td>
-                <td class="table__body__cell table--nested__body__cell">
-                  {{#if var.enum}}
-                  <ul class="info__server__enum-list">
-                    {{#each var.enum as |value|}}
-                    <li>{{value}}</li>
-                    {{/each}}
-                  </ul>
-                  {{else}}
-                    Any
-                  {{/if}}
-                </td>
-                <td class="table__body__cell table--nested__body__cell">{{{var.description}}}</td>
-              </tr>
-              {{/each}}
-            </tbody>
-          </table>
-        </details>
+        <table>
+          <thead>
+            <tr>
+              <td colspan="4">URL Variables</td>
+            </tr>
+            <tr>
+              <th>Name</th>
+              <th>Default value</th>
+              <th>Possible values</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{#each server.variables as |var|}}
+            <tr>
+              <td>{{@key}}</td>
+              <td>
+                {{#if var.default}}
+                  {{var.default}}
+                {{else}}
+                  <em>None</em>
+                {{/if}}
+              </td>
+              <td>
+                {{#if var.enum}}
+                <ul>
+                  {{#each var.enum as |value|}}
+                  <li>{{value}}</li>
+                  {{/each}}
+                </ul>
+                {{else}}
+                  Any
+                {{/if}}
+              </td>
+              <td>{{{var.description}}}</td>
+            </tr>
+            {{/each}}
+          </tbody>
+        </table>
       </td>
     </tr>
     {{/if}}

--- a/templates/markdown/.partials/security.md
+++ b/templates/markdown/.partials/security.md
@@ -2,29 +2,28 @@
 <a name="security"></a>
 ## Security
 
-<table class="table">
-  <thead class="table__head">
-    <tr class="table__head__row">
-      <th class="table__head__cell">Type</th>
-      <th class="table__head__cell">In</th>
-      <th class="table__head__cell">Name</th>
-      <th class="table__head__cell">Scheme</th>
-      <th class="table__head__cell">Format</th>
-      <th class="table__head__cell">Description</th>
+<table>
+  <thead>
+    <tr>
+      <th>Type</th>
+      <th>In</th>
+      <th>Name</th>
+      <th>Scheme</th>
+      <th>Format</th>
+      <th>Description</th>
     </tr>
   </thead>
-  <tbody class="table__body">
+  <tbody>
   {{#each asyncapi._security as |security|}}
-    <tr class="table__body__row">
-      <td class="table__body__cell">{{security.type}}</td>
-      <td class="table__body__cell">{{security.in}}</td>
-      <td class="table__body__cell">{{security.name}}</td>
-      <td class="table__body__cell">{{security.scheme}}</td>
-      <td class="table__body__cell">{{security.bearerFormat}}</td>
-      <td class="table__body__cell">{{{security.descriptionAsHTML}}}</td>
+    <tr>
+      <td>{{security.type}}</td>
+      <td>{{security.in}}</td>
+      <td>{{security.name}}</td>
+      <td>{{security.scheme}}</td>
+      <td>{{security.bearerFormat}}</td>
+      <td>{{{security.descriptionAsHTML}}}</td>
     </tr>
   {{/each}}
-
   </tbody>
 </table>
 {{/if}}

--- a/templates/markdown/.partials/tags.md
+++ b/templates/markdown/.partials/tags.md
@@ -1,7 +1,5 @@
-<div class="tags">
+
 {{#each tags}}
-  <div class="tags__tag">{{./name}}</div>
-{{else}}
-  <div class="tags__no-tags">No tags</div>
+* {{./name}}
 {{/each}}
-</div>
+

--- a/templates/markdown/.partials/topic.md
+++ b/templates/markdown/.partials/topic.md
@@ -21,7 +21,7 @@ You can receive one of the following messages:
 
 {{~#each topic.publish.oneOf as |op index| ~}}
   ##### Message #{{inc index}}
-  {{~> operation operation=op cssClasses='operation--indented'~}}
+  {{~> operation operation=op~}}
 {{else}}
   {{~#if topic.publish ~}}
     {{~> operation operation=topic.publish~}}
@@ -30,7 +30,7 @@ You can receive one of the following messages:
 
 {{~#each topic.subscribe.oneOf as |op index| ~}}
   ##### Message #{{inc index}}
-  {{~> operation operation=op cssClasses='operation--indented'~}}
+  {{~> operation operation=op~}}
 {{else}}
   {{~#if topic.subscribe ~}}
     {{~> operation operation=topic.subscribe~}}


### PR DESCRIPTION
The markdown generated is pretty dirty as it has a lot of HTML markup in the files. It makes the temples prone to errors as HTML is more complex (see #9) and can have side effects with some markdown tooling (see #12). Additionally, there are CSS classes all over the place, which can easily be replaced with simple CSS element selectors. Also, list of tags for example can easily be represented as lists for example, instead of nested divs. So this is my proposal to clean things up and simplify the markdown templates.