### PR TITLE
docs: fix name of the package in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## Install
 
 ```bash
-npm install -g asyncapi-generator
+npm install -g @asyncapi/generator
 ```
 
 Or just use Docker:


### PR DESCRIPTION
**Description**

- fix name of the package in install instructions