### PR TITLE
Fix template installation when using generator as a library

### DIFF
--- a/API.md
+++ b/API.md
@@ -10,6 +10,7 @@
         * [.generateFromString(asyncapiString, [asyncApiFileLocation])](#Generator+generateFromString) ⇒ <code>Promise</code>
         * [.generateFromFile(asyncapiFile)](#Generator+generateFromFile) ⇒ <code>Promise</code>
         * [.getAllParameters(asyncapiDocument)](#Generator+getAllParameters)
+        * [.installTemplate([force])](#Generator+installTemplate)
     * _static_
         * [.getTemplateFile(templateName, filePath, options)](#Generator.getTemplateFile) ⇒ <code>Promise</code>
 
@@ -31,6 +32,7 @@ Instantiates a new Generator object.
 | [options.disabledHooks] | <code>Array.&lt;String&gt;</code> |  | List of hooks to disable. |
 | [options.output] | <code>String</code> | <code>&#x27;fs&#x27;</code> | Type of output. Can be either 'fs' (default) or 'string'. Only available when entrypoint is set. |
 | [options.forceWrite] | <code>Boolean</code> | <code>false</code> | Force writing of the generated files to given directory even if it is a git repo with unstaged files or not empty dir. Default is set to false. |
+| [options.forceInstall] | <code>Boolean</code> | <code>false</code> | Force the installation of the template dependencies. By default, dependencies are installed and this flag is taken into account only if `node_modules` is not in place. |
 
 **Example**  
 ```js
@@ -164,6 +166,17 @@ try {
 | Param | Type | Description |
 | --- | --- | --- |
 | asyncapiDocument | <code>AsyncAPIDocument</code> | AsyncAPI document to use as the source. |
+
+<a name="Generator+installTemplate"></a>
+
+### generator.installTemplate([force])
+Installs template dependencies.
+
+**Kind**: instance method of [<code>Generator</code>](#Generator)  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [force] | <code>Boolean</code> | <code>false</code> | Whether to force installation or not. |
 
 <a name="Generator.getTemplateFile"></a>
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -80,7 +80,7 @@ class Generator {
    * @param {String} [options.output='fs'] Type of output. Can be either 'fs' (default) or 'string'. Only available when entrypoint is set.
    * @param {Boolean} [options.forceWrite=false] Force writing of the generated files to given directory even if it is a git repo with unstaged files or not empty dir. Default is set to false.
    */
-  constructor(templateName, targetDir, { templatesDir, templateParams, entrypoint, noOverwriteGlobs, disabledHooks, output = 'fs', forceWrite = false } = {}) {
+  constructor(templateName, targetDir, { templatesDir, templateParams = {}, entrypoint, noOverwriteGlobs, disabledHooks, output = 'fs', forceWrite = false } = {}) {
     if (!templateName) throw new Error('No template name has been specified.');
     if (!entrypoint && !targetDir) throw new Error('No target directory has been specified.');
     if (!['fs', 'string'].includes(output)) throw new Error(`Invalid output type ${output}. Valid values are 'fs' and 'string'.`);
@@ -143,7 +143,7 @@ class Generator {
 
     try {
       if (!this.forceWrite) await this.verifyTargetDir(this.targetDir);
-      
+
       await this.registerFilters();
 
       if (this.entrypoint) {
@@ -714,7 +714,7 @@ class Generator {
       const isGitRepo = await git(dir).checkIsRepo();
 
       if (isGitRepo) {
-        //Need to figure out root of the repository to properly verify .gitignore 
+        //Need to figure out root of the repository to properly verify .gitignore
         const root = await git(dir).revparse(['--show-toplevel']);
         const gitInfo = git(root);
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -10,6 +10,7 @@ const jmespath = require('jmespath');
 const Ajv = require('ajv');
 const filenamify = require('filenamify');
 const git = require('simple-git/promise');
+const npmi = require('npmi');
 
 const ajv = new Ajv({ allErrors: true });
 
@@ -79,8 +80,9 @@ class Generator {
    * @param {String[]} [options.disabledHooks] List of hooks to disable.
    * @param {String} [options.output='fs'] Type of output. Can be either 'fs' (default) or 'string'. Only available when entrypoint is set.
    * @param {Boolean} [options.forceWrite=false] Force writing of the generated files to given directory even if it is a git repo with unstaged files or not empty dir. Default is set to false.
+   * @param {Boolean} [options.forceInstall=false] Force the installation of the template dependencies. By default, dependencies are installed and this flag is taken into account only if `node_modules` is not in place.
    */
-  constructor(templateName, targetDir, { templatesDir, templateParams = {}, entrypoint, noOverwriteGlobs, disabledHooks, output = 'fs', forceWrite = false } = {}) {
+  constructor(templateName, targetDir, { templatesDir, templateParams = {}, entrypoint, noOverwriteGlobs, disabledHooks, output = 'fs', forceWrite = false, forceInstall = false } = {}) {
     if (!templateName) throw new Error('No template name has been specified.');
     if (!entrypoint && !targetDir) throw new Error('No target directory has been specified.');
     if (!['fs', 'string'].includes(output)) throw new Error(`Invalid output type ${output}. Valid values are 'fs' and 'string'.`);
@@ -94,6 +96,7 @@ class Generator {
     this.disabledHooks = disabledHooks || [];
     this.output = output;
     this.forceWrite = forceWrite;
+    this.forceInstall = forceInstall;
 
     // Config Nunjucks
     this.nunjucks = new Nunjucks.Environment(new Nunjucks.FileSystemLoader(this.templateDir));
@@ -104,7 +107,7 @@ class Generator {
     Object.keys(templateParams).forEach(key => {
       const self = this;
       Object.defineProperty(this.templateParams, key, {
-        get () {
+        get() {
           if (!self.templateConfig.parameters || !self.templateConfig.parameters[key]) {
             throw new Error(`Template parameter "${key}" has not been defined in the .tp-config.json file. Please make sure it's listed there before you use it in your template.`);
           }
@@ -143,7 +146,7 @@ class Generator {
 
     try {
       if (!this.forceWrite) await this.verifyTargetDir(this.targetDir);
-
+      await this.installTemplate(this.forceInstall);
       await this.registerFilters();
 
       if (this.entrypoint) {
@@ -708,9 +711,7 @@ class Generator {
    * @param  {String} dir Directory that needs to be tested for a given condition.
   */
   async verifyTargetDir(dir) {
-
     try {
-
       const isGitRepo = await git(dir).checkIsRepo();
 
       if (isGitRepo) {
@@ -721,8 +722,8 @@ class Generator {
         //Skipping verification if workDir inside repo is declared in .gitignore
         const workDir = path.relative(root, dir);
         if (workDir) {
-            const checkGitIgnore = await gitInfo.checkIgnore(workDir);
-            if (checkGitIgnore.length !== 0) return
+          const checkGitIgnore = await gitInfo.checkIgnore(workDir);
+          if (checkGitIgnore.length !== 0) return;
         }
 
         const gitStatus = await gitInfo.status();
@@ -743,7 +744,30 @@ class Generator {
       throw e;
     }
   }
+
+  /**
+   * Installs template dependencies.
+   *
+   * @param {Boolean} [force=false] Whether to force installation or not.
+   */
+  installTemplate(force = false) {
+    return new Promise(async (resolve, reject) => {
+      const nodeModulesDir = path.resolve(this.templateDir, 'node_modules');
+      const templatePackageFile = path.resolve(this.templateDir, 'package.json');
+      const templateDirExists = await exists(this.templateDir);
+      const templatePackageExists = await exists(templatePackageFile);
+      if (!templateDirExists) return reject(new Error(`Template "${this.templateName}" does not exist.`));
+      if (!templatePackageExists) return reject(new Error(`Directory "${this.templateName}" is not a valid template. Please provide a package.json file.`));
+      if (!force && await exists(nodeModulesDir)) return resolve();
+
+      npmi({
+        path: this.templateDir,
+      }, err => {
+        if (err) return reject(err);
+        resolve();
+      });
+    });
+  }
 }
 
 module.exports = Generator;
-module.exports.DEFAULT_TEMPLATES_DIR = DEFAULT_TEMPLATES_DIR;


### PR DESCRIPTION
We were installing the templates **only** when using the generator from the CLI and, therefore, it was breaking when using it as a library (e.g., in the playground).

This PR moves the installation process out of the `cli.js` file so it's available in both worlds.