### PR TITLE
Add output type: fs or string

### DIFF
--- a/API.md
+++ b/API.md
@@ -18,16 +18,17 @@
 Instantiates a new Generator object.
 
 
-| Param | Type | Description |
-| --- | --- | --- |
-| templateName | <code>String</code> | Name of the template to generate. |
-| targetDir | <code>String</code> | Path to the directory where the files will be generated. |
-| options | <code>Object</code> |  |
-| [options.templatesDir] | <code>String</code> | Path to the directory where to find the given template. Defaults to internal `templates` directory. |
-| [options.templateParams] | <code>String</code> | Optional parameters to pass to the template. Each template define their own params. |
-| [options.entrypoint] | <code>String</code> | Name of the file to use as the entry point for the rendering process. Note: this potentially avoids rendering every file in the template. |
-| [options.noOverwriteGlobs[]] | <code>Array.&lt;String&gt;</code> | List of globs to skip when regenerating the template. |
-| [options.disabledHooks[]] | <code>Array.&lt;String&gt;</code> | List of hooks to disable. |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| templateName | <code>String</code> |  | Name of the template to generate. |
+| targetDir | <code>String</code> |  | Path to the directory where the files will be generated. |
+| options | <code>Object</code> |  |  |
+| [options.templatesDir] | <code>String</code> |  | Path to the directory where to find the given template. Defaults to internal `templates` directory. |
+| [options.templateParams] | <code>String</code> |  | Optional parameters to pass to the template. Each template define their own params. |
+| [options.entrypoint] | <code>String</code> |  | Name of the file to use as the entry point for the rendering process. Note: this potentially avoids rendering every file in the template. |
+| [options.noOverwriteGlobs] | <code>Array.&lt;String&gt;</code> |  | List of globs to skip when regenerating the template. |
+| [options.disabledHooks] | <code>Array.&lt;String&gt;</code> |  | List of hooks to disable. |
+| [options.output] | <code>String</code> | <code>&#x27;fs&#x27;</code> | Type of output. Can be either 'fs' (default) or 'string'. Only available when entrypoint is set. |
 
 **Example**  
 ```js

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -59,12 +59,14 @@ class Generator {
    * @param {String} [options.templatesDir]     Path to the directory where to find the given template. Defaults to internal `templates` directory.
    * @param {String} [options.templateParams]   Optional parameters to pass to the template. Each template define their own params.
    * @param {String} [options.entrypoint]       Name of the file to use as the entry point for the rendering process. Note: this potentially avoids rendering every file in the template.
-   * @param {String[]} [options.noOverwriteGlobs[]] List of globs to skip when regenerating the template.
-   * @param {String[]} [options.disabledHooks[]] List of hooks to disable.
+   * @param {String[]} [options.noOverwriteGlobs] List of globs to skip when regenerating the template.
+   * @param {String[]} [options.disabledHooks] List of hooks to disable.
+   * @param {String} [options.output='fs'] Type of output. Can be either 'fs' (default) or 'string'. Only available when entrypoint is set.
    */
-  constructor(templateName, targetDir, { templatesDir, templateParams, entrypoint, noOverwriteGlobs, disabledHooks }) {
+  constructor(templateName, targetDir, { templatesDir, templateParams, entrypoint, noOverwriteGlobs, disabledHooks, output = 'fs' } = {}) {
     if (!templateName) throw new Error('No template name has been specified.');
     if (!entrypoint && !targetDir) throw new Error('No target directory has been specified.');
+    if (!['fs', 'string'].includes(output)) throw new Error(`Invalid output type ${output}. Valid values are 'fs' and 'string'.`);
 
     this.templateName = templateName;
     this.targetDir = targetDir;
@@ -74,11 +76,11 @@ class Generator {
     this.entrypoint = entrypoint;
     this.noOverwriteGlobs = noOverwriteGlobs || [];
     this.disabledHooks = disabledHooks || [];
+    this.output = output;
 
     // Config Nunjucks
     this.nunjucks = new Nunjucks.Environment(new Nunjucks.FileSystemLoader(this.templateDir));
     this.nunjucks.addFilter('log', console.log);
-    this.registerFilters();
     this.loadTemplateConfig();
     this.registerHooks();
   }
@@ -109,11 +111,18 @@ class Generator {
     if (!(asyncapiDocument instanceof AsyncAPIDocument)) throw new Error('Parameter "asyncapiDocument" must be an AsyncAPIDocument object.');
 
     try {
+      await this.registerFilters();
+
       if (this.entrypoint) {
-        if (!(await exists(this.entrypoint))) throw new Error(`Template entrypoint "${this.entrypoint}" couldn't be found.`);
-        await this.renderFile(asyncapiDocument, path.relative(this.templateDir, this.entrypoint));
-        await this.launchHook('generate:after');
-        return;
+        const entrypointPath = path.resolve(this.templateDir, this.entrypoint);
+        if (!(await exists(entrypointPath))) throw new Error(`Template entrypoint "${entrypointPath}" couldn't be found.`);
+        if (this.output === 'fs') {
+          await this.generateFile(asyncapiDocument, path.basename(entrypointPath), path.dirname(path.relative(this.templateDir, entrypointPath)));
+          await this.launchHook('generate:after');
+          return;
+        } else if (this.output === 'string') {
+          return this.renderString(asyncapiDocument, await readFile(entrypointPath, { encoding: 'utf8' }));
+        }
       }
       await this.validateTemplateConfig(asyncapiDocument);
       await this.generateDirectoryStructure(asyncapiDocument);
