### PR TITLE
change parser to throw errors to callers and increment generator version

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -59,12 +59,12 @@ async function parse (filePath) {
       content = JSON.stringify(filePath);
     } else {
       console.error(`Could not find a valid asyncapi definition: ${filePath}`);
-      return;
+      throw `Could not find a valid asyncapi definition: ${filePath}`;
     }
   } catch (e) {
     console.error('Can not load the content of the AsyncAPI specification file');
     console.error(e);
-    return;
+    throw e;
   }
 
   try {
@@ -72,7 +72,7 @@ async function parse (filePath) {
   } catch (e) {
     console.error('Can not parse the content of the AsyncAPI specification file');
     console.error(e);
-    return;
+    throw e;
   }
 
   try {
@@ -80,7 +80,7 @@ async function parse (filePath) {
   } catch (e) {
     console.error('Can not dereference the JSON obtained from the content of the AsyncAPI specification file');
     console.error(e);
-    return;
+    throw e;
   }
 
   try {
@@ -88,7 +88,7 @@ async function parse (filePath) {
   } catch (e) {
     console.error('Can not bundle the JSON obtained from the content of the AsyncAPI specification file');
     console.error(e);
-    return;
+    throw e;
   }
 
   try {
@@ -97,7 +97,7 @@ async function parse (filePath) {
   } catch (e) {
     console.error('Invalid JSON obtained from the content of the AsyncAPI specification file');
     console.error(e);
-    return;
+    throw e;
   }
 
   return JSON.parse(JSON.stringify(parsed));

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -59,7 +59,7 @@ async function parse (filePath) {
       content = JSON.stringify(filePath);
     } else {
       console.error(`Could not find a valid asyncapi definition: ${filePath}`);
-      throw `Could not find a valid asyncapi definition: ${filePath}`;
+      throw new Error(`Could not find a valid asyncapi definition: ${filePath}`);
     }
   } catch (e) {
     console.error('Can not load the content of the AsyncAPI specification file');
@@ -104,17 +104,25 @@ async function parse (filePath) {
 };
 
 async function parseText (content) {
-  const parsedContent = parseContent(content);
-  if (typeof parsedContent !== 'object' || parsedContent === null) {
-    throw new Error('Invalid YAML content.');
+  let parsedStringified;
+
+  try {
+    const parsedContent = parseContent(content);
+    if (typeof parsedContent !== 'object' || parsedContent === null) {
+      throw new Error('Invalid YAML content.');
+    }
+    const dereferencedJSON = await dereference(parsedContent);
+    const bundledJSON = await bundle(dereferencedJSON);
+    const asyncAPIschema = require('asyncapi')[bundledJSON.asyncapi];
+
+    const parsed = await validate(bundledJSON, asyncAPIschema);
+
+    parsedStringified = JSON.parse(JSON.stringify(parsed));
+  } catch (e) {
+    throw e;
   }
-  const dereferencedJSON = await dereference(parsedContent);
-  const bundledJSON = await bundle(dereferencedJSON);
-  const asyncAPIschema = require('asyncapi')[bundledJSON.asyncapi];
 
-  const parsed = await validate(bundledJSON, asyncAPIschema);
-
-  return JSON.parse(JSON.stringify(parsed));
+  return parsedStringified
 };
 
 module.exports = parse;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asyncapi-generator",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The AsyncAPI generator. It can generate documentation, code, anything!",
   "main": "./lib/generator.js",
   "bin": {


### PR DESCRIPTION
instead of logging errors silently, I'm changing to the parser to re-throw errors to clients. 

NOTE: I'm not sure if this will break others libraries making use of the generator: that would be the case if not doing error handling correctly.

ALSO: I'm sending this directly to Master as fran mentioned we are using from now github flow