### PR TITLE
Move Message Examples Back into Right Column in HTML Template

### DIFF
--- a/templates/html/.partials/message.html
+++ b/templates/html/.partials/message.html
@@ -1,34 +1,41 @@
 {% from "./schema.html" import schema %}
 
-{% macro message(msg, showIndex=false, index=0, open=false) %}
+{% macro message(msg, showIndex=false, index=0, open=false, prefixHtml=false) %}
 
-<div class="bg-grey-lighter rounded p-4 mt-2">
-  <div class="text-sm text-grey-darker mb-2">
-    {% if showIndex %}
-    <span class="text-grey-darker font-bold mr-2">#{{index}}</span>
+<div class="center-block pr-8 pl-8">
+  <div class="operation pb-8">
+    {% if prefixHtml %}
+      {{ prefixHtml | safe }}
     {% endif %}
-    {% if msg.title() %}
-      {{msg.title()}}
-      {% if msg.name() %}
-        <span class="border text-orange rounded text-xs ml-3 py-0 px-2">{{msg.name()}}</span>
+    <div class="bg-grey-lighter rounded p-4 mt-2">
+      <div class="text-sm text-grey-darker mb-2">
+        {% if showIndex %}
+        <span class="text-grey-darker font-bold mr-2">#{{index}}</span>
+        {% endif %}
+        {% if msg.title() %}
+          {{msg.title()}}
+          {% if msg.name() %}
+            <span class="border text-orange rounded text-xs ml-3 py-0 px-2">{{msg.name()}}</span>
+          {% endif %}
+        {% else %}
+          {% if msg.name() %}
+            <span class="border text-orange rounded text-s py-0 px-2">{{msg.name()}}</span>
+          {% endif %}
+        {% endif %}
+      </div>
+      <p class="text-grey-dark text-sm">{{msg.summary()}}</p>
+      <div class="mt-4 mb-4 markdown">{{ msg.description() | markdown2html | safe }}</div>
+      {{ schema(msg.payload(), 'Payload', open=open) }}
+      {% if msg.headers() %}
+        <div class="mt-4">
+          {{ schema(msg.headers(), 'Headers', open=open) }}
+        </div>
       {% endif %}
-    {% else %}
-      {% if msg.name() %}
-        <span class="border text-orange rounded text-s py-0 px-2">{{msg.name()}}</span>
-      {% endif %}
-    {% endif %}
-  </div>
-  <p class="text-grey-dark text-sm">{{msg.summary()}}</p>
-  <div class="mt-4 mb-4 markdown">{{ msg.description() | markdown2html | safe }}</div>
-  {{ schema(msg.payload(), 'Payload', open=open) }}
-  {% if msg.headers() %}
-    <div class="mt-4">
-      {{ schema(msg.headers(), 'Headers', open=open) }}
     </div>
-  {% endif %}
+  </div>
 </div>
 
-<div class="right-block p-8">
+<div class="right-block pr-8 pl-8">
   <h4 class="text-lg text-white mb-4">Examples</h4>
 
   <form>

--- a/templates/html/.partials/operation.html
+++ b/templates/html/.partials/operation.html
@@ -4,36 +4,41 @@
 
 {% macro operation(operation, operationType, channelName, channel) %}
 
-<a name="operation-{{operationType}}-{{channelName}}"></a>
-<div class="center-block p-8">
-  <div class="operation pt-8 pb-8">
-    <h3 class="font-mono text-base">
-      {% if operationType === 'publish' %}
-      <span class="font-mono border border-blue text-blue uppercase p-1 rounded" title="Publish">Pub</span>
-      {% endif %}
-      {% if operationType === 'subscribe' %}
-      <span class="font-mono border border-green-dark text-green-dark uppercase p-1 rounded" title="Subscribe">Sub</span>
-      {% endif %}
-      {{ slicedString(channelName) }}
-    </h3>
+<div class="responsive-container">
+  <a name="operation-{{operationType}}-{{channelName}}"></a>
+  <div class="center-block p-8">
+    <div class="operation pt-8 pb-8">
+      <h3 class="font-mono text-base">
+        {% if operationType === 'publish' %}
+        <span class="font-mono border border-blue text-blue uppercase p-1 rounded" title="Publish">Pub</span>
+        {% endif %}
+        {% if operationType === 'subscribe' %}
+        <span class="font-mono border border-green-dark text-green-dark uppercase p-1 rounded" title="Subscribe">Sub</span>
+        {% endif %}
+        {{ slicedString(channelName) }}
+      </h3>
 
