### PR TITLE
Add support for server variables in Nodejs template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM node:13.8.0-alpine3.11
 
 WORKDIR /app
 
+# Since 0.30.0 release Git is supported and required as a dependency
+RUN apk --update add git && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm /var/cache/apk/*
+
 # Install dependencies
 COPY package*.json ./
 

--- a/templates/nodejs/.filters/all.js
+++ b/templates/nodejs/.filters/all.js
@@ -204,10 +204,14 @@ module.exports = ({ Nunjucks }) => {
    */
   function replaceVariablesWithValues(url, serverVariables) {
     const urlVariables = getVariablesNamesFromUrl(url);
-    const isVariableDeclared =
-      urlVariables.filter(el => serverVariables.hasOwnProperty(el[1])) !== 0;
-
-    if (urlVariables.length !== 0 && isVariableDeclared) {
+    const declaredVariables =
+      urlVariables.filter(el => serverVariables.hasOwnProperty(el[1]))
+    
+    if (declaredVariables.length !== 0) {
+      console.log("dupa")
+    }
+    console.log(declaredVariables)
+    if (urlVariables.length !== 0 && declaredVariables.length !== 0) {
       let value;
       let newUrl = url;
 

--- a/templates/nodejs/.filters/all.js
+++ b/templates/nodejs/.filters/all.js
@@ -199,7 +199,7 @@ module.exports = ({ Nunjucks }) => {
    * Replace is performed only if there are variables in the URL and they are declared for a server
    * @private
    * @param {String} url The server url value.
-   * @param {Object} serverVariables object containins server variables.
+   * @param {Object} serverVariables object containing server variables.
    * @return {String}
    */
   function replaceVariablesWithValues(url, serverVariables) {

--- a/templates/nodejs/.filters/all.js
+++ b/templates/nodejs/.filters/all.js
@@ -207,10 +207,6 @@ module.exports = ({ Nunjucks }) => {
     const declaredVariables =
       urlVariables.filter(el => serverVariables.hasOwnProperty(el[1]))
     
-    if (declaredVariables.length !== 0) {
-      console.log("dupa")
-    }
-    console.log(declaredVariables)
     if (urlVariables.length !== 0 && declaredVariables.length !== 0) {
       let value;
       let newUrl = url;

--- a/templates/nodejs/config/common.yml
+++ b/templates/nodejs/config/common.yml
@@ -16,7 +16,7 @@ default:
       exchange:
       username:
       password:
-      host: {{ asyncapi.server(params.server).url() | host }}
+      host: {{ asyncapi.server(params.server).url() | replaceVariablesWithValues(asyncapi.server(params.server).variables())  | host }}
       port:
       topics: {{ asyncapi | channelNamesWithPublish | toAmqpTopic | dump | safe }}
       queue: {{ asyncapi.info().title() | queueName(asyncapi.info().version()) }}
@@ -27,7 +27,7 @@ default:
 {%- endif %}
 {%- if asyncapi.server(params.server).protocol() === "mqtt" %}
     mqtt:
-      url: mqtt://{{ asyncapi.server(params.server).url() | stripProtocol }}
+      url: mqtt://{{ asyncapi.server(params.server).url() | replaceVariablesWithValues(asyncapi.server(params.server).variables()) | stripProtocol  }}
       topics: {{ asyncapi | channelNamesWithPublish | toMqttTopic | dump | safe }}
       qos:
       protocol: mqtt
@@ -38,7 +38,7 @@ default:
     kafka:
       clientId: {{ asyncapi.info().title() | camelCase }}
       brokers:
-        - {{ asyncapi.server(params.server).url() | host }}
+        - {{ asyncapi.server(params.server).url() | replaceVariablesWithValues(asyncapi.server(params.server).variables()) | host }}
       consumerOptions:
         groupId: {{ asyncapi.info().title() | camelCase }}
       topics:

--- a/templates/nodejs/config/common.yml
+++ b/templates/nodejs/config/common.yml
@@ -4,7 +4,7 @@ default:
     version: {{ asyncapi.info().version() }}
 {% if asyncapi.server(params.server).protocol() === "ws" %}
   ws:
-    port: {{ asyncapi.server(params.server).url() | port(80) }}
+    port: {{ asyncapi.server(params.server).url() | replaceVariablesWithValues(asyncapi.server(params.server).variables()) | port(80) }}
     path: /ws
     topicSeparator: '__'
 {% endif %}

--- a/templates/nodejs/config/common.yml
+++ b/templates/nodejs/config/common.yml
@@ -16,7 +16,7 @@ default:
       exchange:
       username:
       password:
-      host: amqp://{{ asyncapi.server(params.server).url() | replaceVariablesWithValues(asyncapi.server(params.server).variables())  | host }}
+      host: {{ asyncapi.server(params.server).url() | replaceVariablesWithValues(asyncapi.server(params.server).variables())  | host }}
       port:
       topics: {{ asyncapi | channelNamesWithPublish | toAmqpTopic | dump | safe }}
       queue: {{ asyncapi.info().title() | queueName(asyncapi.info().version()) }}

--- a/templates/nodejs/config/common.yml
+++ b/templates/nodejs/config/common.yml
@@ -16,7 +16,7 @@ default:
       exchange:
       username:
       password:
-      host: {{ asyncapi.server(params.server).url() | replaceVariablesWithValues(asyncapi.server(params.server).variables())  | host }}
+      host: amqp://{{ asyncapi.server(params.server).url() | replaceVariablesWithValues(asyncapi.server(params.server).variables())  | host }}
       port:
       topics: {{ asyncapi | channelNamesWithPublish | toAmqpTopic | dump | safe }}
       queue: {{ asyncapi.info().title() | queueName(asyncapi.info().version()) }}

--- a/test/docs/streetlights.yml
+++ b/test/docs/streetlights.yml
@@ -16,7 +16,7 @@ info:
 
 servers:
   production:
-    url: mqtt://test.mosquitto.org
+    url: mqtt://test.mosquitto.org:{port}
     protocol: mqtt
     description: Test broker
     variables:

--- a/test/docs/streetlights.yml
+++ b/test/docs/streetlights.yml
@@ -19,6 +19,13 @@ servers:
     url: mqtt://test.mosquitto.org
     protocol: mqtt
     description: Test broker
+    variables:
+      port:
+        description: Secure connection (TLS) is available through port 8883.
+        default: '1883'
+        enum:
+          - '1883'
+          - '8883'
 
 defaultContentType: application/json
 


### PR DESCRIPTION
Fixes #182 

- Updates docs for creating templates in area of hooks and partials
- Extends the test doc to have a server variable
- Adds support for variables in the `servers` object to the Node.js template. An example is based on the `port` variable

I could test MQTT protocol as it is already in the streetlights.yml. After my changes I generated the Nodejs example and started it. It received a message sent to `mqtt pub -t 'smartylighting/streetlights/1/0/event/{streetlightId}/lighting/measured' -h 'test.mosquitto.org' -p 1883 -m '{"id": 1"}'`

Important notes to how the `replaceVariablesWithValues` filter works:
- if variable is in URL but not declared, it stays
- if variable is in URL and declared, it picks up default, otherwise first enum element, otherwise is stays unchanged
It is pretty generic, works on any string, not just url of course.

I need some suggestions on how to test if my changes work with other brokers. How you do it? should I just grab Kafka and others on my local and play or?

So far I made sure that in `common.yml` config whenever `url()` is grabbed and filter (that gets a string and created new URL object from it) is used, I add the variable parsing filter first to not get errors. If filters are shared among other templates, I'm afraid there might be some issues in other templates...:thinking: I ran generation for all of them and got no errors, but I don't know if it means all is fine