### PR TITLE
feat: add support for template-generator versioning requirements

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -159,6 +159,7 @@ The `.tp-config.json` file contains a JSON object that may have the following in
 |`conditionalFiles[filePath].subject`| String | The `subject` is a [JMESPath](http://jmespath.org/) query to grab the value you want to apply the condition to. It queries an object with the whole AsyncAPI document and, when specified, the given server. The object looks like this: `{ asyncapi: { ... }, server: { ... } }`.
 |`conditionalFiles[filePath].validation`| Object | The `validation` is a JSON Schema Draft 07 object. This JSON Schema definition will be applied to the JSON value resulting from the `subject` query. If validation doesn't have errors, the condition is met, and therefore the given file will be rendered. Otherwise, the file is ignored.
 |`nonRenderableFiles`| [String] | A list of file paths or [globs](https://en.wikipedia.org/wiki/Glob_(programming)) that must be copied "as-is" to the target directory, i.e., without performing any rendering process. This is useful when you want to copy binary files.
+|`generator`| [String] | A string representing the Generator version-range the template is compatible with. This value must follow the [semver](https://docs.npmjs.com/misc/semver) syntax. E.g., `>=1.0.0`, `>=1.0.0 <=2.0.0`, `~1.0.0`, `^1.0.0`, `1.0.0`, etc.
 
 ### Example
 
@@ -188,7 +189,8 @@ The `.tp-config.json` file contains a JSON object that may have the following in
   "nonRenderableFiles": [
     "src/api/middlewares/*.*",
     "lib/lib/config.js"
-  ]
+  ],
+  "generator": "<2.0.0"
 }
 ```
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -13,6 +13,8 @@ const Ajv = require('ajv');
 const filenamify = require('filenamify');
 const git = require('simple-git/promise');
 const npmi = require('npmi');
+const semver = require('semver');
+const packageJson = require('../package.json');
 const {
   convertMapToObject,
   isFileSystemPath,
@@ -669,8 +671,12 @@ class Generator {
    * @return {Promise}
    */
   async validateTemplateConfig(asyncapiDocument) {
-    const { parameters, supportedProtocols, conditionalFiles } = this.templateConfig;
+    const { parameters, supportedProtocols, conditionalFiles, generator } = this.templateConfig;
     let server;
+
+    if (typeof generator === 'string' && !semver.satisfies(packageJson.version, generator)) {
+      throw new Error(`This template is not compatible with this version of the generator (${packageJson.version}). It's compatible with the following version range: ${generator}.`);
+    }
 
     const requiredParams = [];
     Object.keys(parameters || {}).forEach(key => {
@@ -700,10 +706,8 @@ class Generator {
         if (!server) throw new Error(`Couldn't find server with name ${this.templateParams.server}.`);
       }
 
-      if (server && Array.isArray(supportedProtocols)) {
-        if (!supportedProtocols.includes(server.protocol())) {
-          throw new Error(`Server "${this.templateParams.server}" uses the ${server.protocol()} protocol but this template only supports the following ones: ${supportedProtocols}.`);
-        }
+      if (server && Array.isArray(supportedProtocols) && !supportedProtocols.includes(server.protocol())) {
+        throw new Error(`Server "${this.templateParams.server}" uses the ${server.protocol()} protocol but this template only supports the following ones: ${supportedProtocols}.`);
       }
     }
   }

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -675,7 +675,7 @@ class Generator {
     let server;
 
     if (typeof generator === 'string' && !semver.satisfies(packageJson.version, generator)) {
-      throw new Error(`This template is not compatible with this version of the generator (${packageJson.version}). It's compatible with the following version range: ${generator}.`);
+      throw new Error(`This template is not compatible with the current version of the generator (${packageJson.version}). This template is compatible with the following version range: ${generator}.`);
     }
 
     const requiredParams = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1354,6 +1354,14 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "crypto-random-string": {
@@ -3339,6 +3347,14 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
       }
     },
     "normalize-path": {
@@ -6909,6 +6925,13 @@
       "requires": {
         "global-npm": "^0.3.0",
         "semver": "^5.4.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "nunjucks": {
@@ -7826,9 +7849,9 @@
       }
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     },
     "semver-diff": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "minimatch": "^3.0.4",
     "npmi": "^4.0.0",
     "nunjucks": "^3.2.0",
+    "semver": "^7.3.2",
     "simple-git": "^1.131.0"
   },
   "devDependencies": {


### PR DESCRIPTION
**Description**
It allows template owners to specify which version range of the generator they support. For instance, if we find a `.tp-config.json` file with the attribute `"generator": ">=0.36.0 <=1.0.0"` and the current version of the generator is `1.5.0`, it should trigger an error.

The format of the `generator` config property is a string representing semantic versioning ranges. See [semver](https://www.npmjs.com/package/semver) for more details.

**Related issue(s)**
Partially solves #280 