### PR TITLE
Passing 'params' on from generateTemplateFile()

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Generates a file of a given template, and returns the result as a string.
 |options.templatesDir|`string`|No|Directory where to find the templates. Defaults to internal templates directory.|
 |options.template|`string`|Yes|Name of the template you want to use.|
 |options.file|`string`|Yes|Path to the file you want to generate.|
+|options.params|`object`|No|Additional params to pass to templates.|
 |options.config|`object`|Yes|An object containing configuration options.|
 |options.config.asyncapi|`string`&#124;`object`|Yes|Path to the AsyncAPI file to use.
 
@@ -79,6 +80,9 @@ generator.generateTemplateFile({
   file: 'index.html',
   config: {
     asyncapi: path.resolve(__dirname, 'asyncapi.yml'),
+  },
+  params: {
+    "title": "Hello from param"    
   }
 })
   .then((result) => {

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -353,11 +353,15 @@ generator.generateTemplateFile = ({
   template,
   file,
   config,
+  params
 }) => new Promise((resolve, reject) => {
   parseAndApplyDefaults({
     ...config,
     ...{
       template,
+    },
+    params:{
+      ...params
     }
   })
   .then((cfg) => {

--- a/templates/html/.partials/sidebar.html
+++ b/templates/html/.partials/sidebar.html
@@ -78,9 +78,58 @@
         </div>
       </div>
       {{/each}}
+      <!-- Untagged operations -->
+      <div class="mt-4 {{#if open}}is-open{{/if}}">
+        <div class="js-prop cursor-pointer py-2 flex property">
+          <div class="pr-4" style="margin-top:-2px; min-width: 25%;">
+            <span class="text-sm" style="word-break: break-word;text-transform: capitalize;">Untagged</span>
+            <svg class="expand" version="1.1" viewBox="0 0 24 24" x="0" xmlns="http://www.w3.org/2000/svg" y="0">
+              <polygon points="17.3 8.3 12 13.6 6.7 8.3 5.3 9.7 12 16.4 18.7 9.7 "></polygon>
+            </svg>
+          </div>
+        </div>
+        <div class="children">
+          {{#each asyncapi.channels}}
+          {{#if ./publish}}
+          {{#unless publish.tags}}
+          <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3" href="#operation-publish-{{@key}}">
+            {{#if ./deprecated}}<span title="Deprecated"></span>{{/if}}
+            <span class="bg-blue-dark font-bold h-6 no-underline text-white uppercase p-1 mr-2 rounded" style="height: 21px;font-size: 11px;" title="Publish">Pub</span>
+            {{#if ./publish.summary}}
+            <span style="padding-top: 2px;">
+              {{./publish.summary}}
+            </span>
+            {{else}}
+            <div style="display:inline-block;">
+              {{>slicedString string=@key style='padding-top: 2px;'}}
+            </div>
+            {{/if}}
+          </a>
+          {{/unless}}
+          {{/if}}
+          {{#if ./subscribe}}
+          {{#unless subscribe.tags}}
+          <a class="js-menu-item flex break-words no-underline text-grey-darkest mt-8 sm:mt-8 md:mt-3" href="#operation-subscribe-{{@key}}">
+            {{#if ./deprecated}}<span title="Deprecated"></span>{{/if}}
+            <span class="bg-green-dark font-bold no-underline text-white uppercase p-1 mr-2 rounded" style="height: 21px;font-size: 11px;" title="Subscribe">Sub</span>
+            {{#if ./subscribe.summary}}
+            <span style="padding-top: 2px;">
+              {{./subscribe.summary}}
+            </span>
+            {{else}}
+            <div style="display:inline-block;">
+              {{>slicedString string=@key style='padding-top: 2px;'}}
+            </div>
+            {{/if}}
+          </a>
+          {{/unless}}
+          {{/if}}
+          {{/each}}
+        </div>
+      </div>
 
       {{else}}
-  
+
       <!--Without tags in sidebar-->
       {{#each asyncapi.channels}}
       <li>

--- a/test/docs/streetlights.yml
+++ b/test/docs/streetlights.yml
@@ -15,6 +15,12 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0
 
+tags:
+  - name: actions
+    description: Action messages
+  - name: events
+    description: Event messages
+
 servers:
   - url: api.streetlights.smartylighting.com:{port}
     protocol: mqtt
@@ -61,6 +67,8 @@ channels:
           - headerId: 'lighting-measured'
       message:
         $ref: '#/components/messages/lightMeasured'
+      tags:
+      - name: events
 
   action/{streetlightId}/turn/on:
     parameters:
@@ -73,6 +81,8 @@ channels:
           - headerId: 'turn-on'
       message:
         $ref: '#/components/messages/turnOnOff'
+      tags:
+      - name: actions
 
   action/{streetlightId}/turn/off:
     parameters:
@@ -85,6 +95,8 @@ channels:
           - headerId: 'turn-off'
       message:
         $ref: '#/components/messages/turnOnOff'
+      tags:
+        - name: actions
 
   action/{streetlightId}/dim:
     parameters:
@@ -97,6 +109,8 @@ channels:
           - headerId: 'dim'
       message:
         $ref: '#/components/messages/dimLight'
+      tags:
+        - name: actions
 
 components:
   messages:


### PR DESCRIPTION
Passing 'params' on to use it with .generateTemplateFile() as a follow-up to issue #69. Also adding a short description and tags to the streetlights Example for demonstration purposes of the sidebarOrganization param.