### PR TITLE
feat: Move template files to their own directory

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -38,35 +38,20 @@ parser.registerSchemaParser([
   'application/raml+yaml;version=1.0',
 ], ramlDtParser);
 
-const FILTERS_DIRNAME = '.filters';
-const PARTIALS_DIRNAME = '.partials';
-const HOOKS_DIRNAME = '.hooks';
-const NODE_MODULES_DIRNAME = 'node_modules';
+const FILTERS_DIRNAME = 'filters';
+const HOOKS_DIRNAME = 'hooks';
 const CONFIG_FILENAME = '.tp-config.json';
 const PACKAGE_JSON_FILENAME = 'package.json';
-const PACKAGE_LOCK_FILENAME = 'package-lock.json';
 const ROOT_DIR = path.resolve(__dirname, '..');
 const DEFAULT_TEMPLATES_DIR = path.resolve(ROOT_DIR, 'node_modules');
 const TEMPLATE_CONTENT_DIRNAME = 'template';
 
 const shouldIgnoreFile = filePath =>
-  filePath.startsWith(`.git${path.sep}`)
-  || filePath.startsWith(`${PARTIALS_DIRNAME}${path.sep}`)
-  || filePath.startsWith(`${FILTERS_DIRNAME}${path.sep}`)
-  || filePath.startsWith(`${HOOKS_DIRNAME}${path.sep}`)
-  || path.basename(filePath) === CONFIG_FILENAME
-  || path.basename(filePath) === PACKAGE_JSON_FILENAME
-  || path.basename(filePath) === PACKAGE_LOCK_FILENAME;
+  filePath.startsWith(`.git${path.sep}`);
 
 const shouldIgnoreDir = dirPath =>
   dirPath === '.git'
