### PR TITLE
Fix bug in array items

### DIFF
--- a/templates/html/.partials/schema-prop.html
+++ b/templates/html/.partials/schema-prop.html
@@ -141,8 +141,8 @@
           {% if prop.items() %}
             <p class="pl-6 mb-2 text-xs font-bold uppercase text-grey-darker">Items:</p>
             {% if prop.items() | isArray %}
-              {% for itName, it in prop.items() %}
-              {{ schemaProp(it, itName, odd=(not odd), required=(prop.required() | contains(pName))) }}
+              {% for it in prop.items() %}
+              {{ schemaProp(it, loop.index0, odd=(not odd), required=(prop.required() | contains(pName))) }}
               {% endfor %}
             {% else %}
               {{ schemaProp(prop.items(), '0', odd=(not odd)) }}

--- a/templates/html/.partials/type.html
+++ b/templates/html/.partials/type.html
@@ -2,7 +2,7 @@
 {{prop.json('type')}}
 {%- if prop.items() -%}
   &lt;
-  {%- if prop.items().json('type') -%}
+  {%- if prop.items().json and prop.items().json('type') -%}
     {{- prop.items().json('type') -}}
   {% elif prop.items() | isArray -%}
     {%- for p in prop.items() -%}


### PR DESCRIPTION
This PR fixes a bug that's happening when a Schema object of type `array` contains an `items` property which itself is an array.

An example to reproduce the bug:

```yaml
asyncapi: 2.0.0
info:
  title: Test
  version: 1.0.0

channels:
  test:
    publish:
      message:
        payload:
          type: array
          items:
            - type: object
```

The reason is that `items` can be either an array of objects or an object.