### PR TITLE
Feature/refactoring separated files code

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ ag -o ./docs --param title='Hello from param' asyncapi.yaml markdown
 ```
 In the template you can use it like this: ` {{ params.title }}`
 
+### File templating
+To seperate functionality into files, one can specify a filename like `$$channel$$.js` to generate a file for each channel defined in your specification. The following seperations are supported: `$$channel$$`, `$$message$$` and `$$securityScheme$$.js`.
+
 
 ### As a module
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -234,7 +234,7 @@ class Generator {
    * @param {String} [options.templatesDir]  Path to the directory where to find the given template. Defaults to internal `templates` directory.
    * @return {Promise}
    */
-  static async getTemplateFile (templateName, filePath, { templatesDir } = {}) {
+  static async getTemplateFile(templateName, filePath, { templatesDir } = {}) {
     return await readFile(path.resolve(templatesDir || DEFAULT_TEMPLATES_DIR, templateName, filePath), 'utf8');
   }
 
@@ -305,6 +305,11 @@ class Generator {
           } else if (stats.name.includes('$$message$$')) {
             // this file should be handled for each in asyncapi.components.messages
             await this.generateMessageFiles(asyncapiDocument, stats.name, root);
+            const templateFilePath = path.relative(this.templateDir, path.resolve(root, stats.name));
+            fs.unlink(path.resolve(this.targetDir, templateFilePath), next);
+          } else if (stats.name.includes('$$securityScheme$$')) {
+            // this file should be handled for each in asyncapi.components.messages
+            await this.generateSecuritySchemeFiles(asyncapiDocument, stats.name, root);
             const templateFilePath = path.relative(this.templateDir, path.resolve(root, stats.name));
             fs.unlink(path.resolve(this.targetDir, templateFilePath), next);
           } else {
@@ -388,6 +393,56 @@ class Generator {
       const content = await this.renderFile(asyncapiDocument, path.resolve(baseDir, fileName), {
         channelName,
         channel: asyncapiDocument.channel(channelName),
+      });
+
+      await writeFile(targetFile, content, 'utf8');
+    } catch (e) {
+      throw e;
+    }
+  }
+
+  /**
+   * Generates all the files for each security schema.
+   *
+   * @private
+   * @param  {AsyncAPIDocument} asyncapiDocument AsyncAPI document to use as the source.
+   * @param  {String} fileName Name of the file to generate for each security schema.
+   * @param  {String} baseDir Base directory of the given file name.
+   * @returns {Promise}
+   */
+  async generateSecuritySchemeFiles(asyncapiDocument, fileName, baseDir) {
+    const promises = [];
+
+    Object.keys(asyncapiDocument.components().securitySchemes()).forEach((securitySchemeName) => {
+      promises.push(this.generateSecuritySchemeFile(asyncapiDocument, securitySchemeName, fileName, baseDir));
+    });
+
+    return Promise.all(promises);
+  }
+
+  /**
+   * Generates a file for a security schema.
+   *
+   * @private
+   * @param {AsyncAPIDocument} asyncapiDocument AsyncAPI document to use as the source.
+   * @param {String} securitySchemeName Name of the security schema to generate.
+   * @param {String} fileName Name of the file to generate for each security schema.
+   * @param {String} baseDir Base directory of the given file name.
+   * @returns {Promise}
+   */
+  async generateSecuritySchemeFile(asyncapiDocument, securitySchemeName, fileName, baseDir) {
+    try {
+      const relativeBaseDir = path.relative(this.templateDir, baseDir);
+      const newFileName = fileName.replace('$$securityScheme$$', _.kebabCase(securitySchemeName));
+      const targetFile = path.resolve(this.targetDir, relativeBaseDir, newFileName);
+      const relativeTargetFile = path.relative(this.targetDir, targetFile);
+
+      const shouldOverwriteFile = this.shouldOverwriteFile(relativeTargetFile);
+      if (!shouldOverwriteFile) return;
+
+      const content = await this.renderFile(asyncapiDocument, path.resolve(baseDir, fileName), {
+        securitySchemeName,
+        message: asyncapiDocument.components().securitySchemes(securitySchemeName),
       });
 
       await writeFile(targetFile, content, 'utf8');

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -296,20 +296,23 @@ class Generator {
       });
 
       walker.on('file', async (root, stats, next) => {
+        let didSeperateIntoFiles = false;
         try {
           if (stats.name.includes('$$channel$$')) {
             // this file should be handled for each in asyncapi.channels
             await this.generateSeperateFiles(asyncapiDocument, asyncapiDocument.channels(), 'channel', stats.name, root);
-            const templateFilePath = path.relative(this.templateDir, path.resolve(root, stats.name));
-            fs.unlink(path.resolve(this.targetDir, templateFilePath), next);
+            didSeperateIntoFiles = true;
           } else if (stats.name.includes('$$message$$')) {
             // this file should be handled for each in asyncapi.components.messages
             await this.generateSeperateFiles(asyncapiDocument, asyncapiDocument.components().messages(), 'message', stats.name, root);
-            const templateFilePath = path.relative(this.templateDir, path.resolve(root, stats.name));
-            fs.unlink(path.resolve(this.targetDir, templateFilePath), next);
+            didSeperateIntoFiles = true;
           } else if (stats.name.includes('$$securityScheme$$')) {
             // this file should be handled for each in asyncapi.components.securityScheme
             await this.generateSeperateFiles(asyncapiDocument, asyncapiDocument.components().securitySchemes(), 'securityScheme', stats.name, root);
+            didSeperateIntoFiles = true;
+          }
+
+          if (didSeperateIntoFiles) {
             const templateFilePath = path.relative(this.templateDir, path.resolve(root, stats.name));
             fs.unlink(path.resolve(this.targetDir, templateFilePath), next);
           } else {
@@ -320,6 +323,7 @@ class Generator {
             }
             next();
           }
+
         } catch (e) {
           reject(e);
         }
@@ -366,13 +370,13 @@ class Generator {
     const promises = [];
 
     Object.keys(array).forEach((name) => {
-      let component = array[name];
+      const component = array[name];
       promises.push(this.generateSeperateFile(asyncapiDocument, name, component, template, fileName, baseDir));
     });
 
     return Promise.all(promises);
   }
-  
+
   /**
    * Generates a file for a component/channel
    *
@@ -395,8 +399,8 @@ class Generator {
       const shouldOverwriteFile = this.shouldOverwriteFile(relativeTargetFile);
       if (!shouldOverwriteFile) return;
       //Ensure the same object are parsed to the renderFile method as before.
-      var temp = {};
-      temp[template+"Name"] = name;
+      const temp = {};
+      temp[`${template}Name`] = name;
       temp[template] = component;
       const content = await this.renderFile(asyncapiDocument, path.resolve(baseDir, fileName), temp);
 
@@ -405,8 +409,6 @@ class Generator {
       throw e;
     }
   }
-
-
 
   /**
    * Generates a file.

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -308,7 +308,7 @@ class Generator {
             const templateFilePath = path.relative(this.templateDir, path.resolve(root, stats.name));
             fs.unlink(path.resolve(this.targetDir, templateFilePath), next);
           } else if (stats.name.includes('$$securityScheme$$')) {
-            // this file should be handled for each in asyncapi.components.messages
+            // this file should be handled for each in asyncapi.components.securityScheme
             await this.generateSecuritySchemeFiles(asyncapiDocument, stats.name, root);
             const templateFilePath = path.relative(this.templateDir, path.resolve(root, stats.name));
             fs.unlink(path.resolve(this.targetDir, templateFilePath), next);
@@ -439,10 +439,9 @@ class Generator {
 
       const shouldOverwriteFile = this.shouldOverwriteFile(relativeTargetFile);
       if (!shouldOverwriteFile) return;
-
       const content = await this.renderFile(asyncapiDocument, path.resolve(baseDir, fileName), {
         securitySchemeName,
-        message: asyncapiDocument.components().securitySchemes(securitySchemeName),
+        securityScheme: asyncapiDocument.components().securitySchemes()[securitySchemeName],
       });
 
       await writeFile(targetFile, content, 'utf8');
@@ -489,7 +488,6 @@ class Generator {
 
       const shouldOverwriteFile = await this.shouldOverwriteFile(relativeTargetFile);
       if (!shouldOverwriteFile) return;
-
       const content = await this.renderFile(asyncapiDocument, path.resolve(baseDir, fileName), {
         messageName,
         message: asyncapiDocument.components().message(messageName),

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -309,7 +309,7 @@ class Generator {
             fs.unlink(path.resolve(this.targetDir, templateFilePath), next);
           } else if (stats.name.includes('$$securityScheme$$')) {
             // this file should be handled for each in asyncapi.components.securityScheme
-            await this.generateSecuritySchemeFiles(asyncapiDocument, stats.name, root);
+            await this.generateSeperateFiles(asyncapiDocument, asyncapiDocument.components().securitySchemes(), 'securityScheme', stats.name, root);
             const templateFilePath = path.relative(this.templateDir, path.resolve(root, stats.name));
             fs.unlink(path.resolve(this.targetDir, templateFilePath), next);
           } else {
@@ -419,6 +419,37 @@ class Generator {
 
     return Promise.all(promises);
   }
+  generateSeperateFiles(asyncapiDocument, array, template, fileName, baseDir) {
+    const promises = [];
+
+    Object.keys(array).forEach((name) => {
+      let component = array[name];
+      promises.push(this.generateSeperateFile(asyncapiDocument, name, component, template, fileName, baseDir));
+    });
+
+    return Promise.all(promises);
+  }
+  async generateSeperateFile(asyncapiDocument, name, component, template, fileName, baseDir) {
+    try {
+      const relativeBaseDir = path.relative(this.templateDir, baseDir);
+      const newFileName = fileName.replace(`\$\$${template}\$\$`, _.kebabCase(name));
+      const targetFile = path.resolve(this.targetDir, relativeBaseDir, newFileName);
+      const relativeTargetFile = path.relative(this.targetDir, targetFile);
+
+      const shouldOverwriteFile = this.shouldOverwriteFile(relativeTargetFile);
+      if (!shouldOverwriteFile) return;
+      let temp = {
+        name
+      };
+      temp[template] = component;
+      const content = await this.renderFile(asyncapiDocument, path.resolve(baseDir, fileName), temp);
+
+      await writeFile(targetFile, content, 'utf8');
+    } catch (e) {
+      throw e;
+    }
+  }
+
 
   /**
    * Generates a file for a security schema.

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -299,7 +299,6 @@ class Generator {
         try {
           if (stats.name.includes('$$channel$$')) {
             // this file should be handled for each in asyncapi.channels
-            //await this.generateChannelFiles(asyncapiDocument, stats.name, root);
             await this.generateSeperateFiles(asyncapiDocument, asyncapiDocument.channels(), 'channel', stats.name, root);
             const templateFilePath = path.relative(this.templateDir, path.resolve(root, stats.name));
             fs.unlink(path.resolve(this.targetDir, templateFilePath), next);

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -395,6 +395,7 @@ class Generator {
 
       const shouldOverwriteFile = this.shouldOverwriteFile(relativeTargetFile);
       if (!shouldOverwriteFile) return;
+      //Ensure the same object are parsed to the renderFile method as before.
       var temp = {};
       temp[template+"Name"] = name;
       temp[template] = component;

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -299,12 +299,13 @@ class Generator {
         try {
           if (stats.name.includes('$$channel$$')) {
             // this file should be handled for each in asyncapi.channels
-            await this.generateChannelFiles(asyncapiDocument, stats.name, root);
+            //await this.generateChannelFiles(asyncapiDocument, stats.name, root);
+            await this.generateSeperateFiles(asyncapiDocument, asyncapiDocument.channels(), 'channel', stats.name, root);
             const templateFilePath = path.relative(this.templateDir, path.resolve(root, stats.name));
             fs.unlink(path.resolve(this.targetDir, templateFilePath), next);
           } else if (stats.name.includes('$$message$$')) {
             // this file should be handled for each in asyncapi.components.messages
-            await this.generateMessageFiles(asyncapiDocument, stats.name, root);
+            await this.generateSeperateFiles(asyncapiDocument, asyncapiDocument.components().messages(), 'message', stats.name, root);
             const templateFilePath = path.relative(this.templateDir, path.resolve(root, stats.name));
             fs.unlink(path.resolve(this.targetDir, templateFilePath), next);
           } else if (stats.name.includes('$$securityScheme$$')) {
@@ -352,73 +353,16 @@ class Generator {
   }
 
   /**
-   * Generates all the files for each channel.
+   * Generates all the files for each in array
    *
    * @private
    * @param  {AsyncAPIDocument} asyncapiDocument AsyncAPI document to use as the source.
-   * @param  {String} fileName Name of the file to generate for each channel.
-   * @param  {String} baseDir Base directory of the given file name.
-   * @returns {Promise}
-   */
-  async generateChannelFiles(asyncapiDocument, fileName, baseDir) {
-    const promises = [];
-
-    asyncapiDocument.channelNames().forEach((channelName) => {
-      promises.push(this.generateChannelFile(asyncapiDocument, channelName, fileName, baseDir));
-    });
-
-    return Promise.all(promises);
-  }
-
-  /**
-   * Generates a file for a channel.
-   *
-   * @private
-   * @param {AsyncAPIDocument} asyncapiDocument AsyncAPI document to use as the source.
-   * @param {String} channelName Name of the channel to generate.
-   * @param {String} fileName Name of the file to generate for each channel.
-   * @param {String} baseDir Base directory of the given file name.
-   * @returns {Promise}
-   */
-  async generateChannelFile(asyncapiDocument, channelName, fileName, baseDir) {
-    try {
-      const relativeBaseDir = path.relative(this.templateDir, baseDir);
-      const newFileName = fileName.replace('$$channel$$', _.kebabCase(channelName));
-      const targetFile = path.resolve(this.targetDir, relativeBaseDir, newFileName);
-      const relativeTargetFile = path.relative(this.targetDir, targetFile);
-
-      const shouldOverwriteFile = await this.shouldOverwriteFile(relativeTargetFile);
-      if (!shouldOverwriteFile) return;
-
-      const content = await this.renderFile(asyncapiDocument, path.resolve(baseDir, fileName), {
-        channelName,
-        channel: asyncapiDocument.channel(channelName),
-      });
-
-      await writeFile(targetFile, content, 'utf8');
-    } catch (e) {
-      throw e;
-    }
-  }
-
-  /**
-   * Generates all the files for each security schema.
-   *
-   * @private
-   * @param  {AsyncAPIDocument} asyncapiDocument AsyncAPI document to use as the source.
+   * @param  {Array} array The components/channels to generate the separeted files for.
+   * @param  {String} template The template filename to replace.
    * @param  {String} fileName Name of the file to generate for each security schema.
    * @param  {String} baseDir Base directory of the given file name.
    * @returns {Promise}
    */
-  async generateSecuritySchemeFiles(asyncapiDocument, fileName, baseDir) {
-    const promises = [];
-
-    Object.keys(asyncapiDocument.components().securitySchemes()).forEach((securitySchemeName) => {
-      promises.push(this.generateSecuritySchemeFile(asyncapiDocument, securitySchemeName, fileName, baseDir));
-    });
-
-    return Promise.all(promises);
-  }
   generateSeperateFiles(asyncapiDocument, array, template, fileName, baseDir) {
     const promises = [];
 
@@ -429,6 +373,19 @@ class Generator {
 
     return Promise.all(promises);
   }
+  
+  /**
+   * Generates a file for a component/channel
+   *
+   * @private
+   * @param  {AsyncAPIDocument} asyncapiDocument AsyncAPI document to use as the source.
+   * @param  {String} name The name of the component (filename to use)
+   * @param  {Object} component The component/channel object used to generate the file.
+   * @param  {String} template The template filename to replace.
+   * @param  {String} fileName Name of the file to generate for each security schema.
+   * @param  {String} baseDir Base directory of the given file name.
+   * @returns {Promise}
+   */
   async generateSeperateFile(asyncapiDocument, name, component, template, fileName, baseDir) {
     try {
       const relativeBaseDir = path.relative(this.templateDir, baseDir);
@@ -438,9 +395,8 @@ class Generator {
 
       const shouldOverwriteFile = this.shouldOverwriteFile(relativeTargetFile);
       if (!shouldOverwriteFile) return;
-      let temp = {
-        name
-      };
+      var temp = {};
+      temp[template+"Name"] = name;
       temp[template] = component;
       const content = await this.renderFile(asyncapiDocument, path.resolve(baseDir, fileName), temp);
 
@@ -451,84 +407,6 @@ class Generator {
   }
 
 
-  /**
-   * Generates a file for a security schema.
-   *
-   * @private
-   * @param {AsyncAPIDocument} asyncapiDocument AsyncAPI document to use as the source.
-   * @param {String} securitySchemeName Name of the security schema to generate.
-   * @param {String} fileName Name of the file to generate for each security schema.
-   * @param {String} baseDir Base directory of the given file name.
-   * @returns {Promise}
-   */
-  async generateSecuritySchemeFile(asyncapiDocument, securitySchemeName, fileName, baseDir) {
-    try {
-      const relativeBaseDir = path.relative(this.templateDir, baseDir);
-      const newFileName = fileName.replace('$$securityScheme$$', _.kebabCase(securitySchemeName));
-      const targetFile = path.resolve(this.targetDir, relativeBaseDir, newFileName);
-      const relativeTargetFile = path.relative(this.targetDir, targetFile);
-
-      const shouldOverwriteFile = this.shouldOverwriteFile(relativeTargetFile);
-      if (!shouldOverwriteFile) return;
-      const content = await this.renderFile(asyncapiDocument, path.resolve(baseDir, fileName), {
-        securitySchemeName,
-        securityScheme: asyncapiDocument.components().securitySchemes()[securitySchemeName],
-      });
-
-      await writeFile(targetFile, content, 'utf8');
-    } catch (e) {
-      throw e;
-    }
-  }
-
-  /**
-   * Generates all the files for each message.
-   *
-   * @private
-   * @param  {AsyncAPIDocument} asyncapiDocument AsyncAPI document to use as the source.
-   * @param  {String} fileName Name of the file to generate for each message.
-   * @param  {String} baseDir Base directory of the given file name.
-   * @returns {Promise}
-   */
-  async generateMessageFiles(asyncapiDocument, fileName, baseDir) {
-    const promises = [];
-
-    Object.keys(asyncapiDocument.components().messages()).forEach((messageName) => {
-      promises.push(this.generateMessageFile(asyncapiDocument, messageName, fileName, baseDir));
-    });
-
-    return Promise.all(promises);
-  }
-
-  /**
-   * Generates a file for a message.
-   *
-   * @private
-   * @param {AsyncAPIDocument} asyncapiDocument AsyncAPI document to use as the source.
-   * @param {String} messageName Name of the message to generate.
-   * @param {String} fileName Name of the file to generate for each message.
-   * @param {String} baseDir Base directory of the given file name.
-   * @returns {Promise}
-   */
-  async generateMessageFile(asyncapiDocument, messageName, fileName, baseDir) {
-    try {
-      const relativeBaseDir = path.relative(this.templateDir, baseDir);
-      const newFileName = fileName.replace('$$message$$', _.kebabCase(messageName));
-      const targetFile = path.resolve(this.targetDir, relativeBaseDir, newFileName);
-      const relativeTargetFile = path.relative(this.targetDir, targetFile);
-
-      const shouldOverwriteFile = await this.shouldOverwriteFile(relativeTargetFile);
-      if (!shouldOverwriteFile) return;
-      const content = await this.renderFile(asyncapiDocument, path.resolve(baseDir, fileName), {
-        messageName,
-        message: asyncapiDocument.components().message(messageName),
-      });
-
-      await writeFile(targetFile, content, 'utf8');
-    } catch (e) {
-      throw e;
-    }
-  }
 
   /**
    * Generates a file.


### PR DESCRIPTION
Refactoring the code to reduce duplicated code for how files are separated, as discussed in PR #142. The code have been refactored to not change the underlying `renderFile` method. This PR expect #142 to be merged before this one since some code conflicts might occur.