### PR TITLE
allOf schema support for markdown and HTML

### DIFF
--- a/templates/html/.filters/all.js
+++ b/templates/html/.filters/all.js
@@ -16,6 +16,7 @@ module.exports = ({ Nunjucks, Markdown, OpenAPISampler }) => {
       obj.type() === 'array' ||
       (obj.oneOf() && obj.oneOf().length) ||
       (obj.anyOf() && obj.anyOf().length) ||
+      (obj.allOf() && obj.allOf().length) ||
       obj.items() ||
       obj.additionalItems() ||
       (obj.properties() && Object.keys(obj.properties()).length) ||

--- a/templates/html/.partials/schema-prop.html
+++ b/templates/html/.partials/schema-prop.html
@@ -23,6 +23,7 @@
           {{ type(prop) }}
           {% if prop.anyOf() %}anyOf{% endif %}
           {% if prop.oneOf() %}oneOf{% endif %}
+          {% if prop.allOf() %}allOf{% endif %}
           <div class="inline-block">
             {% if prop.format() %}
               <span class="bg-yellow-dark font-bold no-underline text-black rounded lowercase ml-2"
@@ -151,7 +152,13 @@
         {% endif %}
 
         {% if prop.anyOf() %}
-          {% for pName, p in prop.anyOf() %}
+          {% for p in prop.anyOf() %}
+            {{ schemaProp(p, loop.index0, odd=(not odd)) }}
+          {% endfor %}
+        {% endif %}
+
+        {% if prop.allOf() %}
+          {% for p in prop.allOf() %}
             {{ schemaProp(p, loop.index0, odd=(not odd)) }}
           {% endfor %}
         {% endif %}

--- a/templates/markdown/.partials/schema-prop.md
+++ b/templates/markdown/.partials/schema-prop.md
@@ -1,7 +1,7 @@
 {% macro schemaProp(prop, propName, required=false, path='') %}
 <tr>
   <td>{{ path | tree }}{{ propName }} {% if required %}<strong>(required)</strong>{% endif %}</td>
-  <td>{{ prop | log }}{{ prop.type() }}{%- if prop.anyOf() -%}anyOf{%- endif -%}{%- if prop.allOf() -%}allOf{%- endif -%}{%- if prop.oneOf() %}oneOf{%- endif -%}{%- if prop.items().type %}({{prop.items().type()}}){%- endif -%}</td>
+  <td>{{ prop.type() }}{%- if prop.anyOf() -%}anyOf{%- endif -%}{%- if prop.allOf() -%}allOf{%- endif -%}{%- if prop.oneOf() %}oneOf{%- endif -%}{%- if prop.items().type %}({{prop.items().type()}}){%- endif -%}</td>
   <td>{{ prop.description() | markdown2html | safe }}</td>
   <td>{{ prop.enum() | acceptedValues | safe }}</td>
 </tr>

--- a/templates/markdown/.partials/schema-prop.md
+++ b/templates/markdown/.partials/schema-prop.md
@@ -1,14 +1,20 @@
 {% macro schemaProp(prop, propName, required=false, path='') %}
 <tr>
   <td>{{ path | tree }}{{ propName }} {% if required %}<strong>(required)</strong>{% endif %}</td>
-  <td>{{ prop | log }}{{ prop.type() }}{%- if prop.anyOf() -%}anyOf{%- endif -%}{%- if prop.oneOf() %}oneOf{%- endif -%}{%- if prop.items().type %}({{prop.items().type()}}){%- endif -%}</td>
+  <td>{{ prop | log }}{{ prop.type() }}{%- if prop.anyOf() -%}anyOf{%- endif -%}{%- if prop.allOf() -%}allOf{%- endif -%}{%- if prop.oneOf() %}oneOf{%- endif -%}{%- if prop.items().type %}({{prop.items().type()}}){%- endif -%}</td>
   <td>{{ prop.description() | markdown2html | safe }}</td>
   <td>{{ prop.enum() | acceptedValues | safe }}</td>
 </tr>
 {% for p in prop.anyOf() %}
+{% set pName %}<{{ loop.index }}>{% endset %}
+{{ schemaProp(p, pName, path=(propName | buildPath(path, pName))) }}
+{% endfor %}
+{% for p in prop.allOf() %}
+{% set pName %}<{{ loop.index }}>{% endset %}
 {{ schemaProp(p, pName, path=(propName | buildPath(path, pName))) }}
 {% endfor %}
 {% for p in prop.oneOf() %}
+{% set pName %}<{{ loop.index }}>{% endset %}
 {{ schemaProp(p, pName, path=(propName | buildPath(path, pName))) }}
 {% endfor %}
 {% for pName, p in prop.properties() %}


### PR DESCRIPTION
Adding 'allOf' schema type support in markdown and HTML following the pattern of 'anyOf' and 'oneOf'.

Additionally, in markdown, it was displaying `undefined` in the name column of the payload table for each element in the allOf/anyOf/oneOf, and I changed it to display `<1>` or `<2>` etc.