### PR TITLE
Support generic keywords examples and const from draft 6

### DIFF
--- a/templates/html/.partials/schema-prop.html
+++ b/templates/html/.partials/schema-prop.html
@@ -71,13 +71,24 @@
           <div class="text-sm markdown">{{{prop.descriptionAsHTML}}}</div>
         {{/if}}
         {{#unless (equal prop.default undefined)}}
-          <div class="text-xs">Default: {{prop.default}}</div>
+          <div class="text-xs">Default: {{stringify prop.default}}</div>
+        {{/unless}}
+        {{#unless (equal prop.const undefined)}}
+          <div class="text-xs">Const: {{stringify prop.const}}</div>
         {{/unless}}
         {{#if prop.enum}}
           <div class="text-xs">
             Enum:
             {{#each prop.enum as |value|}}
               <span class="border text-orange rounded lowercase ml-1 py-0 px-2">{{stringify value}}</span>
+            {{/each}}
+          </div>
+        {{/if}}
+        {{#if prop.examples}}
+          <div class="text-xs">
+            Examples:
+            {{#each prop.examples as |value|}}
+              <span class="border text-orange rounded ml-1 py-0 px-2">{{stringify value}}</span>
             {{/each}}
           </div>
         {{/if}}


### PR DESCRIPTION
It seems support for these keywords is missing.
https://json-schema.org/understanding-json-schema/reference/generic.html

Also, the default value was not stringified so null looked like this:
```Default:```
instead of this:
```Default: null```
As an added bonus strings and numbers can be differentiated.

I'll open an additional PR in openapi-sampler to support const and examples in the generated payload snippet.