### PR TITLE
feat: Add parserOptions parameter instead of file name

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -7,7 +7,7 @@
     * [new Generator(templateName, targetDir, options)](#new_Generator_new)
     * _instance_
         * [.generate(asyncapiDocument)](#Generator+generate) ⇒ <code>Promise</code>
-        * [.generateFromString(asyncapiString, [asyncApiFileLocation])](#Generator+generateFromString) ⇒ <code>Promise</code>
+        * [.generateFromString(asyncapiString, [parserOptions])](#Generator+generateFromString) ⇒ <code>Promise</code>
         * [.generateFromFile(asyncapiFile)](#Generator+generateFromFile) ⇒ <code>Promise</code>
         * [.installTemplate([force])](#Generator+installTemplate)
     * _static_
@@ -77,15 +77,15 @@ try {
 ```
 <a name="Generator+generateFromString"></a>
 
-### generator.generateFromString(asyncapiString, [asyncApiFileLocation]) ⇒ <code>Promise</code>
+### generator.generateFromString(asyncapiString, [parserOptions]) ⇒ <code>Promise</code>
 Generates files from a given template and AsyncAPI string.
 
 **Kind**: instance method of [<code>Generator</code>](#Generator)  
 
-| Param | Type | Description |
-| --- | --- | --- |
-| asyncapiString | <code>String</code> | AsyncAPI string to use as source. |
-| [asyncApiFileLocation] | <code>String</code> | AsyncAPI file location, used by the @asyncapi/parser for references. |
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| asyncapiString | <code>String</code> |  | AsyncAPI string to use as source. |
+| [parserOptions] | <code>Object</code> | <code>{}</code> | AsyncAPI parser options. Check out [@asyncapi/parser](https://www.github.com/asyncapi/parser-js) for more information. |
 
 **Example**  
 ```js

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -199,21 +199,16 @@ class Generator {
    * }
    *
    * @param  {String} asyncapiString AsyncAPI string to use as source.
-   * @param  {String} [asyncApiFileLocation] AsyncAPI file location, used by the @asyncapi/parser for references.
+   * @param  {Object} [parserOptions={}] AsyncAPI parser options. Check out {@link https://www.github.com/asyncapi/parser-js|@asyncapi/parser} for more information.
    * @return {Promise}
    */
-  async generateFromString(asyncapiString, asyncApiFileLocation) {
+  async generateFromString(asyncapiString, parserOptions = {}) {
     if (!asyncapiString || typeof asyncapiString !== 'string') throw new Error('Parameter "asyncapiString" must be a non-empty string.');
 
     this.originalAsyncAPI = asyncapiString;
-    const parseOptions = {};
-
-    if (asyncApiFileLocation) {
-      parseOptions.path = asyncApiFileLocation;
-    }
 
     try {
-      this.asyncapi = await parse(asyncapiString, parseOptions);
+      this.asyncapi = await parse(asyncapiString, parserOptions);
       return this.generate(this.asyncapi);
     } catch (e) {
       throw e;


### PR DESCRIPTION
### Description
So far, it's been possible to pass the parameter `asyncApiFileLocation` to the `generateFromString` function. This was forwarded to the parser as `path`. However, the parser allows us to customize a bunch of stuff, not just the `path`. I'm opening this param to allow passing anything to the parser.

### Migration

Replace the string value you were passing by an object containing the `path` property. For example:

```js
const generator = new AsyncAPIGenerator('@asyncapi/html-template', os.tmpdir(), {
  entrypoint: 'index.html',
  output: 'string',
  forceWrite: true,
});
// Replace this:
// const html = await generator.generateFromString(myAsyncApiString, 'https://path-to-my-server.com/my-asyncapi.yaml');
// With this:
const html = await generator.generateFromString(myAsyncApiString, { path: 'https://path-to-my-server.com/my-asyncapi.yaml' });
```