### PR TITLE
Fix Docker docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@ FROM node:11
 
 WORKDIR /asyncapi
 
-# Putting the old one in here until the new one supports node
-RUN npm install -g asyncapi-node-codegen
-
 # install dependencies
 COPY package*.json ./
 RUN npm install

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install -g asyncapi-generator
 Or use all the commands below using Docker by prefixing them with:
 
 ```bash
-docker run --rm -it -v $PWD:/app -w /app asyncapi/generator [ag|anc] [COMMAND HERE]
+docker run --rm -it -v $PWD:/app -w /app asyncapi/generator ag [COMMAND HERE]
 ```
 
 ## Usage

--- a/dockerboot.sh
+++ b/dockerboot.sh
@@ -8,9 +8,6 @@ fi
 if [ "$1" == "ag" ]; then
     shift
     node /asyncapi/cli "$@"
-elif [ "$1" == "anc" ]; then
-    shift
-    anc "$@"
 else
    echo "Unknown command"
    exit 1


### PR DESCRIPTION
FYI @treeder and @YBogomolov. I already pushed this image to Docker Hub. It's tagged with `latest` and `0.10.0`.

It removes the need for `asyncapi-node-codegen` as the current generator already supports Node.js.