### PR TITLE
Updated nodejs version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.1-alpine3.11
+FROM node:12-alpine
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:13.8.0-alpine3.11
+FROM node:12.16.1-alpine3.11
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ See [authoring templates](docs/authoring.md) and the [list of templates recipes]
 
 ## Requirements
 
-* Node.js v12.16.1+
+* Node.js v12.16+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ See [authoring templates](docs/authoring.md) and the [list of templates recipes]
 
 ## Requirements
 
-* Node.js v8.5+
+* Node.js v12.16.1+
 
 ## Contributing
 


### PR DESCRIPTION
I changed the nodejs version in the Dockerfile to 12.16.1 (the current version 12 in Docker Hub) and I changed the version in the README requirements section to that version.

This allows template writers to use JavaScript E6 features such as classes.

Slack discussion: https://asyncapi.slack.com/archives/CQVJXFNQL/p1583949648004600?thread_ts=1583869811.002400&cid=CQVJXFNQL