### PR TITLE
Do not show parser extensions

### DIFF
--- a/templates/html/.filters/all.js
+++ b/templates/html/.filters/all.js
@@ -21,7 +21,7 @@ module.exports = ({ _, Nunjucks, Markdown, OpenAPISampler }) => {
       obj.additionalItems() ||
       (obj.properties() && Object.keys(obj.properties()).length) ||
       obj.additionalProperties() ||
-      (obj.extensions() && Object.keys(obj.extensions()).length) ||
+      (obj.extensions() && Object.keys(obj.extensions()).filter(e => !e.startsWith('x-parser-')).length) ||
       obj.patternProperties()
     ) return true;
 
@@ -103,7 +103,7 @@ module.exports = ({ _, Nunjucks, Markdown, OpenAPISampler }) => {
   Nunjucks.addFilter('isArray', (arr) => {
     return Array.isArray(arr);
   });
-  
+
   Nunjucks.addFilter('isObject', (obj) => {
     return typeof obj === 'object' && obj !== null;
   });
@@ -145,5 +145,11 @@ module.exports = ({ _, Nunjucks, Markdown, OpenAPISampler }) => {
 
   Nunjucks.addFilter('generateExample', (schema) => {
     return JSON.stringify(OpenAPISampler.sample(schema) || '', null, 2);
+  });
+
+  Nunjucks.addFilter('nonParserExtensions', (schema) => {
+    if (!schema || !schema.extensions || typeof schema.extensions !== 'function') return new Map();
+    const extensions = Object.entries(schema.extensions());
+    return new Map(extensions.filter(e => !e[0].startsWith('x-parser-')).filter(Boolean));
   });
 };

--- a/templates/html/.partials/schema-prop.html
+++ b/templates/html/.partials/schema-prop.html
@@ -108,9 +108,10 @@
           {% endfor %}
         {% endif %}
 
-        {% if prop.extensions() | length > 0 %}
+        {% set extensions = prop | nonParserExtensions %}
+        {% if extensions.size > 0 %}
           <p class="pl-6 mb-2 mt-4 text-sm font-bold text-grey-darker">Specification Extensions:</p>
-          {% for extensionName, extensionValue in prop.extensions() %}
+          {% for extensionName, extensionValue in extensions %}
               <div class="{% if odd %}bg-grey-lightest{% else %}bg-grey-lighter{% endif %} pl-6">
               {% if extensionValue | isObject  %}
               <div class="{% if open %}is-open{% endif %}">


### PR DESCRIPTION
Latest releases are showing the `x-parser-*` extensions. These extensions are for tooling creators and are of no interest for the consumer.

Thanks to Scott Popplewell for reporting.