### PR TITLE
feat: support filters from external library

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,0 +1,3 @@
+{
+    "FILTERS_DIRNAME": "filters"
+}

--- a/config/default.json
+++ b/config/default.json
@@ -1,3 +1,0 @@
-{
-    "FILTERS_DIRNAME": "filters"
-}

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -64,7 +64,7 @@ Schema name is 'people' and properties are:
 ```
 ## Filters
 
-A filter is a helper function that you can create to perform complex tasks. They are JavaScript files that register one or many [Nunjuck filters](https://mozilla.github.io/nunjucks/api.html#custom-filters). The generator parses all the files in the `.filters` directory. Functions exported from these files are registered as filters.
+A filter is a helper function that you can create to perform complex tasks. They are JavaScript files that register one or many [Nunjuck filters](https://mozilla.github.io/nunjucks/api.html#custom-filters). The generator parses all the files in the `filters` directory. Functions exported from these files are registered as filters.
 
 You can use the filter function in your template as in the following example:
 
@@ -72,7 +72,7 @@ You can use the filter function in your template as in the following example:
 const {{ channelName | camelCase }} = '{{ channelName }}';
 ```
 
-In case you have more than one template and want to reuse filters, you can put them in a single library. You can configure such a library in the template configuration under `filter` property. You can also use the official AsyncAPI [filters library](https://github.com/asyncapi/generator-filters). To learn how to add such filters to configuration [read more about the configuration file](#configuration-file).
+In case you have more than one template and want to reuse filters, you can put them in a single library. You can configure such a library in the template configuration under `filters` property. You can also use the official AsyncAPI [filters library](https://github.com/asyncapi/generator-filters). To learn how to add such filters to configuration [read more about the configuration file](#configuration-file).
 
 ## Hooks
 

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -8,7 +8,7 @@ The AsyncAPI generator has been built with extensibility in mind. The package us
 1. The template can have own dependencies. Just create `package.json` for the template. The generator makes sure to trigger the installation of dependencies.
 1. Templates may contain multiple files. Unless stated otherwise, all files will be rendered.
 1. The template engine is [Nunjucks](https://mozilla.github.io/nunjucks).
-1. Templates may contain `filters` or helper functions. They must be stored in the `.filters` directory under the template directory. [Read more about filters](#filters).
+1. Templates may contain [Nunjucks filters or helper functions](https://mozilla.github.io/nunjucks/templating.html#builtin-filters). [Read more about filters](#filters).
 1. Templates may contain `hooks` that are functions invoked after the generation. They must be stored in the `.hooks` directory under the template directory. [Read more about hooks](#hooks).
 1. Templates may contain `partials` (reusable chunks). They must be stored in the `.partials` directory under the template directory. [Read more about partials](#partials).
 1. Templates may have a configuration file. It must be stored in the template directory and its name must be `.tp-config.json`. [Read more about the configuration file](#configuration-file).
@@ -64,40 +64,15 @@ Schema name is 'people' and properties are:
 ```
 ## Filters
 
-A filter is a helper function that you can create to perform complex tasks. They are JavaScript files that register one or many [Nunjuck filters](https://mozilla.github.io/nunjucks/api.html#custom-filters). The generator will parse all the files in the `.filters` directory.
+A filter is a helper function that you can create to perform complex tasks. They are JavaScript files that register one or many [Nunjuck filters](https://mozilla.github.io/nunjucks/api.html#custom-filters). The generator parses all the files in the `.filters` directory. Functions exported from these files are registered as filters.
 
-Each file must export a function that will receive the following parameters:
-
-* `Nunjucks`: a reference to the [Nunjucks](https://mozilla.github.io/nunjucks) template engine used internally by the generator.
-* `_`: a convenient [Lodash](https://www.lodash.com) reference.
-* `Markdown`: a reference to the [markdown-it](https://github.com/markdown-it/markdown-it) package. Use it to convert Markdown to HTML.
-* `OpenAPISampler`: a reference to the [openapi-sampler](https://github.com/Redocly/openapi-sampler) package. It generates examples from OpenAPI/AsyncAPI schemas.
-
-The common structure for one of these files is the following:
-
-```js
-module.exports = ({ Nunjucks, _, Markdown, OpenAPISampler }) => {
-  Nunjucks.addFilter('yourFilterName', (yourFilterParams) => {
-    return 'doSomething';
-  });
-};
-```
-
-An example filter called `camelCase` which uses the Lodash function `_.camelCase(String)` to convert a template string as camel case:
-
-```js
-module.exports = ({ Nunjucks, _, Markdown, OpenAPISampler }) => {
-  Nunjucks.addFilter('camelCase', (str) => {
-    return _.camelCase(str);
-  });
-};
-```
-
-And then you can use the filter in your template as follows:
+You can use the filter function in your template as in the following example:
 
 ```js
 const {{ channelName | camelCase }} = '{{ channelName }}';
 ```
+
+In case you have more than one template and want to reuse filters, you can put them in a single library. You can configure such a library in the template configuration under `filter` property. You can also use the official AsyncAPI [filters library](https://github.com/asyncapi/generator-filters). To learn how to add such filters to configuration [read more about the configuration file](#configuration-file).
 
 ## Hooks
 
@@ -160,6 +135,7 @@ The `.tp-config.json` file contains a JSON object that may have the following in
 |`conditionalFiles[filePath].validation`| Object | The `validation` is a JSON Schema Draft 07 object. This JSON Schema definition will be applied to the JSON value resulting from the `subject` query. If validation doesn't have errors, the condition is met, and therefore the given file will be rendered. Otherwise, the file is ignored.
 |`nonRenderableFiles`| [String] | A list of file paths or [globs](https://en.wikipedia.org/wiki/Glob_(programming)) that must be copied "as-is" to the target directory, i.e., without performing any rendering process. This is useful when you want to copy binary files.
 |`generator`| [String] | A string representing the Generator version-range the template is compatible with. This value must follow the [semver](https://docs.npmjs.com/misc/semver) syntax. E.g., `>=1.0.0`, `>=1.0.0 <=2.0.0`, `~1.0.0`, `^1.0.0`, `1.0.0`, etc.
+|`filters`| [String] | A list of modules containing functions that can be uses as Nunjucks filters. In case of external modules, remember they need to be added as a dependency in `package.json` of your template.
 
 ### Example
 
@@ -190,7 +166,10 @@ The `.tp-config.json` file contains a JSON object that may have the following in
     "src/api/middlewares/*.*",
     "lib/lib/config.js"
   ],
-  "generator": "<2.0.0"
+  "generator": "<2.0.0",
+  "filters": [
+    "@asyncapi/generator-filters"
+  ]
 }
 ```
 

--- a/lib/filtersRegistry.js
+++ b/lib/filtersRegistry.js
@@ -56,7 +56,7 @@ function registerLocalFilters(nunjucks, templateDir, filtersDir) {
 }
 
 /**
-* Registers the additinally configured filters.
+* Registers the additionally configured filters.
 * @private
 * @param {Object} nunjucks Nunjucks environment.
 * @param {String} templateDir Directory where template is located.

--- a/lib/filtersRegistry.js
+++ b/lib/filtersRegistry.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const xfs = require('fs.extra');
+const { isLocalTemplate } = require('./utils');
 
 /**
  * Registers all template filters.
@@ -12,7 +13,7 @@ const xfs = require('fs.extra');
  */
 module.exports.registerFilters = async (nunjucks, templateConfig, templateDir, filtersDir) => {
   await registerLocalFilters(nunjucks, templateDir, filtersDir);
-  registerConfigFilters(nunjucks, templateConfig);
+  await registerConfigFilters(nunjucks, templateDir, templateConfig);
 };
 
 /**
@@ -58,14 +59,18 @@ function registerLocalFilters(nunjucks, templateDir, filtersDir) {
 * Registers the additinally configured filters.
 * @private
 * @param {Object} nunjucks Nunjucks environment.
+* @param {String} templateDir Directory where template is located.
 * @param {Object} templateConfig Template configuration.
 */
-function registerConfigFilters(nunjucks, templateConfig) {
-  const confFilters = templateConfig.filters;
+async function registerConfigFilters(nunjucks, templateDir, templateConfig) {
+  const confFilters = templateConfig.filters; 
+  const DEFAULT_MODULES_DIR = 'node_modules';
   if (!Array.isArray(confFilters)) return;
-    
-  confFilters.forEach(el => {
-    const mod = require(el);
+
+  confFilters.forEach(async el => {
+    const modulePath = await isLocalTemplate(templateDir) ? path.resolve(templateDir, DEFAULT_MODULES_DIR, el) : el;
+    const mod = require(modulePath);
+
     addFilters(nunjucks, mod);
   });
 }

--- a/lib/filtersRegistry.js
+++ b/lib/filtersRegistry.js
@@ -1,0 +1,78 @@
+const config = require('config');
+const path = require('path');
+const fs = require('fs');
+const xfs = require('fs.extra');
+
+module.exports.registerFilters = async (nunjucks, templateConfig, templateDir) => {
+  registerConfigFilters(nunjucks, templateConfig);
+  await registerLocalFilters(nunjucks, templateDir);
+};
+/**
+   * Registers the template filters.
+   * @private
+   * @param {Object} nunjucks Nunjucks environment.
+   * @param {String} templateDir Directory where template is located.
+   */
+function registerLocalFilters(nunjucks, templateDir) {
+  return new Promise((resolve, reject) => {
+    const filtersDir = config.get('FILTERS_DIRNAME');
+    const localFilters = path.resolve(templateDir, filtersDir);
+
+    if (!fs.existsSync(localFilters)) return resolve();
+
+    const walker = xfs.walk(localFilters, {
+      followLinks: false
+    });
+
+    walker.on('file', async (root, stats, next) => {
+      try {
+        const filePath = path.resolve(templateDir, path.resolve(root, stats.name));
+        // If it's a module constructor, inject dependencies to ensure consistent usage in remote templates in other projects or plain directories.
+        const mod = require(filePath);
+        addFilters(nunjucks, mod);
+        next();
+      } catch (e) {
+        reject(e);
+      }
+    });
+
+    walker.on('errors', (root, nodeStatsArray) => {
+      reject(nodeStatsArray);
+    });
+
+    walker.on('end', async () => {
+      resolve();
+    });
+  });
+}
+
+/**
+* Registers the additinally configured filters.
+* @private
+* @param {Object} nunjucks Nunjucks environment.
+* @param {Object} templateConfig Template configuration.
+*/
+function registerConfigFilters(nunjucks, templateConfig) {
+  const confFilters = templateConfig.filters;
+  if (!Array.isArray(confFilters)) return;
+    
+  confFilters.forEach(el => {
+    const mod = require(el);
+    addFilters(nunjucks, mod);
+  });
+}
+
+/**
+ * Add filter functions to Nunjucks environment. Only owned functions from the module are added.
+ * @private
+ * @param {Object} nunjucks Nunjucks environment.
+ * @param {Object} filters Module with functions.
+ */
+function addFilters(nunjucks, filters) {
+  Object.getOwnPropertyNames(filters).forEach((key) => {
+    const value = filters[key];
+    if (!typeof value === 'function') return;
+
+    nunjucks.addFilter(key, value);
+  });      
+};

--- a/lib/filtersRegistry.js
+++ b/lib/filtersRegistry.js
@@ -1,21 +1,29 @@
-const config = require('config');
 const path = require('path');
 const fs = require('fs');
 const xfs = require('fs.extra');
 
-module.exports.registerFilters = async (nunjucks, templateConfig, templateDir) => {
-  registerConfigFilters(nunjucks, templateConfig);
-  await registerLocalFilters(nunjucks, templateDir);
-};
 /**
- * Registers the template filters.
+ * Registers all template filters.
+ * @private
+ * @param {Object} nunjucks Nunjucks environment.
+ * @param {Object} templateConfig Template configuration.
+ * @param {String} templateDir Directory where template is located.
+ * @param {String} filtersDir Directory where local filters are located.
+ */
+module.exports.registerFilters = async (nunjucks, templateConfig, templateDir, filtersDir) => {
+  await registerLocalFilters(nunjucks, templateDir, filtersDir);
+  registerConfigFilters(nunjucks, templateConfig);
+};
+
+/**
+ * Registers the local template filters.
  * @private
  * @param {Object} nunjucks Nunjucks environment.
  * @param {String} templateDir Directory where template is located.
+ * @param {String} filtersDir Directory where local filters are located.
  */
-function registerLocalFilters(nunjucks, templateDir) {
+function registerLocalFilters(nunjucks, templateDir, filtersDir) {
   return new Promise((resolve, reject) => {
-    const filtersDir = config.get('FILTERS_DIRNAME');
     const localFilters = path.resolve(templateDir, filtersDir);
 
     if (!fs.existsSync(localFilters)) return resolve();

--- a/lib/filtersRegistry.js
+++ b/lib/filtersRegistry.js
@@ -71,8 +71,8 @@ function registerConfigFilters(nunjucks, templateConfig) {
 function addFilters(nunjucks, filters) {
   Object.getOwnPropertyNames(filters).forEach((key) => {
     const value = filters[key];
-    if (!typeof value === 'function') return;
+    if (!value instanceof Function) return;
 
     nunjucks.addFilter(key, value);
   });      
-};
+}

--- a/lib/filtersRegistry.js
+++ b/lib/filtersRegistry.js
@@ -71,7 +71,7 @@ function registerConfigFilters(nunjucks, templateConfig) {
 function addFilters(nunjucks, filters) {
   Object.getOwnPropertyNames(filters).forEach((key) => {
     const value = filters[key];
-    if (!value instanceof Function) return;
+    if (!(value instanceof Function)) return;
 
     nunjucks.addFilter(key, value);
   });      

--- a/lib/filtersRegistry.js
+++ b/lib/filtersRegistry.js
@@ -8,11 +8,11 @@ module.exports.registerFilters = async (nunjucks, templateConfig, templateDir) =
   await registerLocalFilters(nunjucks, templateDir);
 };
 /**
-   * Registers the template filters.
-   * @private
-   * @param {Object} nunjucks Nunjucks environment.
-   * @param {String} templateDir Directory where template is located.
-   */
+ * Registers the template filters.
+ * @private
+ * @param {Object} nunjucks Nunjucks environment.
+ * @param {String} templateDir Directory where template is located.
+ */
 function registerLocalFilters(nunjucks, templateDir) {
   return new Promise((resolve, reject) => {
     const filtersDir = config.get('FILTERS_DIRNAME');

--- a/lib/filtersRegistry.js
+++ b/lib/filtersRegistry.js
@@ -5,7 +5,6 @@ const { isLocalTemplate } = require('./utils');
 
 /**
  * Registers all template filters.
- * @private
  * @param {Object} nunjucks Nunjucks environment.
  * @param {Object} templateConfig Template configuration.
  * @param {String} templateDir Directory where template is located.

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -25,8 +25,9 @@ const {
   readDir,
   writeFile,
   copyFile,
-  exists,
+  exists
 } = require('./utils');
+const { registerFilters } = require('./filtersRegistry');
 
 const ajv = new Ajv({ allErrors: true });
 
@@ -40,7 +41,6 @@ parser.registerSchemaParser([
   'application/raml+yaml;version=1.0',
 ], ramlDtParser);
 
-const FILTERS_DIRNAME = 'filters';
 const HOOKS_DIRNAME = 'hooks';
 const CONFIG_FILENAME = '.tp-config.json';
 const PACKAGE_JSON_FILENAME = 'package.json';
@@ -145,7 +145,7 @@ class Generator {
       this.configNunjucks();
       await this.loadTemplateConfig();
       this.registerHooks();
-      await this.registerFilters();
+      await registerFilters(this.nunjucks, this.templateConfig, this.templateDir);
 
       if (this.entrypoint) {
         const entrypointPath = path.resolve(this.templateContentDir, this.entrypoint);
@@ -325,43 +325,6 @@ class Generator {
       }, (err, result) => {
         if (err) return reject(err);
         resolve(beautifyNpmiResult(result));
-      });
-    });
-  }
-
-  /**
-   * Registers the template filters.
-   * @private
-   */
-  registerFilters() {
-    return new Promise((resolve, reject) => {
-      this.helpersDir = path.resolve(this.templateDir, FILTERS_DIRNAME);
-      if (!fs.existsSync(this.helpersDir)) return resolve();
-
-      const walker = xfs.walk(this.helpersDir, {
-        followLinks: false
-      });
-
-      walker.on('file', async (root, stats, next) => {
-        try {
-          const filePath = path.resolve(this.templateDir, path.resolve(root, stats.name));
-          // If it's a module constructor, inject dependencies to ensure consistent usage in remote templates in other projects or plain directories.
-          const mod = require(filePath);
-          if (typeof mod === 'function') {
-            mod({ Nunjucks: this.nunjucks });
-          }
-          next();
-        } catch (e) {
-          reject(e);
-        }
-      });
-
-      walker.on('errors', (root, nodeStatsArray) => {
-        reject(nodeStatsArray);
-      });
-
-      walker.on('end', async () => {
-        resolve();
       });
     });
   }
@@ -647,7 +610,6 @@ class Generator {
    */
   configNunjucks() {
     this.nunjucks = new Nunjucks.Environment(new Nunjucks.FileSystemLoader(this.templateDir));
-    this.nunjucks.addFilter('log', console.log);
   }
 
   /**
@@ -667,7 +629,6 @@ class Generator {
     } catch (e) {
       this.templateConfig = {};
     }
-
     await this.validateTemplateConfig();
   }
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -41,6 +41,7 @@ parser.registerSchemaParser([
   'application/raml+yaml;version=1.0',
 ], ramlDtParser);
 
+const FILTERS_DIRNAME = 'filters';
 const HOOKS_DIRNAME = 'hooks';
 const CONFIG_FILENAME = '.tp-config.json';
 const PACKAGE_JSON_FILENAME = 'package.json';
@@ -145,7 +146,7 @@ class Generator {
       this.configNunjucks();
       await this.loadTemplateConfig();
       this.registerHooks();
-      await registerFilters(this.nunjucks, this.templateConfig, this.templateDir);
+      await registerFilters(this.nunjucks, this.templateConfig, this.templateDir, FILTERS_DIRNAME);
 
       if (this.entrypoint) {
         const entrypointPath = path.resolve(this.templateContentDir, this.entrypoint);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -81,21 +81,3 @@ utils.getLocalTemplateDetails = async (templatePath) => {
     resolvedLink: path.resolve(path.dirname(templatePath), linkTarget),
   };
 };
-
-/**
- * Add filter functions to Nunjucks environment
- * @private
- * @param {Object} env Nunjucks environment.
- * @param {Object} filters Module with functions.
- */
-utils.addFilters = (env, filters) => {
-  /*
-    Object.getOwnPropertyNames(_).forEach((key) => {
-      if (_.isFunction(_[key])) filter[key] = _[key];
-    });
-    */
-  const filtersOnly = Object.getOwnPropertyNames(filters);
-  const filtersArray = filtersOnly.map((key) => [key, filters[key]]);
-    
-  filtersArray.forEach(([name, filter]) => env.addFilter(name, filter));
-};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -81,3 +81,21 @@ utils.getLocalTemplateDetails = async (templatePath) => {
     resolvedLink: path.resolve(path.dirname(templatePath), linkTarget),
   };
 };
+
+/**
+ * Add filter functions to Nunjucks environment
+ * @private
+ * @param {Object} env Nunjucks environment.
+ * @param {Object} filters Module with functions.
+ */
+utils.addFilters = (env, filters) => {
+  /*
+    Object.getOwnPropertyNames(_).forEach((key) => {
+      if (_.isFunction(_[key])) filter[key] = _[key];
+    });
+    */
+  const filtersOnly = Object.getOwnPropertyNames(filters);
+  const filtersArray = filtersOnly.map((key) => [key, filters[key]]);
+    
+  filtersArray.forEach(([name, filter]) => env.addFilter(name, filter));
+};

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@asyncapi/raml-dt-schema-parser": "^1.0.4",
     "ajv": "^6.10.2",
     "commander": "^2.12.2",
-    "config": "^3.3.1",
     "filenamify": "^4.1.0",
     "fs.extra": "^1.3.2",
     "jmespath": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@asyncapi/raml-dt-schema-parser": "^1.0.4",
     "ajv": "^6.10.2",
     "commander": "^2.12.2",
+    "config": "^3.3.1",
     "filenamify": "^4.1.0",
     "fs.extra": "^1.3.2",
     "jmespath": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "release": "semantic-release",
     "docker-build": "docker build -t asyncapi/generator:latest .",
     "get-version": "echo $npm_package_version",
-    "eslint": "eslint --config .eslintrc ."
+    "lint": "eslint --config .eslintrc ."
   },
   "preferGlobal": true,
   "bugs": {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- support filters from an external library. New template config parameter is added, `filters` that accepts an array of libraries that you can additionally register as filters for your template.
- generator now reads any function and then registers it as a filter so it is easier to write functions for templates and test them
- extracted whole logic related to filters registration to a separate file as `generator.js` is super overwhelming so using the opportunity that I worked on filters I moved them out

How to test:
`./cli.js test/docs/streetlights.yml https://github.com/derberg/html-template/#use-filters-lib -o output --force-write`

## Migration Guide
Your templates will not work with the latest generator. In your template, in filter directory you need to refactor your functions to follow new structure or remove filters that are already extracted to https://github.com/asyncapi/generator-filters

* To use https://github.com/asyncapi/generator-filters you need to add the following property to your template configuration file
```
  "filters": [
    "@asyncapi/generator-filters"
  ]
```
and have this package in `package.json` dependencies
```
 "@asyncapi/generator-filters": "^1.0.0"
```
* To refactor your existing filters just make sure your filters are normal JS functions and you export them as part of the module. Have a look on one of our official templates to see how new filters look like https://github.com/asyncapi/html-template/blob/master/filters/all.js. You do not have to change the logic, they just need to be refactored as they no longer need Nunjucks environment as input, which also means they are much easier to test now

**Related issue(s)**
Fixes #212