### PR TITLE
Cleanup setup of docker and add automated publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,15 @@
+name: Publish docker image
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run a one-line script
+      run: make docker release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,4 +12,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run a one-line script
-      run: make docker release
+      run: |
+        echo ${{secrets.DOCKER_PASSWORD}} | docker login -u ${{secrets.DOCKER_USERNAME}} --password-stdin
+        make docker release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,9 @@
 name: Publish docker image
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+    - '*'
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,12 +7,10 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
-    - name: Run a one-line script
+    - name: Start release
       run: |
         echo ${{secrets.DOCKER_PASSWORD}} | docker login -u ${{secrets.DOCKER_USERNAME}} --password-stdin
         make docker release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-FROM node:11
+FROM node:13.8.0-alpine3.11
 
-WORKDIR /asyncapi
+WORKDIR /app
 
-# install dependencies
+# Install dependencies
 COPY package*.json ./
+
 RUN npm install
 
-# copy code
+# Copy sources
 COPY . .
 
-ENTRYPOINT [ "node", "/asyncapi/cli" ]
+ENTRYPOINT [ "node", "/app/cli" ]

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
-
+.PHONY: docker
 docker: 
 	docker build -t asyncapi/generator:latest .
 
+.PHONY: release
 release:
-	# todo: do this using CI
 	./release.sh
-
-.PHONY: docker release

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: docker
 docker: 
-	docker build -t asyncapi/generator:latest .
+	docker build -t derberg/generator:latest .
 
 .PHONY: release
 release:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: docker
 docker: 
-	docker build -t derberg/generator:latest .
+	docker build -t asyncapi/generator:latest .
 
 .PHONY: release
 release:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 <p align="center">
   <em>Use your AsyncAPI definition to generate literally anything. Markdown documentation, Node.js code, HTML documentation, anything!</em>
 </p>
