### PR TITLE
fix: update parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,9 @@
       }
     },
     "@asyncapi/parser": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-0.18.1.tgz",
-      "integrity": "sha512-QWSuQsf4RETmQdiZYjgqz1VFh/3wq9uGwgbccvUyfHP0z0w4fXfeNscZmovaouas7+6ZTDalLgC7mWhzes0u9w==",
+      "version": "0.18.3",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-0.18.3.tgz",
+      "integrity": "sha512-7Jr3VbTTsMA15+8aA/NZlEcw3NqdUN+JIqggAIYFlYdr2H5DlsAe7en9UcgcKM2ReccuifsezYjS+VhO92fdlg==",
       "requires": {
         "@apidevtools/json-schema-ref-parser": "github:fmvilas/json-schema-ref-parser#add-more-info-about-errors",
         "@asyncapi/specs": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "homepage": "https://github.com/asyncapi/generator",
   "dependencies": {
     "@asyncapi/openapi-schema-parser": "^1.0.0",
-    "@asyncapi/parser": "^0.18.1",
+    "@asyncapi/parser": "^0.18.3",
     "@asyncapi/raml-dt-schema-parser": "^1.0.4",
     "ajv": "^6.10.2",
     "commander": "^2.12.2",


### PR DESCRIPTION
Updates parser to the latest version to include `Schema.deprecated()`.