### PR TITLE
fix: watcher not reloading changes done to local filters and hooks

### DIFF
--- a/lib/filtersRegistry.js
+++ b/lib/filtersRegistry.js
@@ -36,8 +36,11 @@ function registerLocalFilters(nunjucks, templateDir, filtersDir) {
       try {
         const filePath = path.resolve(templateDir, path.resolve(root, stats.name));
         // If it's a module constructor, inject dependencies to ensure consistent usage in remote templates in other projects or plain directories.
+        delete require.cache[require.resolve(filePath)];
         const mod = require(filePath);
+
         addFilters(nunjucks, mod);
+        
         next();
       } catch (e) {
         reject(e);

--- a/lib/hooksRegistry.js
+++ b/lib/hooksRegistry.js
@@ -37,6 +37,7 @@ async function registerLocalHooks(hooks, templateDir, hooksDir) {
     walker.on('file', async (root, stats, next) => {
       try {
         const filePath = path.resolve(templateDir, path.resolve(root, stats.name));
+        delete require.cache[require.resolve(filePath)];
         const mod = require(filePath);
 
         addHook(hooks, mod);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- clear module cache each time hooks and filters are required

**Related issue(s)**
Resolves #204 