### PR TITLE
fix: pick always the last element from the list of installed packages

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -31,7 +31,7 @@ utils.isFileSystemPath = (string) => {
  * @returns {Object}
  */
 utils.beautifyNpmiResult = (result) => {
-  const [nameWithVersion, pkgPath] = result[0];
+  const [nameWithVersion, pkgPath] = result[result.length-1];
   const nameWithVersionArray = nameWithVersion.split('@');
   const version = nameWithVersionArray[nameWithVersionArray.length - 1];
   const name = nameWithVersionArray.splice(0, nameWithVersionArray.length - 1).join('@');


### PR DESCRIPTION
**Description**

Generator could not work propery in CI-like environment where all had to be installed from scratch. The npmi package as a result of installation returns an array of installed package. When you try it out locally and it can use local cache and node_modules, it always returns 1 element and this is why picking first element of an array result worked. Thing is that in CI-like env where you have no modules and everything has to be downloaded from scratch, and additional dependencies installed, the result is more than 1 and main package is always the last element

```
> github-action-for-generator@0.0.2 start /Users/wookiee/Documents/sources/github-action-for-generator
> node lib/index.js

npm http fetch GET 200 https://registry.npmjs.org/@asyncapi%2fnodejs-template 1958ms
npm http fetch GET 200 https://registry.npmjs.org/@asyncapi/nodejs-template/-/nodejs-template-0.3.0.tgz 1029ms
npm http fetch GET 200 https://registry.npmjs.org/filenamify 93ms
npm http fetch GET 200 https://registry.npmjs.org/filenamify/-/filenamify-4.1.0.tgz 79ms
npm http fetch GET 200 https://registry.npmjs.org/lodash 437ms
npm http fetch GET 200 https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz 1084ms
npm http fetch GET 200 https://registry.npmjs.org/filename-reserved-regex 87ms
npm http fetch GET 200 https://registry.npmjs.org/strip-outer 107ms
npm http fetch GET 200 https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz 100ms
npm http fetch GET 200 https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz 91ms
npm http fetch GET 200 https://registry.npmjs.org/trim-repeated 267ms
npm http fetch GET 200 https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz 132ms
npm http fetch GET 200 https://registry.npmjs.org/escape-string-regexp 95ms
npm http fetch GET 200 https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz 102ms
npm WARN enoent ENOENT: no such file or directory, open '/Users/wookiee/Documents/sources/github-action-for-generator/fresh-nodemodule-dir/package.json'
npm WARN fresh-nodemodule-dir No description
npm WARN fresh-nodemodule-dir No repository field.
npm WARN fresh-nodemodule-dir No README data
npm WARN fresh-nodemodule-dir No license field.

+ @asyncapi/nodejs-template@0.3.0
added 7 packages from 4 contributors in 5.397s
[
  [
    'escape-string-regexp@1.0.5',
    'fresh-nodemodule-dir/node_modules/escape-string-regexp'
  ],
  [
    'filename-reserved-regex@2.0.0',
    'fresh-nodemodule-dir/node_modules/filename-reserved-regex'
  ],
  [
    'strip-outer@1.0.1',
    'fresh-nodemodule-dir/node_modules/strip-outer'
  ],
  [
    'trim-repeated@1.0.0',
    'fresh-nodemodule-dir/node_modules/trim-repeated'
  ],
  [
    'filenamify@4.1.0',
    'fresh-nodemodule-dir/node_modules/filenamify'
  ],
  [ 'lodash@4.17.15', 'fresh-nodemodule-dir/node_modules/lodash' ],
  [
    '@asyncapi/nodejs-template@0.3.0',
    'fresh-nodemodule-dir/node_modules/@asyncapi/nodejs-template'
  ]
]

```