### PR TITLE
Register optional schema parsers

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -4,7 +4,10 @@ const util = require('util');
 const xfs = require('fs.extra');
 const walkSync = require('klaw-sync');
 const minimatch = require('minimatch');
-const { parse, AsyncAPIDocument } = require('asyncapi-parser');
+const parser = require('asyncapi-parser');
+const { parse, AsyncAPIDocument } = parser;
+const ramlDtParser = require('@asyncapi/raml-dt-schema-parser');
+const openapiSchemaParser = require('@asyncapi/openapi-schema-parser');
 const Nunjucks = require('nunjucks');
 const jmespath = require('jmespath');
 const Ajv = require('ajv');
@@ -13,6 +16,16 @@ const git = require('simple-git/promise');
 const npmi = require('npmi');
 
 const ajv = new Ajv({ allErrors: true });
+
+parser.registerSchemaParser([
+  'application/vnd.oai.openapi;version=3.0.0',
+  'application/vnd.oai.openapi+json;version=3.0.0',
+  'application/vnd.oai.openapi+yaml;version=3.0.0',
+], openapiSchemaParser);
+
+parser.registerSchemaParser([
+  'application/raml+yaml;version=1.0',
+], ramlDtParser);
 
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,17 +150,15 @@
             "integrity": "sha512-ROszLQMYzyp/CzPyLhuT/9NpJXxI7wrjv6yW8JpA/XVMEWCqyVXr9jajJhs9d/863+ispS+ptGhg1PC17AnIzQ=="
         },
         "asyncapi-parser": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/asyncapi-parser/-/asyncapi-parser-0.14.0.tgz",
-            "integrity": "sha512-FR7Cx4DyBS3SP2hd1KJ1uFgMVbIES/cRIYq4teqUcogmd0La5mV6T21iLhCwPGWbWJUcR8KrvQyNOY9yNLPaEw==",
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/asyncapi-parser/-/asyncapi-parser-0.15.0.tgz",
+            "integrity": "sha512-K8P8ELZGBCtETvsx3QyBPHhF1DOSeL40EDcdXW9DtgX9BCD2H5PTCBEhOvNZO78mBx+TXEPSY0QF7rBlzteicg==",
             "requires": {
-                "@openapi-contrib/openapi-schema-to-json-schema": "^3.0.0",
                 "ajv": "^6.10.1",
                 "asyncapi": "^2.6.1",
                 "js-yaml": "^3.13.1",
                 "json-schema-ref-parser": "^7.1.0",
                 "node-fetch": "^2.6.0",
-                "ramldt2jsonschema": "^1.1.0",
                 "tiny-merge-patch": "^0.1.2"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,23 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@asyncapi/openapi-schema-parser": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@asyncapi/openapi-schema-parser/-/openapi-schema-parser-1.0.0.tgz",
+            "integrity": "sha512-zvE58V0nBjpb4E+IC1i7mjUAUF0u58fGL9/c+/wAgT/AuCPO5C8kGzIJDYb04ck17isFlHZ4xg74c6qvKnLUKw==",
+            "requires": {
+                "@openapi-contrib/openapi-schema-to-json-schema": "^3.0.0"
+            }
+        },
+        "@asyncapi/raml-dt-schema-parser": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@asyncapi/raml-dt-schema-parser/-/raml-dt-schema-parser-1.0.4.tgz",
+            "integrity": "sha512-1JQxr2LISzMevMcrerHhnv973W/skWZ8MfAaG8NoUmuFUIvH8rDVD9yCppLikBUaygJ360JcDjIujn5+BufF9Q==",
+            "requires": {
+                "js-yaml": "^3.13.1",
+                "ramldt2jsonschema": "^1.1.0"
+            }
+        },
         "@babel/parser": {
             "version": "7.8.6",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "license": "Apache-2.0",
     "homepage": "https://github.com/asyncapi/generator",
     "dependencies": {
+        "@asyncapi/openapi-schema-parser": "^1.0.0",
+        "@asyncapi/raml-dt-schema-parser": "^1.0.4",
         "ajv": "^6.10.2",
         "asyncapi-parser": "^0.14.0",
         "commander": "^2.12.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@asyncapi/openapi-schema-parser": "^1.0.0",
         "@asyncapi/raml-dt-schema-parser": "^1.0.4",
         "ajv": "^6.10.2",
-        "asyncapi-parser": "^0.14.0",
+        "asyncapi-parser": "^0.15.0",
         "commander": "^2.12.2",
         "filenamify": "^4.1.0",
         "fs.extra": "^1.3.2",


### PR DESCRIPTION
After [extracting RAML and OpenAPI schema parsers](https://github.com/asyncapi/parser-js/pull/44) from the JS parser, we must register them explicitly now.