+
+![npm](https://img.shields.io/npm/v/asyncapi-generator?style=for-the-badge) ![npm](https://img.shields.io/npm/dt/asyncapi-generator?style=for-the-badge)
+
 <br><br>
 
 > :warning: This package doesn't support AsyncAPI 1.x anymore. We recommend to upgrade to the latest AsyncAPI version using the [AsyncAPI converter](https://github.com/asyncapi/converter). If you need to convert documents on the fly, you may use the [Node.js](https://github.com/asyncapi/converter) or [Go](https://github.com/asyncapi/converter-go) converters.
@@ -12,10 +15,12 @@
 npm install -g asyncapi-generator
 ```
 
-Or use all the commands below using Docker by replacing `ag` in all the commands below with:
+Or just use Docker:
 
 ```bash
 docker run --rm -it -v $PWD:/app -w /app asyncapi/generator [COMMAND HERE]
+# Example that you can run inside generator directory after cloning this repository
+docker run --rm -it -v $PWD:/app -w /app asyncapi/generator -o ag -o ./my_output ./test/docs/streetlights.yml markdown
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -18,9 +18,15 @@ npm install -g asyncapi-generator
 Or just use Docker:
 
 ```bash
-docker run --rm -it -v [ASYNCAPI FILES LOCATION]:/app/my_files asyncapi/generator [COMMAND HERE]
-# Example that you can run inside generator directory after cloning this repository
-docker run --rm -it -v ${PWD}/test/docs:/app/my_files asyncapi/generator -o ./my_files my_files/streetlights.yml markdown
+docker run --rm -it \
+-v [ASYNCAPI FILE LOCATION]:/app/asyncapi.yml \
+-v [GENERATED FILES LOCATION]:/app/output \
+asyncapi/generator [COMMAND HERE]
+# Example that you can run inside generator directory after cloning this repository. First you specify mount in location of your AsyncAPI file and then you mount in directory where generation result should be saved.
+docker run --rm -it \
+-v ${PWD}/test/docs/streetlights.yml:/app/asyncapi.yml \
+-v ${PWD}/output:/app/output \
+asyncapi/generator -o ./output asyncapi.yml markdown
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ npm install -g asyncapi-generator
 Or just use Docker:
 
 ```bash
-docker run --rm -it -v $PWD:/app -w /app asyncapi/generator [COMMAND HERE]
+docker run --rm -it -v ${PWD}:/app -w /app asyncapi/generator [COMMAND HERE]
 # Example that you can run inside generator directory after cloning this repository
-docker run --rm -it -v $PWD:/app -w /app asyncapi/generator -o ag -o ./my_output ./test/docs/streetlights.yml markdown
+docker run --rm -it -v ${PWD}:/app -w /app asyncapi/generator -o ag -o ./my_output ./test/docs/streetlights.yml markdown
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install -g asyncapi-generator
 Or just use Docker:
 
 ```bash
-docker run --rm -it -v ${PWD}/test/docs:/app/my_files asyncapi/generator [COMMAND HERE]
+docker run --rm -it -v [ASYNCAPI FILES LOCATION]:/app/my_files asyncapi/generator [COMMAND HERE]
 # Example that you can run inside generator directory after cloning this repository
 docker run --rm -it -v ${PWD}/test/docs:/app/my_files asyncapi/generator -o ./my_files my_files/streetlights.yml markdown
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Or just use Docker:
 ```bash
 docker run --rm -it -v ${PWD}:/app -w /app asyncapi/generator [COMMAND HERE]
 # Example that you can run inside generator directory after cloning this repository
-docker run --rm -it -v ${PWD}:/app -w /app asyncapi/generator -o ag -o ./my_output ./test/docs/streetlights.yml markdown
+docker run --rm -it -v ${PWD}:/app asyncapi/generator -o ./my_output ./test/docs/streetlights.yml markdown
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install -g asyncapi-generator
 Or just use Docker:
 
 ```bash
-docker run --rm -it -v ${PWD}:/app -w /app asyncapi/generator [COMMAND HERE]
+docker run --rm -it -v ${PWD}:/app asyncapi/generator [COMMAND HERE]
 # Example that you can run inside generator directory after cloning this repository
 docker run --rm -it -v ${PWD}:/app asyncapi/generator -o ./my_output ./test/docs/streetlights.yml markdown
 ```

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ npm install -g asyncapi-generator
 Or just use Docker:
 
 ```bash
-docker run --rm -it -v ${PWD}:/app asyncapi/generator [COMMAND HERE]
+docker run --rm -it -v ${PWD}/test/docs:/app/my_files asyncapi/generator [COMMAND HERE]
 # Example that you can run inside generator directory after cloning this repository
-docker run --rm -it -v ${PWD}:/app asyncapi/generator -o ./my_output ./test/docs/streetlights.yml markdown
+docker run --rm -it -v ${PWD}/test/docs:/app/my_files asyncapi/generator -o ./my_files my_files/streetlights.yml markdown
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,51 +1,52 @@
 {
-  "name": "asyncapi-generator",
-  "version": "0.28.3",
-  "description": "The AsyncAPI generator. It can generate documentation, code, anything!",
-  "main": "./lib/generator.js",
-  "bin": {
-    "asyncapi-generator": "./cli.js",
-    "ag": "./cli.js"
-  },
-  "scripts": {
-    "docs": "jsdoc2md lib/generator.js > API.md"
-  },
-  "preferGlobal": true,
-  "bugs": {
-    "url": "https://github.com/asyncapi/generator/issues"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/asyncapi/generator.git"
-  },
-  "keywords": [
-    "asyncapi",
-    "documentation",
-    "generator",
-    "markdown"
-  ],
-  "author": {
-    "name": "Fran Mendez",
-    "email": "fmvilas@gmail.com"
-  },
-  "homepage": "https://github.com/asyncapi/generator",
-  "dependencies": {
-    "ajv": "^6.10.2",
-    "asyncapi-parser": "^0.13.0",
-    "commander": "^2.12.2",
-    "filenamify": "^4.1.0",
-    "fs.extra": "^1.3.2",
-    "jmespath": "^0.15.0",
-    "js-yaml": "^3.13.1",
-    "klaw-sync": "^6.0.0",
-    "lodash": "^4.17.15",
-    "markdown-it": "^8.4.1",
-    "minimatch": "^3.0.4",
-    "nunjucks": "^3.2.0",
-    "openapi-sampler": "^1.0.0-beta.9"
-  },
-  "devDependencies": {
-    "chokidar": "^3.3.0",
-    "jsdoc-to-markdown": "^5.0.0"
-  }
+    "name": "asyncapi-generator",
+    "version": "0.28.3",
+    "description": "The AsyncAPI generator. It can generate documentation, code, anything!",
+    "main": "./lib/generator.js",
+    "bin": {
+        "asyncapi-generator": "./cli.js",
+        "ag": "./cli.js"
+    },
+    "scripts": {
+        "docs": "jsdoc2md lib/generator.js > API.md"
+    },
+    "preferGlobal": true,
+    "bugs": {
+        "url": "https://github.com/asyncapi/generator/issues"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/asyncapi/generator.git"
+    },
+    "keywords": [
+        "asyncapi",
+        "documentation",
+        "generator",
+        "markdown"
+    ],
+    "author": {
+        "name": "Fran Mendez",
+        "email": "fmvilas@gmail.com"
+    },
+    "license": "Apache-2.0",
+    "homepage": "https://github.com/asyncapi/generator",
+    "dependencies": {
+        "ajv": "^6.10.2",
+        "asyncapi-parser": "^0.13.0",
+        "commander": "^2.12.2",
+        "filenamify": "^4.1.0",
+        "fs.extra": "^1.3.2",
+        "jmespath": "^0.15.0",
+        "js-yaml": "^3.13.1",
+        "klaw-sync": "^6.0.0",
+        "lodash": "^4.17.15",
+        "markdown-it": "^8.4.1",
+        "minimatch": "^3.0.4",
+        "nunjucks": "^3.2.0",
+        "openapi-sampler": "^1.0.0-beta.9"
+    },
+    "devDependencies": {
+        "chokidar": "^3.3.0",
+        "jsdoc-to-markdown": "^5.0.0"
+    }
 }

--- a/release.sh
+++ b/release.sh
@@ -3,8 +3,6 @@
 version=$(docker run --rm -v $PWD:/app treeder/bump --extract --filename package.json)
 echo "version $version"
 
-make docker
-
 docker tag asyncapi/generator:latest asyncapi/generator:$version
 docker push asyncapi/generator:$version
 docker push asyncapi/generator:latest

--- a/release.sh
+++ b/release.sh
@@ -3,6 +3,6 @@
 version=$(docker run --rm -v $PWD:/app treeder/bump --extract --filename package.json)
 echo "version $version"
 
-docker tag asyncapi/generator:latest asyncapi/generator:$version
-docker push asyncapi/generator:$version
-docker push asyncapi/generator:latest
+docker tag derberg/generator:latest derberg/generator:$version
+docker push derberg/generator:$version
+docker push derberg/generator:latest

--- a/release.sh
+++ b/release.sh
@@ -3,6 +3,6 @@
 version=$(docker run --rm -v $PWD:/app treeder/bump --extract --filename package.json)
 echo "version $version"
 
-docker tag derberg/generator:latest derberg/generator:$version
-docker push derberg/generator:$version
-docker push derberg/generator:latest
+docker tag asyncapi/generator:latest asyncapi/generator:$version
+docker push asyncapi/generator:$version
+docker push asyncapi/generator:latest


### PR DESCRIPTION
GitHub Action that published docker image will be triggered on a new tag creation.

- changed base image in dockerfile to alpine version which makes image much smaller and is enough, and still official node image. Instead of 937MB it is 145MB now on local
- added license to package.json as npm didn't like it is missing
- added example of running docker on local to README.md
- sorry for badges but I'm just a huge fan....can remove if you do not like them...
- cleaned up makefile and release.sh
- GitHub action is very simple as most of the work was already done in scripts that I reused. I decided to keep flow with scripts instead of specific GitHub Action as I think having scripts in a repo is great if you have to push from local, and best if the same scripts are also used in CI
- echoing the password to stdin in docker login in github action - I took it from here https://github.com/elgohr/Publish-Docker-Github-Action/blob/a6e48211ae26c311681c44c45a0ca5130dd9c7aa/entrypoint.sh#L26 but to be honest I have no idea why it is better than just passing it as a parameter, like username. I assumed it is best practice, especially that it is used in this very popular GitHub Action. 

You can see GitHub action works like a charm on my fork where I configured it for the sake of this PR: https://github.com/derberg/generator/runs/432173556?check_suite_focus=true

Related to #187