### PR TITLE
Add hooks and no-overwrite option

### DIFF
--- a/API.md
+++ b/API.md
@@ -26,6 +26,8 @@ Instantiates a new Generator object.
 | [options.templatesDir] | <code>String</code> | Path to the directory where to find the given template. Defaults to internal `templates` directory. |
 | [options.templateParams] | <code>String</code> | Optional parameters to pass to the template. Each template define their own params. |
 | [options.entrypoint] | <code>String</code> | Name of the file to use as the entry point for the rendering process. Note: this potentially avoids rendering every file in the template. |
+| [options.noOverwriteGlobs[]] | <code>Array.&lt;String&gt;</code> | List of globs to skip when regenerating the template. |
+| [options.disabledHooks[]] | <code>Array.&lt;String&gt;</code> | List of hooks to disable. |
 
 **Example**  
 ```js

--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ docker run --rm -it -v $PWD:/app -w /app asyncapi/generator ag [COMMAND HERE]
   Options:
 
     -V, --version                  output the version number
-    -o, --output <outputDir>       directory where to put the generated files (defaults to current directory)
-    -t, --templates <templatesDir> directory where templates are located (defaults to internal templates directory)
-    -p, --param <name=value>       additional param to pass to the template
+    -o, --output <outputDir>       directory where to put the generated files (defaults to current directory) (default: /Users/fmvilas/www/asyncapi-generator)
+    -d, --disable-hook <hookName>  disable a specific hook
+    -n, --no-overwrite <glob>      glob or path of the file(s) to skip when regenerating
+    -p, --param <name=value>       additional param to pass to templates
+    -t, --templates <templateDir>  directory where templates are located (defaults to internal templates directory) (default: null)
     -h, --help                     output usage information
 ```
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -2,6 +2,7 @@ const path = require('path');
 const fs = require('fs');
 const util = require('util');
 const xfs = require('fs.extra');
+const walkSync = require('klaw-sync');
 const _ = require('lodash');
 const Markdown = require('markdown-it');
 const OpenAPISampler = require('openapi-sampler');
@@ -20,12 +21,14 @@ const exists = util.promisify(fs.exists);
 
 const FILTERS_DIRNAME = '.filters';
 const PARTIALS_DIRNAME = '.partials';
+const HOOKS_DIRNAME = '.hooks';
 const CONFIG_FILENAME = '.tp-config.json';
 const DEFAULT_TEMPLATES_DIR = path.resolve(__dirname, '..', 'templates');
 
 const shouldIgnoreFile = filePath =>
   filePath.startsWith(`${PARTIALS_DIRNAME}${path.sep}`)
   || filePath.startsWith(`${FILTERS_DIRNAME}${path.sep}`)
