### PR TITLE
fix: Add enumerable to template parameters

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -102,6 +102,7 @@ class Generator {
     Object.keys(templateParams).forEach(key => {
       const self = this;
       Object.defineProperty(this.templateParams, key, {
+        enumerable: true,
         get() {
           if (!self.templateConfig.parameters || !self.templateConfig.parameters[key]) {
             throw new Error(`Template parameter "${key}" has not been defined in the .tp-config.json file. Please make sure it's listed there before you use it in your template.`);


### PR DESCRIPTION
**Description**
There is a bug with definition of `templateParams`
Use following hooks:
```js
module.exports = register => {
    register('generate:before', generator => {
        console.log(generator.templateParams);
    });
};
module.exports = register => {
    register('generate:after', generator => {
        console.log("/////////////////////////////////");
        console.log(generator.templateParams);
    });
};
```
Run as
```bash
docker run --rm -it -v ../java-spring-template-my-fork:/app/my-fork -v $pwd/asyncapi.yml:/app/asyncapi.yml -v $pwd/output:/app/output asyncapi/generator -o ./output -p listenerConcurrency=5 -p listenerPollTimeout=4000 asyncapi.yml /app/my-fork --force-write
```
Output:
```bash
{}
//////////////////////////////////
{}
```

For details about fix and `enumerable` - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty

**Related issue(s)**
no, discussion in Slack