### PR TITLE
Add support for gitignore to git protection feature

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -700,19 +700,29 @@ class Generator {
   }
 
   /**
-   * Check if given directory is a git repo with unstaged changes or is not empty
+   * Check if given directory is a git repo with unstaged changes and is not in .gitignore or is not empty
    * @private
    * @param  {String} dir Directory that needs to be tested for a given condition.
   */
   async verifyTargetDir(dir) {
-    const gitInfo = git(dir);
 
     try {
-      const isGitRepo = await gitInfo.checkIsRepo();
+
+      const isGitRepo = await git(dir).checkIsRepo();
 
       if (isGitRepo) {
-        const gitStatus = await gitInfo.status();
+        //Need to figure out root of the repository to properly verify .gitignore 
+        const root = await git(dir).revparse(['--show-toplevel']);
+        const gitInfo = git(root);
 
+        //Skipping verification if workDir inside repo is declared in .gitignore
+        const workDir = path.relative(root, dir);
+        if (workDir) {
+            const checkGitIgnore = await gitInfo.checkIgnore(workDir);
+            if (checkGitIgnore.length !== 0) return
+        }
+
+        const gitStatus = await gitInfo.status();
         //New files are not tracked and not visible as modified
         const hasUntrackedUnstagedFiles = gitStatus.not_added.length !== 0;
 
@@ -720,7 +730,7 @@ class Generator {
         const modifiedFiles = gitStatus.modified;
         const hasModifiedUstagedFiles = (modifiedFiles.filter(e => stagedFiles.indexOf(e) === -1)).length !== 0;
 
-        if (hasModifiedUstagedFiles || hasUntrackedUnstagedFiles) throw new Error(`"${this.targetDir}" is in a git repository with unstaged changes. Please commit your changes before proceeding or use the --force-write flag to skip this rule (not recommended).`);
+        if (hasModifiedUstagedFiles || hasUntrackedUnstagedFiles) throw new Error(`"${this.targetDir}" is in a git repository with unstaged changes. Please commit your changes before proceeding or add proper directory to .gitignore file. You can also use the --force-write flag to skip this rule (not recommended).`);
       } else {
         const isDirEmpty = (await readDir(dir)).length === 0;
 


### PR DESCRIPTION
I started using this feature because I started working on latest master for another issue....and I got annoyed that there is no support for case:
_I have a git repo and my output directory is in .gitignore which mean no harm if generator generates files there_