@@ -167,7 +176,7 @@ class Generator {
 
     try {
       const parsed = await parse(asyncapiString);
-      await this.generate(parsed);
+      return this.generate(parsed);
     } catch (e) {
       throw e;
     }
@@ -198,7 +207,7 @@ class Generator {
   async generateFromFile(asyncapiFile) {
     try {
       const doc = await readFile(asyncapiFile, { encoding: 'utf8' });
-      await this.generateFromString(doc);
+      return this.generateFromString(doc);
     } catch (e) {
       throw e;
     }
@@ -225,8 +234,8 @@ class Generator {
    * @param {String} [options.templatesDir]  Path to the directory where to find the given template. Defaults to internal `templates` directory.
    * @return {Promise}
    */
-  static async getTemplateFile (templateName, filePath, { templatesDir }) {
-    return await readFile(path.relative(templatesDir || DEFAULT_TEMPLATES_DIR, path.resolve(templateName, filePath)), 'utf8');
+  static async getTemplateFile (templateName, filePath, { templatesDir } = {}) {
+    return await readFile(path.resolve(templatesDir || DEFAULT_TEMPLATES_DIR, templateName, filePath), 'utf8');
   }
 
   /**
@@ -430,6 +439,29 @@ class Generator {
   }
 
   /**
+   * Renders a template string and outputs it.
+   *
+   * @private
+   * @param {AsyncAPIDocument} asyncapiDocument AsyncAPI document to pass to the template.
+   * @param {String} templateString String containing the template.
+   * @param {Object} [extraTemplateData] Extra data to pass to the template.
+   * @return {Promise}
+   */
+  renderString(asyncapiDocument, templateString, extraTemplateData = {}) {
+    return new Promise((resolve, reject) => {
+      this.nunjucks.renderString(templateString, {
+        asyncapi: asyncapiDocument,
+        params: this.templateParams,
+        originalAsyncAPI: this.originalAsyncAPI,
+        ...extraTemplateData,
+      }, (err, result) => {
+        if (err) return reject(err);
+        resolve(result);
+      });
+    });
+  }
+
+  /**
    * Renders the content of a file and outputs it.
    *
    * @private
@@ -441,12 +473,7 @@ class Generator {
   async renderFile(asyncapiDocument, filePath, extraTemplateData = {}) {
     try {
       const content = await readFile(filePath, 'utf8');
-      return this.nunjucks.renderString(content, {
-        asyncapi: asyncapiDocument,
-        params: this.templateParams,
-        originalAsyncAPI: this.originalAsyncAPI,
-        ...extraTemplateData,
-      });
+      return this.renderString(asyncapiDocument, content, extraTemplateData);
     } catch (e) {
       throw e;
     }

--- a/templates/html/.partials/content.html
+++ b/templates/html/.partials/content.html
@@ -1,7 +1,7 @@
-{% include "./introduction.html" %}
+{% include ".partials/introduction.html" %}
 {% if asyncapi.hasServers() %}
-{% include "./servers.html" %}
+{% include ".partials/servers.html" %}
 {% endif %}
 {% if asyncapi.hasChannels() %}
-{% include "./operations.html" %}
+{% include ".partials/operations.html" %}
 {% endif %}

--- a/templates/html/.partials/example.html
+++ b/templates/html/.partials/example.html
@@ -12,7 +12,7 @@
     {% if msg | getPayloadExamples | length %}
       {% for ex in msg | getPayloadExamples %}
         <h6 class="text-xs font-bold text-grey-darker">Example #{{loop.index}}</h6>
-        <pre class="hljs mb-4 border border-grey-darkest rounded"><code>{{ex | safe }}</code></pre>
+        <pre class="hljs mb-4 border border-grey-darkest rounded"><code>{{ex | dump | safe }}</code></pre>
       {% endfor %}
     {% elif msg.payload() %}
     <pre class="hljs mb-4 border border-grey-darkest rounded"><code>{{ msg.payload().json() | generateExample | safe }}</code></pre>
@@ -24,7 +24,7 @@
     {% if msg | getHeadersExamples | length %}
       {% for ex in msg | getHeadersExamples %}
         <h6 class="text-xs font-bold text-grey-darker">Example #{{loop.index}}</h6>
-        <pre class="hljs mb-4 border border-grey-darkest rounded"><code>{{ ex | safe }}</code></pre>
+        <pre class="hljs mb-4 border border-grey-darkest rounded"><code>{{ ex | dump | safe }}</code></pre>
       {% endfor %}
     {% elif msg.headers() %}
     <pre class="hljs mb-4 border border-grey-darkest rounded"><code>{{ msg.headers().json() | generateExample | safe }}</code></pre>

--- a/templates/html/.partials/message.html
+++ b/templates/html/.partials/message.html
@@ -43,7 +43,7 @@
       {% if msg | getPayloadExamples | length %}
         {% for ex in msg | getPayloadExamples %}
           <h6 class="text-xs font-bold text-grey-darker">Example #{{loop.index}}</h6>
-          <pre class="hljs mb-4 border border-grey-darkest rounded"><code>{{ex | safe }}</code></pre>
+          <pre class="hljs mb-4 border border-grey-darkest rounded"><code>{{ex | dump | safe }}</code></pre>
         {% endfor %}
       {% elif msg.payload() %}
         <pre class="hljs mb-4 border border-grey-darkest rounded"><code>{{ msg.payload().json() | generateExample | safe }}</code></pre>
@@ -55,7 +55,7 @@
       {% if msg | getHeadersExamples | length %}
         {% for ex in msg | getHeadersExamples %}
           <h6 class="text-xs font-bold text-grey-darker">Example #{{loop.index}}</h6>
-          <pre class="hljs mb-4 border border-grey-darkest rounded"><code>{{ ex | safe }}</code></pre>
+          <pre class="hljs mb-4 border border-grey-darkest rounded"><code>{{ ex | dump | safe }}</code></pre>
         {% endfor %}
       {% elif msg.headers() %}
         <pre class="hljs mb-4 border border-grey-darkest rounded"><code>{{ msg.headers().json() | generateExample | safe }}</code></pre>

--- a/templates/markdown/.partials/content.md
+++ b/templates/markdown/.partials/content.md
@@ -1,5 +1,5 @@
-{% include "./info.md" %}
+{% include ".partials/info.md" %}
 
 {% if asyncapi.hasChannels() %}
-{% include "./channels.md"  %}
+{% include ".partials/channels.md"  %}
 {% endif %}

--- a/templates/markdown/.partials/schema-prop.md
+++ b/templates/markdown/.partials/schema-prop.md
@@ -2,6 +2,7 @@
 <tr>
   <td>{{ path | tree }}{{ propName }} {% if required %}<strong>(required)</strong>{% endif %}</td>
   <td>
+    {{ prop | log }}
     {{ prop.type() }}
     {%- if prop.anyOf() -%}anyOf{%- endif -%}
     {%- if prop.oneOf() %}oneOf{%- endif -%}
@@ -10,10 +11,10 @@
   <td>{{ prop.description() | markdown2html | safe }}</td>
   <td>{{ prop.enum() | acceptedValues | safe }}</td>
 </tr>
-{% for pName, p in prop.anyOf() %}
+{% for p in prop.anyOf() %}
 {{ schemaProp(p, pName, path=(propName | buildPath(path, pName))) }}
 {% endfor %}
-{% for pName, p in prop.oneOf() %}
+{% for p in prop.oneOf() %}
 {{ schemaProp(p, pName, path=(propName | buildPath(path, pName))) }}
 {% endfor %}
 {% for pName, p in prop.properties() %}


### PR DESCRIPTION
Add a new option to choose between the output of the generation process between `fs` (filesystem) or `string`. The latter can be chosen only when `entrypoint` is set.