### PR TITLE
Add $$everySchema$$ to replace $$schema$$

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -332,8 +332,9 @@ class Generator {
       channel: asyncapiDocument.channels(),
       message: this.convertMapToObject(asyncapiDocument.allMessages()),
       securityScheme: asyncapiDocument.components() ? asyncapiDocument.components().securitySchemes() : {},
-      schema: this.convertMapToObject(asyncapiDocument.allSchemas()),
+      schema: asyncapiDocument.components() ? asyncapiDocument.components().schemas() : {},
       parameter: this.convertMapToObject(this.getAllParameters(asyncapiDocument)),
+      everySchema: this.convertMapToObject(asyncapiDocument.allSchemas()),
     };
 
     return new Promise((resolve, reject) => {

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -445,8 +445,9 @@ class Generator {
       if (!shouldOverwriteFile) return;
       //Ensure the same object are parsed to the renderFile method as before.
       const temp = {};
-      temp[`${template}Name`] = name;
-      temp[template] = component;
+      const key = template === 'everySchema' ? 'schema' : template;
+      temp[`${key}Name`] = name;
+      temp[key] = component;
       const content = await this.renderFile(asyncapiDocument, path.resolve(baseDir, fileName), temp);
 
       await writeFile(targetFile, content, 'utf8');


### PR DESCRIPTION
`$$schema$$` is producing a file for each schema, including parameters, headers, etc. That's not the desired behavior therefore, this PR makes `$$schema$$` generate a file for each schema defined under the components section.

To achieve the same behavior as before, you can use `$$everySchema$$`.

Fixes #213 