### PR TITLE
Fixed isExpandable filter

### DIFF
--- a/templates/html/.filters/all.js
+++ b/templates/html/.filters/all.js
@@ -14,13 +14,12 @@ module.exports = ({ Nunjucks, Markdown, OpenAPISampler }) => {
     if (
       obj.type === 'object' ||
       obj.type === 'array' ||
-      obj.oneOf ||
-      obj.anyOf ||
-      obj.items ||
-      obj.additionalItems ||
-      obj.properties ||
-      obj.additionalProperties ||
-      obj.patternProperties
+      obj.oneOf() ||
+      obj.anyOf() ||
+      obj.items() ||
+      obj.properties() ||
+      obj.additionalProperties() ||
+      obj.patternProperties()
     ) return true;
 
     return false;

--- a/templates/html/.partials/schema-prop.html
+++ b/templates/html/.partials/schema-prop.html
@@ -1,6 +1,6 @@
 {% from "./type.html" import type %}
 
-{% macro schemaProp(prop, propName, open=false, root=fase, odd=false, specialName=false) %}
+{% macro schemaProp(prop, propName, open=false, root=false, odd=false, specialName=false, required=false) %}
 
 <div class="{% if odd %}bg-grey-lighter{% else %}bg-grey-lightest{% endif %} {% if not root %}pl-8 pr-8{% endif %} rounded">
   <div class="{% if open %}is-open{% endif %}">


### PR DESCRIPTION
Fixes #116 

- removed additionalItems, which wasn't actually a property. 
- checked the result of the function instead of the existence of a function to determine expandability.