### PR TITLE
fix: add strict engines restriction when installing generator and update readme

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@
 
 > :warning: This package doesn't support AsyncAPI 1.x anymore. We recommend to upgrade to the latest AsyncAPI version using the [AsyncAPI converter](https://github.com/asyncapi/converter). If you need to convert documents on the fly, you may use the [Node.js](https://github.com/asyncapi/converter) or [Go](https://github.com/asyncapi/converter-go) converters.
 
+## Requirements
+
+* Node.js v12.16+
+* npm v6.13.7+
+
+Install both packages using [official installer](https://nodejs.org/en/download/). After installation make sure both packages have proper version by running `node -v` and `npm -v`. To upgrade invalid npm version run `npm install npm@latest -g`
+
 ## Install
 
 ```bash
@@ -105,10 +112,6 @@ See [API documentation](docs/api.md).
 ### Authoring templates
 
 See [authoring templates](docs/authoring.md) and the [list of templates recipes](docs/templates-recipes.md).
-
-## Requirements
-
-* Node.js v12.16+
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "asyncapi-generator": "./cli.js",
     "ag": "./cli.js"
   },
+  "engines": {
+    "node": ">=12.16",
+    "npm": ">=6.13.7"
+  },
   "scripts": {
     "docs": "jsdoc2md lib/generator.js > docs/api.md",
     "release": "semantic-release",


### PR DESCRIPTION
**Description**

- Update readme with information about requirements
- Add `engines` to package.json that will result in blocking installation if the engine requirements are not fulfilled:
```bash
Lukaszs-MBP:generator wookiee$ npm install
npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for @asyncapi/generator@0.36.3: wanted: {"node":">=12.16","npm":">=6.13.7"} (current: {"node":"11.15.0","npm":"6.7.0"})
npm ERR! notsup Not compatible with your version of node/npm: @asyncapi/generator@0.36.3
npm ERR! notsup Not compatible with your version of node/npm: @asyncapi/generator@0.36.3
npm ERR! notsup Required: {"node":">=12.16","npm":">=6.13.7"}
npm ERR! notsup Actual:   {"npm":"6.7.0","node":"11.15.0"}

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/wookiee/.npm/_logs/2020-04-09T11_46_28_068Z-debug.log
Lukaszs-MBP:generator wookiee$ nvm use v12.16.1
Now using node v12.16.1 (npm v6.14.4)
Lukaszs-MBP:generator wookiee$ npm install
npm WARN semantic-release-slack-bot@1.5.0 requires a peer of semantic-release@>=11.0.0 <16.0.0 but none is installed. You must install peer dependencies yourself.

audited 28677 packages in 4.527s

51 packages are looking for funding
  run `npm fund` for details

found 231 low severity vulnerabilities
  run `npm audit fix` to fix them, or `npm audit` for details
```

fixes #287 