### PR TITLE
Set sane CSS defaults on the HTML template

### DIFF
--- a/templates/html/css/main.css
+++ b/templates/html/css/main.css
@@ -1,9 +1,18 @@
 html, body {
   font-weight: lighter;
+  background-color: white;
 }
 
 h1, h2, h3, h4, h5, h6 {
   font-weight: lighter;
+}
+
+a {
+  color: #333;
+}
+
+a:hover {
+  color: black;
 }
 
 .string-chunk {


### PR DESCRIPTION
When using the HTML template on a dark background browser, the background color is not white but "dark" and the template doesn't look great. This PR provides a sane default for background and links.

Fixes https://github.com/asyncapi/vscode-extension/issues/1