-    <div class="mt-4 mb-4 markdown">{{ channel.description() | markdown2html | safe }}</div>
+      <div class="mt-4 mb-4 markdown">{{ channel.description() | markdown2html | safe }}</div>
 
-    <p class="text-grey text-sm">{{operation.summary()}}</p>
-    <div class="mt-4 mb-4 markdown">{{ operation.description() | markdown2html | safe }}</div>
+      <p class="text-grey text-sm">{{operation.summary()}}</p>
+      <div class="mt-4 mb-4 markdown">{{ operation.description() | markdown2html | safe }}</div>
 
-    {% if operation.hasMultipleMessages() %}
-      <p>Accepts <strong>one of</strong> the following messages:</p>
-      {% for msg in operation.messages() %}
-        {{ message(msg, showIndex=true, index=loop.index, open=false) }}
-      {% endfor %}
-    {% else %}
-      <p>Accepts the following message:</p>
-      {{ message(operation.message(0), showIndex=false, open=true) }}
-    {% endif %}
 
-    {{ tags(operation.tags()) }}
+      {{ tags(operation.tags()) }}
+    </div>
   </div>
 </div>
+
+{% if operation.hasMultipleMessages() %}
+  {% for msg in operation.messages() %}
+    <div class="responsive-container message-container">
+      {{ message(msg, showIndex=true, index=loop.index, open=false, prefixHtml='<p>Accepts <strong>one of</strong> the following messages:</p>') }}
+    </div>
+  {% endfor %}
+{% else %}
+  <div class="responsive-container message-container">
+    {{ message(operation.message(0), showIndex=false, open=true, prefixHtml='<p>Accepts the following message:</p>') }}
+  </div>
+{% endif %}
 
 {% endmacro %}

--- a/templates/html/.partials/operations.html
+++ b/templates/html/.partials/operations.html
@@ -4,12 +4,10 @@
 <h2 class="mb-4 ml-8">Operations</h2>
 
 {% for channelName, channel in asyncapi.channels() %}
-  <div class="responsive-container">
-    {% if channel.hasPublish() %}
-      {{ operation(channel.publish(), 'publish', channelName, channel) }}
-    {% endif %}
-    {% if channel.hasSubscribe() %}
-      {{ operation(channel.subscribe(), 'subscribe', channelName, channel) }}
-    {% endif %}
-  </div>
+  {% if channel.hasPublish() %}
+    {{ operation(channel.publish(), 'publish', channelName, channel) }}
+  {% endif %}
+  {% if channel.hasSubscribe() %}
+    {{ operation(channel.subscribe(), 'subscribe', channelName, channel) }}
+  {% endif %}
 {% endfor %}

--- a/templates/html/css/main.css
+++ b/templates/html/css/main.css
@@ -109,6 +109,10 @@ h1, h2, h3, h4, h5, h6 {
   z-index: 1;
 }
 
+.message-container > .p-8 {
+  padding: 0 2rem;
+}
+
 @media only screen and (min-width: 992px) {
   .sidebar-panel {
     display: block;
@@ -136,7 +140,7 @@ h1, h2, h3, h4, h5, h6 {
 
   .right-block {
     background-color: transparent;
-    margin-top: 2rem;
+    margin-top: 0;
     margin-bottom: 2rem;
     width: 40%;
   }
@@ -155,6 +159,10 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 @media only screen and (max-width: 991px) {
+  .right-block {
+    padding-top: 2rem;
+  }
+
   #burger-menu + label {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
Fixes #96 

This fixes 3 bugs that were introduced in f411b4d during the migration to Nunjuck:

1. It forced the Message Examples into the center column rather than in the right column
2. If there were multiple messages, it would lay them out horizontally rather than vertically. 
3. If a channel had both a publish and a subscribe, it would lay them out horizontally rather than vertically. 

This patch fixes this and also reduces some of the padding that was caused by the fix.

Current/Broken:

![Screen Shot 2019-08-21 at 3 41 21 PM](https://user-images.githubusercontent.com/3516836/63474064-8aee7800-c42c-11e9-9de5-1f185a5891f5.png)

After patch:

![Screen Shot 2019-08-21 at 3 59 22 PM](https://user-images.githubusercontent.com/3516836/63474083-a9547380-c42c-11e9-9f29-51770ca173b0.png)
