### PR TITLE
Fix content overlapping examples

### DIFF
--- a/templates/html/.partials/schema-prop.html
+++ b/templates/html/.partials/schema-prop.html
@@ -89,6 +89,14 @@
             {% endfor %}
           </div>
         {% endif %}
+        {% if prop.examples() %}
+          <div class="text-xs">
+            Examples:
+            {% for value in prop.examples() %}
+              <span class="border text-orange rounded ml-1 py-0 px-2">{{value | dump(2) | safe }}</span>
+            {% endfor %}
+          </div>
+        {% endif %}
       </div>
     </div>
 

--- a/templates/html/.partials/schema-prop.html
+++ b/templates/html/.partials/schema-prop.html
@@ -89,14 +89,6 @@
             {% endfor %}
           </div>
         {% endif %}
-        {% if prop.examples() %}
-          <div class="text-xs">
-            Examples:
-            {% for value in prop.examples() %}
-              <span class="border text-orange rounded ml-1 py-0 px-2">{{value | dump(2) | safe }}</span>
-            {% endfor %}
-          </div>
-        {% endif %}
       </div>
     </div>
 

--- a/templates/html/css/main.css
+++ b/templates/html/css/main.css
@@ -116,6 +116,7 @@ h1, h2, h3, h4, h5, h6 {
 
   .content-panel {
     margin-left: 256px;
+    width: calc((100% - 256px) * 0.4);
   }
 }
 


### PR DESCRIPTION
This fixes an issue where the centered content might overlap the examples on the right on medium-sized screens (15").

It also removes the `Example` section within the schema/payload block, as this information is duplicated anyway by the examples on the right.

**Before**
![Before](https://i.imgur.com/MJONUQb.png)

**After**
![After](https://i.imgur.com/CHntCPb.jpg)