### PR TITLE
feat: add info that package is public for releases to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "name": "Fran Mendez",
     "email": "fmvilas@gmail.com"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "license": "Apache-2.0",
   "homepage": "https://github.com/asyncapi/generator",
   "dependencies": {


### PR DESCRIPTION
**Description**

- add info that package is public for releases to npm. Otherwise the first release with new scoped package fails