### PR TITLE
feat: add templatesDir option to getTemplateFile

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -11,7 +11,7 @@
         * [.generateFromFile(asyncapiFile)](#Generator+generateFromFile) ⇒ <code>Promise</code>
         * [.installTemplate([force])](#Generator+installTemplate)
     * _static_
-        * [.getTemplateFile(templateName, filePath, options)](#Generator.getTemplateFile) ⇒ <code>Promise</code>
+        * [.getTemplateFile(templateName, filePath, [templatesDir])](#Generator.getTemplateFile) ⇒ <code>Promise</code>
 
 <a name="new_Generator_new"></a>
 
@@ -30,7 +30,7 @@ Instantiates a new Generator object.
 | [options.disabledHooks] | <code>Array.&lt;String&gt;</code> |  | List of hooks to disable. |
 | [options.output] | <code>String</code> | <code>&#x27;fs&#x27;</code> | Type of output. Can be either 'fs' (default) or 'string'. Only available when entrypoint is set. |
 | [options.forceWrite] | <code>Boolean</code> | <code>false</code> | Force writing of the generated files to given directory even if it is a git repo with unstaged files or not empty dir. Default is set to false. |
-| [options.forceInstall] | <code>Boolean</code> | <code>false</code> | Force the installation of the template and its dependencies. |
+| [options.install] | <code>Boolean</code> | <code>false</code> | Install the template and its dependencies, even when the template has already been installed. |
 
 **Example**  
 ```js
@@ -162,19 +162,24 @@ Downloads and installs a template and its dependencies.
 
 <a name="Generator.getTemplateFile"></a>
 
-### Generator.getTemplateFile(templateName, filePath, options) ⇒ <code>Promise</code>
+### Generator.getTemplateFile(templateName, filePath, [templatesDir]) ⇒ <code>Promise</code>
 Returns the content of a given template file.
 
 **Kind**: static method of [<code>Generator</code>](#Generator)  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| templateName | <code>String</code> | Name of the template to generate. |
-| filePath | <code>String</code> | Path to the file to render. Relative to the template directory. |
-| options | <code>Object</code> |  |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| templateName | <code>String</code> |  | Name of the template to generate. |
+| filePath | <code>String</code> |  | Path to the file to render. Relative to the template directory. |
+| [templatesDir] | <code>String</code> | <code>DEFAULT_TEMPLATES_DIR</code> | Path to the directory where the templates are installed. |
 
 **Example**  
 ```js
 const Generator = require('asyncapi-generator');
-const content = await Generator.getTemplateFile('html', '.partials/content.html');
+const content = await Generator.getTemplateFile('@asyncapi/html-template', 'partials/content.html');
+```
+**Example** *(Using a custom &#x60;templatesDir&#x60;)*  
+```js
+const Generator = require('asyncapi-generator');
+const content = await Generator.getTemplateFile('@asyncapi/html-template', 'partials/content.html', '~/my-templates');
 ```

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -256,16 +256,20 @@ class Generator {
    *
    * @example
    * const Generator = require('asyncapi-generator');
-   * const content = await Generator.getTemplateFile('html', 'partials/content.html');
+   * const content = await Generator.getTemplateFile('@asyncapi/html-template', 'partials/content.html');
+   *
+   * @example <caption>Using a custom `templatesDir`</caption>
+   * const Generator = require('asyncapi-generator');
+   * const content = await Generator.getTemplateFile('@asyncapi/html-template', 'partials/content.html', '~/my-templates');
    *
    * @static
    * @param {String} templateName  Name of the template to generate.
    * @param {String} filePath      Path to the file to render. Relative to the template directory.
-   * @param {Object} options
+   * @param {String} [templatesDir=DEFAULT_TEMPLATES_DIR] Path to the directory where the templates are installed.
    * @return {Promise}
    */
-  static async getTemplateFile(templateName, filePath) {
-    return await readFile(path.resolve(DEFAULT_TEMPLATES_DIR, templateName, filePath), 'utf8');
+  static async getTemplateFile(templateName, filePath, templatesDir = DEFAULT_TEMPLATES_DIR) {
+    return await readFile(path.resolve(templatesDir, templateName, filePath), 'utf8');
   }
 
   /**


### PR DESCRIPTION
### Description
If you're using the generator as a library, your application's `node_modules` will be different than the default `DEFAULT_TEMPLATES_DIR`. For instance:

```
my-app/node_modules/@asyncapi/generator/...
my-app/node_modules/@asyncapi/html-template/...
```

If I use the generator as a library in this scenario, `DEFAULT_TEMPLATES_DIR` would be `my-app/node_modules/@asyncapi/generator/` and using the `@asyncapi/html-template` would result in the template being installed as a sibling of the generator, like above. Therefore, using `getTemplateFile('@asyncapi/html', 'partials/content.html')` will result in an attempt to access the file `my-app/node_modules/@asyncapi/generator/node_modules/@asyncapi/html-template/partials/content.html`, which is incorrect.

This PR lets you change the `DEFAULT_TEMPLATES_DIR` only for the `getTemplateFile` method.