+  || filePath.startsWith(`${HOOKS_DIRNAME}${path.sep}`)
   || path.basename(filePath) === CONFIG_FILENAME;
 
 class Generator {
@@ -53,11 +56,13 @@ class Generator {
    * @param {String} templateName  Name of the template to generate.
    * @param {String} targetDir     Path to the directory where the files will be generated.
    * @param {Object} options
-   * @param {String} [options.templatesDir]    Path to the directory where to find the given template. Defaults to internal `templates` directory.
-   * @param {String} [options.templateParams]  Optional parameters to pass to the template. Each template define their own params.
-   * @param {String} [options.entrypoint]      Name of the file to use as the entry point for the rendering process. Note: this potentially avoids rendering every file in the template.
+   * @param {String} [options.templatesDir]     Path to the directory where to find the given template. Defaults to internal `templates` directory.
+   * @param {String} [options.templateParams]   Optional parameters to pass to the template. Each template define their own params.
+   * @param {String} [options.entrypoint]       Name of the file to use as the entry point for the rendering process. Note: this potentially avoids rendering every file in the template.
+   * @param {String[]} [options.noOverwriteGlobs[]] List of globs to skip when regenerating the template.
+   * @param {String[]} [options.disabledHooks[]] List of hooks to disable.
    */
-  constructor(templateName, targetDir, { templatesDir, templateParams, entrypoint }) {
+  constructor(templateName, targetDir, { templatesDir, templateParams, entrypoint, noOverwriteGlobs, disabledHooks }) {
     if (!templateName) throw new Error('No template name has been specified.');
     if (!entrypoint && !targetDir) throw new Error('No target directory has been specified.');
 
@@ -67,12 +72,15 @@ class Generator {
     this.templateDir = path.resolve(this.templatesDir, this.templateName);
     this.templateParams = templateParams || {};
     this.entrypoint = entrypoint;
+    this.noOverwriteGlobs = noOverwriteGlobs || [];
+    this.disabledHooks = disabledHooks || [];
 
     // Config Nunjucks
     this.nunjucks = new Nunjucks.Environment(new Nunjucks.FileSystemLoader(this.templateDir));
     this.nunjucks.addFilter('log', console.log);
     this.registerFilters();
     this.loadTemplateConfig();
+    this.registerHooks();
   }
 
   /**
@@ -104,10 +112,12 @@ class Generator {
       if (this.entrypoint) {
         if (!(await exists(this.entrypoint))) throw new Error(`Template entrypoint "${this.entrypoint}" couldn't be found.`);
         await this.renderFile(asyncapiDocument, path.relative(this.templateDir, this.entrypoint));
+        await this.launchHook('generate:after');
         return;
       }
       await this.validateTemplateConfig(asyncapiDocument);
       await this.generateDirectoryStructure(asyncapiDocument);
+      await this.launchHook('generate:after');
     } catch (e) {
       throw e;
     }
@@ -152,6 +162,8 @@ class Generator {
    */
   async generateFromString(asyncapiString) {
     if (!asyncapiString || typeof asyncapiString !== 'string') throw new Error('Parameter "asyncapiString" must be a non-empty string.');
+
+    this.originalAsyncAPI = asyncapiString;
 
     try {
       const parsed = await parse(asyncapiString);
@@ -297,7 +309,13 @@ class Generator {
       walker.on('directory', async (root, stats, next) => {
         try {
           const dirPath = path.resolve(this.targetDir, path.relative(this.templateDir, path.resolve(root, stats.name)));
-          if (stats.name !== PARTIALS_DIRNAME && stats.name !== FILTERS_DIRNAME) xfs.mkdirpSync(dirPath);
+          if (
+            stats.name !== PARTIALS_DIRNAME
+            && stats.name !== FILTERS_DIRNAME
+            && stats.name !== HOOKS_DIRNAME
+          ) {
+            xfs.mkdirpSync(dirPath);
+          }
           next();
         } catch (e) {
           reject(e);
@@ -348,6 +366,11 @@ class Generator {
       const relativeBaseDir = path.relative(this.templateDir, baseDir);
       const newFileName = fileName.replace('$$channel$$', _.kebabCase(channelName));
       const targetFile = path.resolve(this.targetDir, relativeBaseDir, newFileName);
+      const relativeTargetFile = path.relative(this.targetDir, targetFile);
+
+      const shouldOverwriteFile = await this.shouldOverwriteFile(relativeTargetFile);
+      if (!shouldOverwriteFile) return;
+
       const content = await this.renderFile(asyncapiDocument, path.resolve(baseDir, fileName), {
         channelName,
         channel: asyncapiDocument.channel(channelName),
@@ -373,10 +396,14 @@ class Generator {
       const sourceFile = path.resolve(baseDir, fileName);
       const relativeSourceFile = path.relative(this.templateDir, sourceFile);
       const targetFile = path.resolve(this.targetDir, relativeSourceFile);
+      const relativeTargetFile = path.relative(this.targetDir, targetFile);
 
       if (this.isNonRenderableFile(relativeSourceFile)) {
         return await copyFile(sourceFile, targetFile);
       }
+
+      const shouldOverwriteFile = await this.shouldOverwriteFile(relativeTargetFile);
+      if (!shouldOverwriteFile) return;
 
       if (this.templateConfig.conditionalFiles && this.templateConfig.conditionalFiles[relativeSourceFile]) {
         const server = this.templateParams.server && asyncapiDocument.server(this.templateParams.server);
@@ -417,6 +444,7 @@ class Generator {
       return this.nunjucks.renderString(content, {
         asyncapi: asyncapiDocument,
         params: this.templateParams,
+        originalAsyncAPI: this.originalAsyncAPI,
         ...extraTemplateData,
       });
     } catch (e) {
@@ -434,9 +462,22 @@ class Generator {
   isNonRenderableFile(fileName) {
     if (!Array.isArray(this.templateConfig.nonRenderableFiles)) return false;
 
-    return this.templateConfig.nonRenderableFiles.some((globExp) => {
-      return minimatch(fileName, globExp);
-    });
+    return this.templateConfig.nonRenderableFiles.some(globExp => minimatch(fileName, globExp));
+  }
+
+  /**
+   * Checks if a given file should be overwritten.
+   *
+   * @private
+   * @param  {string} filePath Path to the file to check against a list of glob patterns.
+   * @return {boolean}
+   */
+  async shouldOverwriteFile(filePath) {
+    if (!Array.isArray(this.noOverwriteGlobs)) return true;
+    const fileExists = await exists(path.resolve(this.targetDir, filePath));
+    if (!fileExists) return true;
+
+    return !this.noOverwriteGlobs.some(globExp => minimatch(filePath, globExp));
   }
 
   /**
@@ -500,6 +541,45 @@ class Generator {
         }
       }
     }
+  }
+
+  /**
+   * Loads the template hooks.
+   * @private
+   */
+  registerHooks() {
+    try {
+      this.hooks = {};
+      const hooksPath = path.resolve(this.templateDir, HOOKS_DIRNAME);
+      if (!fs.existsSync(hooksPath)) return this.hooks;
+
+      const files = walkSync(hooksPath, { nodir: true });
+      files.forEach(file => {
+        require(file.path)((when, hook) => {
+          this.hooks[when] = this.hooks[when] || [];
+          this.hooks[when].push(hook);
+        });
+      });
+    } catch (e) {
+      e.message = `There was a problem registering the hooks: ${e.message}`;
+      throw e;
+    }
+  }
+
+  /**
+   * Launches all the hooks registered at a given hook point/name.
+   * @private
+   */
+  async launchHook(hookName) {
+    if (this.disabledHooks.includes(hookName)) return;
+    if (!Array.isArray(this.hooks[hookName])) return;
+
+    const promises = this.hooks[hookName].map(async (hook) => {
+      if (typeof hook !== 'function') return;
+      await hook(this);
+    });
+
+    return Promise.all(promises);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1741,6 +1741,14 @@
         "graceful-fs": "^4.1.9"
       }
     },
+    "klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "requires": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
@@ -1885,6 +1893,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -1892,7 +1901,8 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "jmespath": "^0.15.0",
     "js-yaml": "^3.13.1",
     "json-schema-ref-parser": "^5.1.0",
+    "klaw-sync": "^6.0.0",
     "lodash": "^4.17.15",
     "markdown-it": "^8.4.1",
     "minimatch": "^3.0.4",
-    "mkdirp": "^0.5.1",
     "nunjucks": "^3.2.0",
     "openapi-sampler": "^1.0.0-beta.9"
   },


### PR DESCRIPTION
```
  Usage: ag [options] <asyncapi> <template>


  Options:

    -V, --version                  output the version number
    -o, --output <outputDir>       directory where to put the generated files (defaults to current directory) (default: /Users/fmvilas/www/asyncapi-generator)
->    -d, --disable-hook <hookName>  disable a specific hook
->    -n, --no-overwrite <glob>      glob or path of the file(s) to skip when regenerating
    -p, --param <name=value>       additional param to pass to templates
    -t, --templates <templateDir>  directory where templates are located (defaults to internal templates directory) (default: null)
    -h, --help                     output usage information
```

1. Added hooks functionality. So far there's only one hook point: `generate:after`. Hooks are custom functions you can run at a given point in the generation process.
2. The `--disable-hook` option on the CLI or its equivalent in the API `disabledHooks`, let's you disable a specific hook point.
3. The `--no-overwrite` option on the CLI or its equivalent in the API `noOverwriteGlobs`, let's you overwrite certain files/directories during the generation process. This opens the door for generating code not only to bootstrap a project but during the whole lifecycle of an application.