### PR TITLE
AVRO template

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -302,6 +302,11 @@ class Generator {
             await this.generateChannelFiles(asyncapiDocument, stats.name, root);
             const templateFilePath = path.relative(this.templateDir, path.resolve(root, stats.name));
             fs.unlink(path.resolve(this.targetDir, templateFilePath), next);
+          } else if (stats.name.includes('$$message$$')) {
+            // this file should be handled for each in asyncapi.components.messages
+            await this.generateMessageFiles(asyncapiDocument, stats.name, root);
+            const templateFilePath = path.relative(this.templateDir, path.resolve(root, stats.name));
+            fs.unlink(path.resolve(this.targetDir, templateFilePath), next);
           } else {
             const filePath = path.relative(this.templateDir, path.resolve(root, stats.name));
             if (!shouldIgnoreFile(filePath)) {
@@ -383,6 +388,56 @@ class Generator {
       const content = await this.renderFile(asyncapiDocument, path.resolve(baseDir, fileName), {
         channelName,
         channel: asyncapiDocument.channel(channelName),
+      });
+
+      await writeFile(targetFile, content, 'utf8');
+    } catch (e) {
+      throw e;
+    }
+  }
+
+  /**
+   * Generates all the files for each message.
+   *
+   * @private
+   * @param  {AsyncAPIDocument} asyncapiDocument AsyncAPI document to use as the source.
+   * @param  {String} fileName Name of the file to generate for each message.
+   * @param  {String} baseDir Base directory of the given file name.
+   * @returns {Promise}
+   */
+  async generateMessageFiles(asyncapiDocument, fileName, baseDir) {
+    const promises = [];
+
+    Object.keys(asyncapiDocument.components().messages()).forEach((messageName) => {
+      promises.push(this.generateMessageFile(asyncapiDocument, messageName, fileName, baseDir));
+    });
+
+    return Promise.all(promises);
+  }
+
+  /**
+   * Generates a file for a message.
+   *
+   * @private
+   * @param {AsyncAPIDocument} asyncapiDocument AsyncAPI document to use as the source.
+   * @param {String} messageName Name of the message to generate.
+   * @param {String} fileName Name of the file to generate for each message.
+   * @param {String} baseDir Base directory of the given file name.
+   * @returns {Promise}
+   */
+  async generateMessageFile(asyncapiDocument, messageName, fileName, baseDir) {
+    try {
+      const relativeBaseDir = path.relative(this.templateDir, baseDir);
+      const newFileName = fileName.replace('$$message$$', _.kebabCase(messageName));
+      const targetFile = path.resolve(this.targetDir, relativeBaseDir, newFileName);
+      const relativeTargetFile = path.relative(this.targetDir, targetFile);
+
+      const shouldOverwriteFile = await this.shouldOverwriteFile(relativeTargetFile);
+      if (!shouldOverwriteFile) return;
+
+      const content = await this.renderFile(asyncapiDocument, path.resolve(baseDir, fileName), {
+        messageName,
+        message: asyncapiDocument.components().message(messageName),
       });
 
       await writeFile(targetFile, content, 'utf8');

--- a/templates/avro/$$message$$.avsc
+++ b/templates/avro/$$message$$.avsc
@@ -1,0 +1,8 @@
+{% set schemaName = messageName -%}
+{% set schema = message.payload() -%}
+{% if message.payload()._json.namespace -%}
+  {% set namespace = message.payload()._json.namespace -%}
+{% else -%}
+  {% set namespace = "com.asyncapi" -%}
+{% endif -%}
+{% include ".partials/record.avsc" %}

--- a/templates/avro/.filters/all.js
+++ b/templates/avro/.filters/all.js
@@ -1,0 +1,41 @@
+module.exports = ({ Nunjucks, _ }) => {
+  Nunjucks.addFilter('dump', object => {
+    return JSON.stringify(object);
+  });
+
+  Nunjucks.addFilter('wrapValue', (value, type) => {
+    if (type === 'string') {
+      return '"' + value + '"';
+    } else {
+      return value;
+    }
+  });
+
+  Nunjucks.addFilter('upperCamelCase', (str) => {
+    return _.chain(str).camelCase().upperFirst().value();
+  });
+
+  Nunjucks.addFilter('translateType', (type, format) => {
+    switch(type) {
+      case 'integer':
+        if (format && format === 'int64')
+          return 'long';
+        else
+          return 'int';
+      case 'string':
+        if (format && format === 'byte')
+          return 'bytes';
+        else
+          return 'string';
+      case 'boolean':
+        return 'boolean';
+      case 'number':
+        if (format && format === 'double')
+          return 'double';
+        else
+          return 'float';
+      default:
+        return 'null';
+    }
+  });
+};

--- a/templates/avro/.partials/array.avsc
+++ b/templates/avro/.partials/array.avsc
@@ -1,0 +1,16 @@
+{
+  "name": "{{ schemaName }}",
+  "type": {
+    "type": "array"
+    {% if schema.items() %}
+    , "items":
+      {% if schema.items().type() == "object" %}
+        {% set schemaName = schemaName + "Item" %}
+        {% set schema = schema.items() %}
+        {% include ".partials/record.avsc" %}
+      {% else %}
+        "{{ schema.items().type() | translateType(schema.items().format()) }}"
+      {% endif %}
+    {% endif %}
+  }
+}

--- a/templates/avro/.partials/record.avsc
+++ b/templates/avro/.partials/record.avsc
@@ -1,0 +1,37 @@
+{
+  "type": "record",
+  "name": "{{ schemaName | upperCamelCase }}",
+  {% if namespace %}"namespace": "{{ namespace }}",{% endif %}
+  "fields" : [
+    {% for propertyName, property in schema.properties() %}
+      {% if property.type() === "object" %}
+        {% if property._json['defined_type'] %}
+          {
+            "name": "{{ propertyName }}",
+            "type": "{{ property._json['defined_type'] }}"
+          }
+        {% else %}
+          {% set schemaName = propertyName %}
+          {% set schema = property %}
+          {% set namespace = null %}
+          {
+            "name": "{{propertyName}}",
+            "type": {% include ".partials/record.avsc" %}
+          }
+        {% endif %}
+      {% elif property.type() === "array" %}
+        {% set schemaName = propertyName %}
+        {% set schema = property %}
+        {% include ".partials/array.avsc" %}
+      {% else %}
+        {
+          "name": "{{ propertyName }}",
+          {% if property.default() %}"default": {{ property.default() | wrapValue(property.type()) | safe }},{% endif %}
+          {% if property.enum() %}"enum": {{ property.enum() | dump | safe }},{% endif %}
+          "type" : "{{ property.type() | translateType(property.format()) }}"
+        }
+      {% endif %}
+      {% if not loop.last %},{% endif %}
+    {% endfor %}
+  ]
+}

--- a/test/docs/store.yml
+++ b/test/docs/store.yml
@@ -1,0 +1,61 @@
+asyncapi: "2.0.0"
+info:
+  title: Store API
+  version: "1.0.0"
+
+servers:
+  local:
+    url: localhost:9091
+    protocol: kafka
+    description: Test broker
+
+defaultContentType: avro/binary
+
+channels:
+  order_created:
+    description: The topic on which order created event may be produced and consumed.
+    subscribe:
+      summary: Receive orders when they are created.
+      operationId: receiveCreatedOrders
+      message:
+        $ref: "#/components/messages/orderCreated"
+
+components:
+  messages:
+    orderCreated:
+      name: orderCreated
+      title: Order Created
+      summary: Order created data
+      contentType: avro/binary
+      payload:
+        $ref: "#/components/schemas/orderCreatedEnvelope"
+  schemas:
+    orderCreatedEnvelope:
+      namespace: com.store
+      type: object
+      properties:
+        payload:
+          $ref: "#/components/schemas/orderCreatedPayload"
+        metadata:
+          $ref: "#/components/schemas/metadata"
+    orderCreatedPayload:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/orderItem"
+    orderItem:
+      type: object
+      properties:
+        productId:
+          type: string
+        amount:
+          type: integer
+    metadata:
+      type: object
+      defined_type: com.store.commons.Metadata
+      properties:
+        timestamp:
+          type: string
+          format: date-time


### PR DESCRIPTION
Template to generate AVRO schemas from AsyncAPI document.

Note: there are two schema properties that are not defined in AsyncAPI specification but that are useful to generate the AVRO schemas, namespace and defined_type (for company defined schemas, for example).

A more complex AsyncAPI document will be added to test folder in order to test the template.