### PR TITLE
Bump parser version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,14 @@
             "integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
             "dev": true
         },
+        "@openapi-contrib/openapi-schema-to-json-schema": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@openapi-contrib/openapi-schema-to-json-schema/-/openapi-schema-to-json-schema-3.0.0.tgz",
+            "integrity": "sha512-nM0Xn6lCwk1nt/fCWwiLBT1SbH4TlX099bWfz4h5lleW7yeu3SHGDP3knFBDHXPCLwywo5qqOOTVvjTTGf/7lA==",
+            "requires": {
+                "deep-equal": "^1.0.1"
+            }
+        },
         "a-sync-waterfall": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
@@ -125,16 +133,17 @@
             "integrity": "sha512-ROszLQMYzyp/CzPyLhuT/9NpJXxI7wrjv6yW8JpA/XVMEWCqyVXr9jajJhs9d/863+ispS+ptGhg1PC17AnIzQ=="
         },
         "asyncapi-parser": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/asyncapi-parser/-/asyncapi-parser-0.13.0.tgz",
-            "integrity": "sha512-UTj9W8tfm0VKA5xkUbc8OBSLMrFOO3bXW4Rdrx6WTIiZjK1Mve3qkwOOXI15d4oCkTMhWjmh6AvHd51/61eemA==",
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/asyncapi-parser/-/asyncapi-parser-0.14.0.tgz",
+            "integrity": "sha512-FR7Cx4DyBS3SP2hd1KJ1uFgMVbIES/cRIYq4teqUcogmd0La5mV6T21iLhCwPGWbWJUcR8KrvQyNOY9yNLPaEw==",
             "requires": {
+                "@openapi-contrib/openapi-schema-to-json-schema": "^3.0.0",
                 "ajv": "^6.10.1",
                 "asyncapi": "^2.6.1",
                 "js-yaml": "^3.13.1",
                 "json-schema-ref-parser": "^7.1.0",
                 "node-fetch": "^2.6.0",
-                "openapi-schema-to-json-schema": "^2.2.0",
+                "ramldt2jsonschema": "^1.1.0",
                 "tiny-merge-patch": "^0.1.2"
             }
         },
@@ -432,6 +441,11 @@
                 "strip-ansi": "^3.0.1",
                 "wrap-ansi": "^2.0.0"
             }
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
         },
         "code-point-at": {
             "version": "1.1.0",
@@ -1896,10 +1910,41 @@
                 "walk-back": "^4.0.0"
             }
         },
+        "json-schema-migrate": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-0.2.0.tgz",
+            "integrity": "sha1-ukelsAcvxyOWRg4b1gtE1SF4u8Y=",
+            "requires": {
+                "ajv": "^5.0.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "5.5.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+                    "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+                    "requires": {
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
+                    }
+                },
+                "fast-deep-equal": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+                    "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+                },
+                "json-schema-traverse": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+                    "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+                }
+            }
+        },
         "json-schema-ref-parser": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-7.1.3.tgz",
-            "integrity": "sha512-/Lmyl0PW27dOmCO03PI339+1gs4Z2PlqIyUgzIOtoRp08zkkMCB30TRbdppbPO7WWzZX0uT98HqkDiZSujkmbA==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-7.1.4.tgz",
+            "integrity": "sha512-AD7bvav0vak1/63w3jH8F7eHId/4E4EPdMAEZhGxtjktteUv9dnNB/cJy6nVnMyoTPBJnLwFK6tiQPSTeleCtQ==",
             "requires": {
                 "call-me-maybe": "^1.0.1",
                 "js-yaml": "^3.13.1",
@@ -2283,14 +2328,6 @@
             "resolved": "https://registry.npmjs.org/ono/-/ono-6.0.1.tgz",
             "integrity": "sha512-5rdYW/106kHqLeG22GE2MHKq+FlsxMERZev9DCzQX1zwkxnFwBivSn5i17a5O/rDmOJOdf4Wyt80UZljzx9+DA=="
         },
-        "openapi-schema-to-json-schema": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/openapi-schema-to-json-schema/-/openapi-schema-to-json-schema-2.2.0.tgz",
-            "integrity": "sha512-a8ouPAEl7U4MCpQBje+9cDIDSL6xCtWBPat/2i2Py42D5q9EPuB0IkXh4mNRc/cECjHjsgsEn2+GTeMvgE58+w==",
-            "requires": {
-                "deep-equal": "^1.0.1"
-            }
-        },
         "optimist": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -2346,6 +2383,24 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        },
+        "ramldt2jsonschema": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/ramldt2jsonschema/-/ramldt2jsonschema-1.1.0.tgz",
+            "integrity": "sha512-JPGVxcuJhFAg2FRqNpiPQXak2jbTLVLfZRGv0biv9Gat/Zhomo2iUdnr4cQ1UJrVdGWzgGRr2nxXZoWj3+Bzcw==",
+            "requires": {
+                "commander": "^4.0.0",
+                "js-yaml": "^3.13.1",
+                "json-schema-migrate": "^0.2.0",
+                "webapi-parser": "^0.4.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+                    "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
+                }
+            }
         },
         "readable-stream": {
             "version": "2.3.7",
@@ -3058,6 +3113,32 @@
             "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-4.0.0.tgz",
             "integrity": "sha512-kudCA8PXVQfrqv2mFTG72vDBRi8BKWxGgFLwPpzHcpZnSwZk93WMwUDVcLHWNsnm+Y0AC4Vb6MUNRgaHfyV2DQ==",
             "dev": true
+        },
+        "webapi-parser": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/webapi-parser/-/webapi-parser-0.4.1.tgz",
+            "integrity": "sha512-F5oSV1ttCnm4H8tLyAiT6l564A1B0KLkVSBJs3jpyalDPkMn/qvpB+jniEWLNmhOroLCunV07xCCUKJTf98f7Q==",
+            "requires": {
+                "ajv": "6.5.2"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+                    "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+                    "requires": {
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.1"
+                    }
+                },
+                "fast-deep-equal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+                }
+            }
         },
         "which": {
             "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "homepage": "https://github.com/asyncapi/generator",
     "dependencies": {
         "ajv": "^6.10.2",
-        "asyncapi-parser": "^0.13.0",
+        "asyncapi-parser": "^0.14.0",
         "commander": "^2.12.2",
         "filenamify": "^4.1.0",
         "fs.extra": "^1.3.2",


### PR DESCRIPTION
A few minutes ago, I [released a new version](https://github.com/asyncapi/parser-js/releases/tag/v0.14.0) of the JS parser. I'm updating it here too.