### PR TITLE
fix: mkdirp misuse

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
+const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const program = require('commander');
 const packageInfo = require('./package.json');
-const mkdirp = require('mkdirp');
 const Generator = require('./lib/generator');
 const Watcher = require('./lib/watcher');
 const { isLocalTemplate } = require('./lib/utils');
@@ -67,7 +67,7 @@ if (!asyncapiFile) {
   program.help(); // This exits the process
 }
 
-mkdirp(program.output, async err => {
+fs.mkdir(program.output, { recursive: true }, async err => {
   if (err) return showErrorAndExit(err);
   try {
     await generate(program.output);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4470,11 +4470,6 @@
                 }
             }
         },
-        "mkdirp": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
-            "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g=="
-        },
         "mkdirp2": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "klaw-sync": "^6.0.0",
     "markdown-it": "^8.4.1",
     "minimatch": "^3.0.4",
-    "mkdirp": "^1.0.3",
     "npmi": "^4.0.0",
     "nunjucks": "^3.2.0",
     "simple-git": "^1.131.0"


### PR DESCRIPTION
**Description**
Fixes a bug with `mkdirp` that was introduced in the last release. I took the opportunity to remove the dependency because it's not needed anymore now that we're on Node.js 12.

**Related issue(s)**
See #123 