### PR TITLE
fix: watcher ignores output and regeneration in loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Options:
   -o, --output <outputDir>       directory where to put the generated files (defaults to current directory)
   -p, --param <name=value>       additional param to pass to templates
   --force-write                  force writing of the generated files to given directory even if it is a git repo with unstaged files or not empty dir (defaults to false)
-  --watch-template               watches the template directory and the AsyncAPI document, and re-generate the files when changes occur
+  --watch-template               watches the template directory and the AsyncAPI document, and re-generate the files when changes occur. Ignores the output directory
   -h, --help                     output usage information
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Options:
   -o, --output <outputDir>       directory where to put the generated files (defaults to current directory)
   -p, --param <name=value>       additional param to pass to templates
   --force-write                  force writing of the generated files to given directory even if it is a git repo with unstaged files or not empty dir (defaults to false)
-  --watch-template               watches the template directory and the AsyncAPI document, and re-generate the files when changes occur. Ignores the output directory
+  --watch-template               watches the template directory and the AsyncAPI document, and re-generate the files when changes occur. Ignores the output directory. This flag should be used only for template development.
   -h, --help                     output usage information
 ```
 

--- a/cli.js
+++ b/cli.js
@@ -60,7 +60,7 @@ program
   .option('-o, --output <outputDir>', 'directory where to put the generated files (defaults to current directory)', parseOutput, process.cwd())
   .option('-p, --param <name=value>', 'additional param to pass to templates', paramParser)
   .option('--force-write', 'force writing of the generated files to given directory even if it is a git repo with unstaged files or not empty dir (defaults to false)')
-  .option('--watch-template', 'watches the template directory and the AsyncAPI document, and re-generate the files when changes occur')
+  .option('--watch-template', 'watches the template directory and the AsyncAPI document, and re-generate the files when changes occur. Ignores the output directory')
   .parse(process.argv);
 
 if (!asyncapiFile) {
@@ -78,14 +78,14 @@ xfs.mkdirp(program.output, async err => {
 
   // If we want to watch for changes do that
   if (program.watchTemplate) {
-    const watchDir = path.resolve(Generator.DEFAULT_TEMPLATES_DIR, template);
+    const watchDir = path.resolve(template);
     console.log(`[WATCHER] Watching for changes in the template directory ${magenta(watchDir)} and in the AsyncAPI file ${magenta(asyncapiFile)}`);
 
     if (!(await isLocalTemplate(watchDir))) {
       console.warn(`WARNING: ${template} is a remote template. Changes may be lost on subsequent installations.`);
     }
-
-    const watcher = new Watcher([asyncapiFile, watchDir]);
+    const outputPath = path.resolve(watchDir, program.output);
+    const watcher = new Watcher([asyncapiFile, watchDir], outputPath);
     watcher.watch(async (changedFiles) => {
       console.clear();
       console.log('[WATCHER] Change detected');

--- a/cli.js
+++ b/cli.js
@@ -79,9 +79,14 @@ xfs.mkdirp(program.output, async err => {
   // If we want to watch for changes do that
   if (program.watchTemplate) {
     const watchDir = path.resolve(template);
+    // Template name is needed as it is not always a part of the cli commad
+    // There is a use case that you run generator from a root of the template with `./` path
+    const templateName = require(path.resolve(watchDir,'./package.json')).name;
+
     console.log(`[WATCHER] Watching for changes in the template directory ${magenta(watchDir)} and in the AsyncAPI file ${magenta(asyncapiFile)}`);
 
-    if (!(await isLocalTemplate(watchDir))) {
+    // Must check template in its installation path in generator to use isLocalTemplate function
+    if (!await isLocalTemplate(path.resolve(Generator.DEFAULT_TEMPLATES_DIR, templateName))) {
       console.warn(`WARNING: ${template} is a remote template. Changes may be lost on subsequent installations.`);
     }
     const outputPath = path.resolve(watchDir, program.output);

--- a/cli.js
+++ b/cli.js
@@ -81,7 +81,7 @@ xfs.mkdirp(program.output, async err => {
     const watchDir = path.resolve(template);
     // Template name is needed as it is not always a part of the cli commad
     // There is a use case that you run generator from a root of the template with `./` path
-    const templateName = require(path.resolve(watchDir,'./package.json')).name;
+    const templateName = require(path.resolve(watchDir,'package.json')).name;
 
     console.log(`[WATCHER] Watching for changes in the template directory ${magenta(watchDir)} and in the AsyncAPI file ${magenta(asyncapiFile)}`);
 

--- a/cli.js
+++ b/cli.js
@@ -60,7 +60,7 @@ program
   .option('-o, --output <outputDir>', 'directory where to put the generated files (defaults to current directory)', parseOutput, process.cwd())
   .option('-p, --param <name=value>', 'additional param to pass to templates', paramParser)
   .option('--force-write', 'force writing of the generated files to given directory even if it is a git repo with unstaged files or not empty dir (defaults to false)')
-  .option('--watch-template', 'watches the template directory and the AsyncAPI document, and re-generate the files when changes occur. Ignores the output directory')
+  .option('--watch-template', 'watches the template directory and the AsyncAPI document, and re-generate the files when changes occur. Ignores the output directory. This flag should be used only for template development.')
   .parse(process.argv);
 
 if (!asyncapiFile) {

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -5,7 +5,7 @@ const chokidar = require('chokidar');
  * Class to watch for change in certain file(s)
  */
 class Watcher {
-  constructor(paths) {
+  constructor(paths, ignorePath) {
     if (Array.isArray(paths)) {
       this.paths = paths;
     } else {
@@ -19,6 +19,7 @@ class Watcher {
     this.fsWait = false;
     this.watchers = {};
     this.filesChanged = {};
+    this.ignorePath = ignorePath;
   }
 
   /**
@@ -28,7 +29,7 @@ class Watcher {
   async watch(changeCallback, errorCallback) {
     for (const index in this.paths) {
       const path = this.paths[index];
-      const watcher = chokidar.watch(path, {ignoreInitial: true});
+      const watcher = chokidar.watch(path, {ignoreInitial: true, ignored: this.ignorePath});
       watcher.on('all', (eventType, changedPath) => this.fileChanged(path, changedPath, eventType, changeCallback, errorCallback));
       this.watchers[path] = watcher;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2433,9 +2433,9 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
-      "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
+      "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
@@ -2444,7 +2444,7 @@
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.3.0"
+        "readdirp": "~3.4.0"
       }
     },
     "ci-info": {
@@ -11512,11 +11512,11 @@
       }
     },
     "readdirp": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
-      "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+      "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
       "requires": {
-        "picomatch": "^2.0.7"
+        "picomatch": "^2.2.1"
       }
     },
     "realpath-native": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@semantic-release/github": "^7.0.4",
     "@semantic-release/npm": "^7.0.3",
     "@semantic-release/release-notes-generator": "^9.0.1",
-    "chokidar": "^3.3.0",
+    "chokidar": "^3.4.0",
     "conventional-changelog-conventionalcommits": "^4.2.3",
     "eslint": "^6.8.0",
     "eslint-plugin-jest": "^23.8.2",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- watcher now watches explicitly the location of the template specified by the user. Before it was watching location where the template was installed in the generator global location
```
/.../.nvm/versions/node/v12.16.1/lib/node_modules/@asyncapi/generator/node_modules/@asyncapi/nodejs-ws-template/output/src/api/index.js was changed
```
- watcher now by default ignores output directory
- watcher supports flow when you trigger generation with watcher in the root of the template
- bump chokidar to latest

**Related issue(s)**
Fixes #185