### PR TITLE
fix: resolves "invalid bin entry for package" bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN apk --update add git && \
 # Install dependencies
 COPY package*.json ./
 
+# Installing latest version of npm 6. The one packaged with node:12.16.1-alpine3.11 has a bug.
+RUN npm install -g npm@6
 RUN npm install
 
 # Copy sources

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ asyncapi/generator [COMMAND HERE]
 docker run --rm -it \
 -v ${PWD}/test/docs/streetlights.yml:/app/asyncapi.yml \
 -v ${PWD}/output:/app/output \
-asyncapi/generator -o ./output asyncapi.yml markdown
+asyncapi/generator -o ./output asyncapi.yml @asyncapi/html-template --force-write
 ```
 
 ## Usage


### PR DESCRIPTION
**Description**
There is a bug with the npm version (6.13.4) packaged with the latest stable Node.js version (12.16.1). So far, the only information I could find is to update to the latest npm version. See this comment here: https://github.com/npm/cli/issues/613#issuecomment-578528618.

I also updated the Docker usage on the README.

**Related issue(s)**
Fixes #269 