### PR TITLE
fix: install missing mkdirp dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2502,6 +2502,13 @@
                 "mkdirp": "0.3.x",
                 "ncp": "~0.4.2",
                 "rimraf": "~2.2.0"
+            },
+            "dependencies": {
+                "mkdirp": {
+                    "version": "0.3.5",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+                    "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
+                }
             }
         },
         "fs-then-native": {
@@ -2518,6 +2525,13 @@
                 "fs-extra": "~0.6.1",
                 "mkdirp": "~0.3.5",
                 "walk": "^2.3.9"
+            },
+            "dependencies": {
+                "mkdirp": {
+                    "version": "0.3.5",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+                    "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
+                }
             }
         },
         "fs.realpath": {
@@ -4457,9 +4471,9 @@
             }
         },
         "mkdirp": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-            "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
+            "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g=="
         },
         "mkdirp2": {
             "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   "homepage": "https://github.com/asyncapi/generator",
   "dependencies": {
     "@asyncapi/openapi-schema-parser": "^1.0.0",
+    "@asyncapi/parser": "^0.16.0",
     "@asyncapi/raml-dt-schema-parser": "^1.0.4",
     "ajv": "^6.10.2",
-    "@asyncapi/parser": "^0.16.0",
     "commander": "^2.12.2",
     "filenamify": "^4.1.0",
     "fs.extra": "^1.3.2",
@@ -50,6 +50,7 @@
     "klaw-sync": "^6.0.0",
     "markdown-it": "^8.4.1",
     "minimatch": "^3.0.4",
+    "mkdirp": "^1.0.3",
     "npmi": "^4.0.0",
     "nunjucks": "^3.2.0",
     "simple-git": "^1.131.0"


### PR DESCRIPTION
**Description**
Adds a missing dependency to package.json: mkdirp.

**Related issue(s)**
Fixes #262 