### PR TITLE
#25 operation and message templates hide schema example and show formatted example

### DIFF
--- a/templates/html/.partials/message.html
+++ b/templates/html/.partials/message.html
@@ -26,9 +26,9 @@
 
   <h4>Payload</h4>
 
-  {{> schema schema=message.payload schemaName='Message Payload' hideTitle=true}}
+  {{> schema schema=message.payload schemaName='Message Payload' hideTitle=true hideExample=true}}
 
-  {{#if message.example}}
+  {{#if message.formattedExample}}
   <h4>Example</h4>
 
   <pre class="hljs"><code class="json">{{~message.formattedExample~}}</code></pre>

--- a/templates/html/.partials/operation.html
+++ b/templates/html/.partials/operation.html
@@ -18,9 +18,9 @@
 
 <h4>Payload</h4>
 
-{{> schema schema=operation.payload schemaName='Message Payload' hideTitle=true}}
+{{> schema schema=operation.payload schemaName='Message Payload' hideTitle=true hideExample=true}}
 
-{{#if operation.example}}
+{{#if operation.formattedExample}}
 <h4>Example</h4>
 
 <pre class="hljs"><code class="json">{{~operation.formattedExample~}}</code></pre>

--- a/templates/html/.partials/schema.html
+++ b/templates/html/.partials/schema.html
@@ -44,6 +44,7 @@
   </table>
   {{/if}}
 
+{{#unless hideExample}}
 {{#if schema.example}}
 <h4>Example</h4>
 
@@ -55,4 +56,5 @@
   <pre class="hljs"><code class="json">{{~schema.generatedExample~}}</code></pre>
   {{/if}}
 {{/if}}
+{{/unless}}
 </div>

--- a/test/docs/array_example.yml
+++ b/test/docs/array_example.yml
@@ -1,0 +1,42 @@
+asyncapi: '1.1.0'
+info:
+  title: Array-level example
+  version: '1.0.0'
+
+topics:
+  array_example:
+    subscribe:
+      $ref: '#/components/messages/array_example'
+  number_example:
+    subscribe:
+      $ref: '#/components/messages/number_example'
+  no_example:
+    subscribe:
+      $ref: '#/components/messages/no_example'
+
+components:
+  messages:
+    array_example:
+      description: Array with example
+      payload:
+        $ref: '#/components/schemas/schema1'
+    number_example:
+      description: Number with example
+      payload:
+        $ref: '#/components/schemas/schema2'
+    no_example:
+      description: No examples provided
+      payload:
+        $ref: '#/components/schemas/schema3'
+
+  schemas:
+    schema1:
+      type: array
+      items:
+        type: number
+      example: [35.4, 38.6, 46.7, 66.5]
+    schema2:
+      type: number
+      example: 52.8
+    schema3:
+      type: number


### PR DESCRIPTION
I ran all given tests (including the one I added) before and after changes, and checked outputs with kdiff. This only touches the html template. Hopefully this commit PR is OK, I realize that I kind of just appeared out from nowhere!