-  || dirPath.startsWith(`.git${path.sep}`)
-  || dirPath === PARTIALS_DIRNAME
-  || dirPath.startsWith(`${PARTIALS_DIRNAME}${path.sep}`)
-  || dirPath === FILTERS_DIRNAME
-  || dirPath.startsWith(`${FILTERS_DIRNAME}${path.sep}`)
-  || dirPath === HOOKS_DIRNAME
-  || dirPath.startsWith(`${HOOKS_DIRNAME}${path.sep}`);
+  || dirPath.startsWith(`.git${path.sep}`);
 
 class Generator {
   /**
@@ -340,7 +325,7 @@ class Generator {
    */
   registerFilters() {
     return new Promise((resolve, reject) => {
-      this.helpersDir = path.resolve(this.templateContentDir, FILTERS_DIRNAME);
+      this.helpersDir = path.resolve(this.templateDir, FILTERS_DIRNAME);
       if (!fs.existsSync(this.helpersDir)) return resolve();
 
       const walker = xfs.walk(this.helpersDir, {
@@ -349,7 +334,7 @@ class Generator {
 
       walker.on('file', async (root, stats, next) => {
         try {
-          const filePath = path.resolve(this.templateContentDir, path.resolve(root, stats.name));
+          const filePath = path.resolve(this.templateDir, path.resolve(root, stats.name));
           // If it's a module constructor, inject dependencies to ensure consistent usage in remote templates in other projects or plain directories.
           const mod = require(filePath);
           if (typeof mod === 'function') {
@@ -730,7 +715,7 @@ class Generator {
   registerHooks() {
     try {
       this.hooks = {};
-      const hooksPath = path.resolve(this.templateContentDir, HOOKS_DIRNAME);
+      const hooksPath = path.resolve(this.templateDir, HOOKS_DIRNAME);
       if (!fs.existsSync(hooksPath)) return this.hooks;
 
       const files = walkSync(hooksPath, { nodir: true });

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -256,7 +256,7 @@ class Generator {
    *
    * @example
    * const Generator = require('asyncapi-generator');
-   * const content = await Generator.getTemplateFile('html', '.partials/content.html');
+   * const content = await Generator.getTemplateFile('html', 'partials/content.html');
    *
    * @static
    * @param {String} templateName  Name of the template to generate.
@@ -636,7 +636,7 @@ class Generator {
    * @private
    */
   configNunjucks() {
-    this.nunjucks = new Nunjucks.Environment(new Nunjucks.FileSystemLoader(this.templateContentDir));
+    this.nunjucks = new Nunjucks.Environment(new Nunjucks.FileSystemLoader(this.templateDir));
     this.nunjucks.addFilter('log', console.log);
   }
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -47,6 +47,7 @@ const PACKAGE_JSON_FILENAME = 'package.json';
 const PACKAGE_LOCK_FILENAME = 'package-lock.json';
 const ROOT_DIR = path.resolve(__dirname, '..');
 const DEFAULT_TEMPLATES_DIR = path.resolve(ROOT_DIR, 'node_modules');
+const TEMPLATE_CONTENT_DIRNAME = 'template';
 
 const shouldIgnoreFile = filePath =>
   filePath.startsWith(`.git${path.sep}`)
@@ -156,13 +157,14 @@ class Generator {
       const { name: templatePkgName, path: templatePkgPath } = await this.installTemplate(this.install);
       this.templateDir = templatePkgPath;
       this.templateName = templatePkgName;
+      this.templateContentDir = path.resolve(this.templateDir, TEMPLATE_CONTENT_DIRNAME);
       this.configNunjucks();
       await this.loadTemplateConfig();
       this.registerHooks();
       await this.registerFilters();
 
       if (this.entrypoint) {
-        const entrypointPath = path.resolve(this.templateDir, this.entrypoint);
+        const entrypointPath = path.resolve(this.templateContentDir, this.entrypoint);
         if (!(await exists(entrypointPath))) throw new Error(`Template entrypoint "${entrypointPath}" couldn't be found.`);
         if (this.output === 'fs') {
           await this.generateFile(asyncapiDocument, path.basename(entrypointPath), path.dirname(entrypointPath));
@@ -341,7 +343,7 @@ class Generator {
    */
   registerFilters() {
     return new Promise((resolve, reject) => {
-      this.helpersDir = path.resolve(this.templateDir, FILTERS_DIRNAME);
+      this.helpersDir = path.resolve(this.templateContentDir, FILTERS_DIRNAME);
       if (!fs.existsSync(this.helpersDir)) return resolve();
 
       const walker = xfs.walk(this.helpersDir, {
@@ -350,7 +352,7 @@ class Generator {
 
       walker.on('file', async (root, stats, next) => {
         try {
-          const filePath = path.resolve(this.templateDir, path.resolve(root, stats.name));
+          const filePath = path.resolve(this.templateContentDir, path.resolve(root, stats.name));
           // If it's a module constructor, inject dependencies to ensure consistent usage in remote templates in other projects or plain directories.
           const mod = require(filePath);
           if (typeof mod === 'function') {
@@ -419,7 +421,7 @@ class Generator {
     return new Promise((resolve, reject) => {
       xfs.mkdirpSync(this.targetDir);
 
-      const walker = xfs.walk(this.templateDir, {
+      const walker = xfs.walk(this.templateContentDir, {
         followLinks: false
       });
 
@@ -431,7 +433,7 @@ class Generator {
             if (Object.prototype.hasOwnProperty.call(fileNamesForSeparation, prop)) {
               if (stats.name.includes(`$$${prop}$$`)) {
                 await this.generateSeparateFiles(asyncapiDocument, fileNamesForSeparation[prop], prop, stats.name, root);
-                const templateFilePath = path.relative(this.templateDir, path.resolve(root, stats.name));
+                const templateFilePath = path.relative(this.templateContentDir, path.resolve(root, stats.name));
                 fs.unlink(path.resolve(this.targetDir, templateFilePath), next);
                 wasSeparated = true;
                 //The filename can only contain 1 specifier (message, scheme etc)
@@ -451,7 +453,7 @@ class Generator {
 
       walker.on('directory', async (root, stats, next) => {
         try {
-          const relativeDir = path.relative(this.templateDir, path.resolve(root, stats.name));
+          const relativeDir = path.relative(this.templateContentDir, path.resolve(root, stats.name));
           const dirPath = path.resolve(this.targetDir, relativeDir);
           if (!shouldIgnoreDir(relativeDir)) {
             xfs.mkdirpSync(dirPath);
@@ -508,7 +510,7 @@ class Generator {
    */
   async generateSeparateFile(asyncapiDocument, name, component, template, fileName, baseDir) {
     try {
-      const relativeBaseDir = path.relative(this.templateDir, baseDir);
+      const relativeBaseDir = path.relative(this.templateContentDir, baseDir);
       const newFileName = fileName.replace(`\$\$${template}\$\$`, filenamify(name, { replacement: '-', maxLength: 255 }));
       const targetFile = path.resolve(this.targetDir, relativeBaseDir, newFileName);
       const relativeTargetFile = path.relative(this.targetDir, targetFile);
@@ -540,7 +542,7 @@ class Generator {
   async generateFile(asyncapiDocument, fileName, baseDir) {
     try {
       const sourceFile = path.resolve(baseDir, fileName);
-      const relativeSourceFile = path.relative(this.templateDir, sourceFile);
+      const relativeSourceFile = path.relative(this.templateContentDir, sourceFile);
       const targetFile = path.resolve(this.targetDir, relativeSourceFile);
       const relativeTargetFile = path.relative(this.targetDir, targetFile);
 
@@ -652,7 +654,7 @@ class Generator {
    * @private
    */
   configNunjucks() {
-    this.nunjucks = new Nunjucks.Environment(new Nunjucks.FileSystemLoader(this.templateDir));
+    this.nunjucks = new Nunjucks.Environment(new Nunjucks.FileSystemLoader(this.templateContentDir));
     this.nunjucks.addFilter('log', console.log);
   }
 
@@ -731,7 +733,7 @@ class Generator {
   registerHooks() {
     try {
       this.hooks = {};
-      const hooksPath = path.resolve(this.templateDir, HOOKS_DIRNAME);
+      const hooksPath = path.resolve(this.templateContentDir, HOOKS_DIRNAME);
       if (!fs.existsSync(hooksPath)) return this.hooks;
 
       const files = walkSync(hooksPath, { nodir: true });

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -56,8 +56,7 @@ const shouldIgnoreFile = filePath =>
   || filePath.startsWith(`${HOOKS_DIRNAME}${path.sep}`)
   || path.basename(filePath) === CONFIG_FILENAME
   || path.basename(filePath) === PACKAGE_JSON_FILENAME
-  || path.basename(filePath) === PACKAGE_LOCK_FILENAME
-  || filePath.startsWith(`${NODE_MODULES_DIRNAME}${path.sep}`);
+  || path.basename(filePath) === PACKAGE_LOCK_FILENAME;
 
 const shouldIgnoreDir = dirPath =>
   dirPath === '.git'
@@ -67,9 +66,7 @@ const shouldIgnoreDir = dirPath =>
   || dirPath === FILTERS_DIRNAME
   || dirPath.startsWith(`${FILTERS_DIRNAME}${path.sep}`)
   || dirPath === HOOKS_DIRNAME
-  || dirPath.startsWith(`${HOOKS_DIRNAME}${path.sep}`)
-  || dirPath === NODE_MODULES_DIRNAME
-  || dirPath.startsWith(`${NODE_MODULES_DIRNAME}${path.sep}`);
+  || dirPath.startsWith(`${HOOKS_DIRNAME}${path.sep}`);
 
 class Generator {
   /**


### PR DESCRIPTION
**Description**
This makes the generator assume that from now the template files are located inside a folder called `template`. This way, the template files that should end up in the output directory are not mixed with the package details, i.e. package.json, package-lock.json, node_modules, .git, README.md (the usage README not the resulting one), .gitignore, etc.

**Related issue(s)**
Fixes #230

* See https://github.com/asyncapi/nodejs-template/pull/5

**To do**
Create pull requests on every template.