### PR TITLE
Add topicPrefix to Nodejs config file

### DIFF
--- a/templates/nodejs/config/common.yml
+++ b/templates/nodejs/config/common.yml
@@ -40,7 +40,7 @@ default:
       brokers:
         - {{ asyncapi.server(params.server).url() | host }}
       consumerOptions:
-        groupId: 'replace-me'
+        groupId: {{ asyncapi.info().title() | camelCase }}
       topics:
       {%- for topic in asyncapi | channelNamesWithPublish %}
         - {{ topic | toKafkaTopic }}

--- a/templates/nodejs/config/common.yml
+++ b/templates/nodejs/config/common.yml
@@ -46,6 +46,7 @@ default:
         - {{ topic | toKafkaTopic }}
       {%- endfor %}
       topicSeparator: '__'
+      topicPrefix:
 {%- endif %}
 
 development:


### PR DESCRIPTION
This option was already there but was not in the config file. It's useful when you're using free instances of cloud brokers, where the vendor usually prepend your username to every topic. I'm leaving it empty so, by default, it's not taken into account but it's possible to override the value from a `.env` file and access it like `config.broker.kafka.topicPrefix`.

### Example of free cloud Kafka instance at [cloudkarafka.com]()

`qw7yecbj` is my username and it prepends `qw7yecbj-` to every topic.

![Screen Shot 2019-11-22 at 12 57 07](https://user-images.githubusercontent.com/242119/69423919-a321ac00-0d27-11ea-846e-e2871b672587.png)