### PR TITLE
Fix: Place pub and sub operations in their own responsive-containers.

### DIFF
--- a/templates/html/.partials/operations.html
+++ b/templates/html/.partials/operations.html
@@ -8,6 +8,8 @@
     {% if channel.hasPublish() %}
       {{ operation(channel.publish(), 'publish', channelName, channel) }}
     {% endif %}
+  </div>
+  <div class="responsive-container">
     {% if channel.hasSubscribe() %}
       {{ operation(channel.subscribe(), 'subscribe', channelName, channel) }}
     {% endif %}


### PR DESCRIPTION
Placing pub and sub operations in their own responsive-containers causes them to wrap to their own rows in XL device widths.