### PR TITLE
Fix wrong require statements

### DIFF
--- a/templates/nodejs/.filters/all.js
+++ b/templates/nodejs/.filters/all.js
@@ -1,4 +1,5 @@
 const { URL } = require('url');
+const filenamify = require('filenamify');
 
 module.exports = ({ Nunjucks, _ }) => {
   Nunjucks.addFilter('kebabCase', (string) => {
@@ -186,5 +187,9 @@ module.exports = ({ Nunjucks, _ }) => {
 
   Nunjucks.addFilter('toJS', (string) => {
     return toJS(string);
+  });
+
+  Nunjucks.addFilter('filenamify', (string, options) => {
+    return filenamify(string, options || { replacement: '-', maxLength: 255 });
   });
 };

--- a/templates/nodejs/src/api/index.js
+++ b/templates/nodejs/src/api/index.js
@@ -10,7 +10,7 @@ const config = require('../lib/config');
 {%- set protocol = asyncapi.server(params.server).protocol() %}
 const {{ protocol | capitalize }}Adapter = require('hermesjs-{{protocol}}');
 {%- for channelName, channel in asyncapi.channels() %}
-const {{ channelName | camelCase }} = require('./routes/{{ channelName | kebabCase }}.js');
+const {{ channelName | camelCase }} = require('./routes/{{ channelName | filenamify }}.js');
 {%- endfor %}
 
 app.addAdapter({{ protocol | capitalize }}Adapter, config.{% if protocol === 'ws' %}ws{% else %}broker.{{protocol}}{% endif %});

--- a/templates/nodejs/src/api/routes/$$channel$$.js
+++ b/templates/nodejs/src/api/routes/$$channel$$.js
@@ -1,6 +1,6 @@
 const Router = require('hermesjs/lib/router');
 const router = new Router();
-const {{ channelName | camelCase }}Handler = require('../handlers/{{ channelName | kebabCase }}');
+const {{ channelName | camelCase }}Handler = require('../handlers/{{ channelName | filenamify }}');
 module.exports = router;
 {% if channel.hasPublish() %}
   {%- if channel.publish().summary() %}

--- a/test/docs/streetlights.yml
+++ b/test/docs/streetlights.yml
@@ -16,23 +16,9 @@ info:
 
 servers:
   production:
-    url: test.mosquitto.org:{port}
+    url: mqtt://test.mosquitto.org
     protocol: mqtt
     description: Test broker
-    variables:
-      port:
-        description: Secure connection (TLS) is available through port 8883.
-        default: '1883'
-        enum:
-          - '1883'
-          - '8883'
-    security:
-      - apiKey: []
-      - supportedOauthFlows:
-        - streetlights:on
-        - streetlights:off
-        - streetlights:dim
-      - openIdConnectWellKnown: []
 
 defaultContentType: application/json
 


### PR DESCRIPTION
After the change we did yesterday to "filenamify" file names, routes and handlers requires were broken.

Also, I'm taking the opportunity to remove server url variables, which is not yet supported by the generator. I created a different issue here: https://github.com/asyncapi/generator/issues/182.