### PR TITLE
fix: remove travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-node_js:
-  - "8"
-deploy:
-  provider: script
-  script: "cp .npmrc.template $HOME/.npmrc && npm install && npm test && npm publish"
-  on:
-    tags: true


### PR DESCRIPTION
**Description**

- This PR remove not needed travis configuration as releases go through GitHub Actions now

This PR must be merged as fix to release PATCH release. The reason is that previous release was affected due to active travis and after 0.34, the 0.33 was created as is now visible as latest, and cannot be removed.