### PR TITLE
Generate messages files

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -302,6 +302,11 @@ class Generator {
             await this.generateChannelFiles(asyncapiDocument, stats.name, root);
             const templateFilePath = path.relative(this.templateDir, path.resolve(root, stats.name));
             fs.unlink(path.resolve(this.targetDir, templateFilePath), next);
+          } else if (stats.name.includes('$$message$$')) {
+            // this file should be handled for each in asyncapi.components.messages
+            await this.generateMessageFiles(asyncapiDocument, stats.name, root);
+            const templateFilePath = path.relative(this.templateDir, path.resolve(root, stats.name));
+            fs.unlink(path.resolve(this.targetDir, templateFilePath), next);
           } else {
             const filePath = path.relative(this.templateDir, path.resolve(root, stats.name));
             if (!shouldIgnoreFile(filePath)) {
@@ -383,6 +388,56 @@ class Generator {
       const content = await this.renderFile(asyncapiDocument, path.resolve(baseDir, fileName), {
         channelName,
         channel: asyncapiDocument.channel(channelName),
+      });
+
+      await writeFile(targetFile, content, 'utf8');
+    } catch (e) {
+      throw e;
+    }
+  }
+
+  /**
+   * Generates all the files for each message.
+   *
+   * @private
+   * @param  {AsyncAPIDocument} asyncapiDocument AsyncAPI document to use as the source.
+   * @param  {String} fileName Name of the file to generate for each message.
+   * @param  {String} baseDir Base directory of the given file name.
+   * @returns {Promise}
+   */
+  async generateMessageFiles(asyncapiDocument, fileName, baseDir) {
+    const promises = [];
+
+    Object.keys(asyncapiDocument.components().messages()).forEach((messageName) => {
+      promises.push(this.generateMessageFile(asyncapiDocument, messageName, fileName, baseDir));
+    });
+
+    return Promise.all(promises);
+  }
+
+  /**
+   * Generates a file for a message.
+   *
+   * @private
+   * @param {AsyncAPIDocument} asyncapiDocument AsyncAPI document to use as the source.
+   * @param {String} messageName Name of the message to generate.
+   * @param {String} fileName Name of the file to generate for each message.
+   * @param {String} baseDir Base directory of the given file name.
+   * @returns {Promise}
+   */
+  async generateMessageFile(asyncapiDocument, messageName, fileName, baseDir) {
+    try {
+      const relativeBaseDir = path.relative(this.templateDir, baseDir);
+      const newFileName = fileName.replace('$$message$$', _.kebabCase(messageName));
+      const targetFile = path.resolve(this.targetDir, relativeBaseDir, newFileName);
+      const relativeTargetFile = path.relative(this.targetDir, targetFile);
+
+      const shouldOverwriteFile = await this.shouldOverwriteFile(relativeTargetFile);
+      if (!shouldOverwriteFile) return;
+
+      const content = await this.renderFile(asyncapiDocument, path.resolve(baseDir, fileName), {
+        messageName,
+        message: asyncapiDocument.components().message(messageName),
       });
 
       await writeFile(targetFile, content, 'utf8');


### PR DESCRIPTION
A first step to generate message definition files (like Avro files) is to allow generate a file for each message in the AsyncAPI definition.

As it's done for channels, with this PR the generator allows use $$message$$ in the file name of a file to generate message files.