### PR TITLE
feat: add default value for template parameters

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -183,7 +183,7 @@ The `.tp-config.json` file contains a JSON object that may have the following in
 |`supportedProtocols`| [String] | A list with all the protocols this template supports.
 |`parameters`| Object[String, Object] | An object with all the parameters that can be passed when generating the template. When using the command line, it's done by indicating `--param name=value` or `-p name=value`.
 |`parameters[param].description`| String | A user-friendly description about the parameter.
-|`parameters[param].default`| String | Default value of this parameter if not set in the start command.
+|`parameters[param].default`| Any | Default value of the parameter if not specified.
 |`parameters[param].required`| Boolean | Whether the parameter is required or not.
 |`conditionalFiles`| Object[String, Object] | An object containing all the file paths that should be conditionally rendered. Each key represents a file path and each value must be an object with the keys `subject` and `validation`.
 |`conditionalFiles[filePath].subject`| String | The `subject` is a [JMESPath](http://jmespath.org/) query to grab the value you want to apply the condition to. It queries an object with the whole AsyncAPI document and, when specified, the given server. The object looks like this: `{ asyncapi: { ... }, server: { ... } }`.
@@ -201,8 +201,12 @@ The `.tp-config.json` file contains a JSON object that may have the following in
   "parameters": {
     "server": {
       "description": "The server you want to use in the code.",
-      "default": "localhost",
       "required": true
+    },
+    "pathToApiFile": {
+      "description": "The path to store original AsyncAPI file.",
+      "default": "./api",
+      "required": false
     }
   },
   "conditionalFiles": {

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -203,9 +203,9 @@ The `.tp-config.json` file contains a JSON object that may have the following in
       "description": "The server you want to use in the code.",
       "required": true
     },
-    "asyncapiFileDir": {
-      "description": "The path to store original AsyncAPI file.",
-      "default": "./api",
+    "dummyParameter": {
+      "description": "Example of parameter with default value.",
+      "default": "just a string",
       "required": false
     }
   },
@@ -244,4 +244,3 @@ There are some template parameters that have a special meaning:
 |Name|Description|
 |---|---|
 |`server`| It is used to let the template know which server you want to use. In some cases, this may be required. For instance, when generating code that connects to a specific server. If your template need your users to specify a server, use this parameter.
-|`asyncapiFileDir`| It is used by `@asyncapi/generator-hooks#`[`createAsyncapiFile`](https://github.com/asyncapi/generator-hooks/blob/62c50cac6156110e1325152cb2599d916a310055/src/index.js#L5) to specify directory where original AsyncAPI file will be stored. Defining a default parameter value allows template maintainers to pre-set this location. |

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -183,6 +183,7 @@ The `.tp-config.json` file contains a JSON object that may have the following in
 |`supportedProtocols`| [String] | A list with all the protocols this template supports.
 |`parameters`| Object[String, Object] | An object with all the parameters that can be passed when generating the template. When using the command line, it's done by indicating `--param name=value` or `-p name=value`.
 |`parameters[param].description`| String | A user-friendly description about the parameter.
+|`parameters[param].default`| String | Default value of this parameter if not set in the start command.
 |`parameters[param].required`| Boolean | Whether the parameter is required or not.
 |`conditionalFiles`| Object[String, Object] | An object containing all the file paths that should be conditionally rendered. Each key represents a file path and each value must be an object with the keys `subject` and `validation`.
 |`conditionalFiles[filePath].subject`| String | The `subject` is a [JMESPath](http://jmespath.org/) query to grab the value you want to apply the condition to. It queries an object with the whole AsyncAPI document and, when specified, the given server. The object looks like this: `{ asyncapi: { ... }, server: { ... } }`.
@@ -200,6 +201,7 @@ The `.tp-config.json` file contains a JSON object that may have the following in
   "parameters": {
     "server": {
       "description": "The server you want to use in the code.",
+      "default": "localhost",
       "required": true
     }
   },

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -183,7 +183,7 @@ The `.tp-config.json` file contains a JSON object that may have the following in
 |`supportedProtocols`| [String] | A list with all the protocols this template supports.
 |`parameters`| Object[String, Object] | An object with all the parameters that can be passed when generating the template. When using the command line, it's done by indicating `--param name=value` or `-p name=value`.
 |`parameters[param].description`| String | A user-friendly description about the parameter.
-|`parameters[param].default`| Any | Default value of the parameter if not specified.
+|`parameters[param].default`| Any | Default value of the parameter if not specified. Shouldn't be used for mandatory `required=true` parameters.
 |`parameters[param].required`| Boolean | Whether the parameter is required or not.
 |`conditionalFiles`| Object[String, Object] | An object containing all the file paths that should be conditionally rendered. Each key represents a file path and each value must be an object with the keys `subject` and `validation`.
 |`conditionalFiles[filePath].subject`| String | The `subject` is a [JMESPath](http://jmespath.org/) query to grab the value you want to apply the condition to. It queries an object with the whole AsyncAPI document and, when specified, the given server. The object looks like this: `{ asyncapi: { ... }, server: { ... } }`.
@@ -203,7 +203,7 @@ The `.tp-config.json` file contains a JSON object that may have the following in
       "description": "The server you want to use in the code.",
       "required": true
     },
-    "pathToApiFile": {
+    "asyncapiFileDir": {
       "description": "The path to store original AsyncAPI file.",
       "default": "./api",
       "required": false
@@ -244,3 +244,4 @@ There are some template parameters that have a special meaning:
 |Name|Description|
 |---|---|
 |`server`| It is used to let the template know which server you want to use. In some cases, this may be required. For instance, when generating code that connects to a specific server. If your template need your users to specify a server, use this parameter.
+|`asyncapiFileDir`| It is used by `@asyncapi/generator-hooks#`[`createAsyncapiFile`](https://github.com/asyncapi/generator-hooks/blob/62c50cac6156110e1325152cb2599d916a310055/src/index.js#L5) to specify directory where original AsyncAPI file will be stored. Defining a default parameter value allows template maintainers to pre-set this location. |

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -652,7 +652,7 @@ class Generator {
    * @private
    */
   async loadDefaultValues() {
-    const { parameters, supportedProtocols, conditionalFiles, generator } = this.templateConfig;
+    const parameters = this.templateConfig.parameters;
     const defaultValues = [];
     Object.keys(parameters || {}).forEach(key => {
       if (parameters[key].default) {
@@ -667,7 +667,8 @@ class Generator {
           get() {
             return parameters[dv].default;
           }
-      }));
+        })
+      );
     }
   }
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -642,7 +642,33 @@ class Generator {
     } catch (e) {
       this.templateConfig = {};
     }
+    await this.loadDefaultValues();
     await this.validateTemplateConfig();
+  }
+
+  /**
+   * Loads default values of parameters from template config. If value was already set as parameter it will not be
+   * overrided.
+   * @private
+   */
+  async loadDefaultValues() {
+    const { parameters, supportedProtocols, conditionalFiles, generator } = this.templateConfig;
+    const defaultValues = [];
+    Object.keys(parameters || {}).forEach(key => {
+      if (parameters[key].default) {
+        defaultValues.push(key);
+      }
+    });
+
+    if (Array.isArray(defaultValues)) {
+      defaultValues.filter(dv => this.templateParams[dv] === undefined).forEach(dv =>
+        Object.defineProperty(this.templateParams, dv, {
+          enumerable: true,
+          get() {
+            return parameters[dv].default;
+          }
+      }));
+    }
   }
 
   /**

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -653,23 +653,16 @@ class Generator {
    */
   async loadDefaultValues() {
     const parameters = this.templateConfig.parameters;
-    const defaultValues = [];
-    Object.keys(parameters || {}).forEach(key => {
-      if (parameters[key].default) {
-        defaultValues.push(key);
-      }
-    });
+    const defaultValues = Object.keys(parameters || {}).filter(key => parameters[key].default);
 
-    if (Array.isArray(defaultValues)) {
-      defaultValues.filter(dv => this.templateParams[dv] === undefined).forEach(dv =>
-        Object.defineProperty(this.templateParams, dv, {
-          enumerable: true,
-          get() {
-            return parameters[dv].default;
-          }
-        })
-      );
-    }
+    defaultValues.filter(dv => this.templateParams[dv] === undefined).forEach(dv =>
+      Object.defineProperty(this.templateParams, dv, {
+        enumerable: true,
+        get() {
+          return parameters[dv].default;
+        }
+      })
+    );
   }
 
   /**
@@ -687,16 +680,11 @@ class Generator {
       throw new Error(`This template is not compatible with the current version of the generator (${packageJson.version}). This template is compatible with the following version range: ${generator}.`);
     }
 
-    const requiredParams = [];
-    Object.keys(parameters || {}).forEach(key => {
-      if (parameters[key].required === true) requiredParams.push(key);
-    });
+    const requiredParams = Object.keys(parameters || {}).filter(key => parameters[key].required === true);
 
-    if (Array.isArray(requiredParams)) {
-      const missingParams = requiredParams.filter(rp => this.templateParams[rp] === undefined);
-      if (missingParams.length) {
-        throw new Error(`This template requires the following missing params: ${missingParams}.`);
-      }
+    const missingParams = requiredParams.filter(rp => this.templateParams[rp] === undefined);
+    if (missingParams.length) {
+      throw new Error(`This template requires the following missing params: ${missingParams}.`);
     }
 
     if (typeof conditionalFiles === 'object') {

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -387,11 +387,11 @@ describe('Generator', () => {
   describe('#loadDefaultValues', () => {
     it('default value of parameter is set', async () => {
       const gen = new Generator('testTemplate', __dirname, {
-                                  templateParams: {
-                                    test: true
-                                  }
-                                });
-      let json = '{"parameters": {' +
+        templateParams: {
+          test: true
+        }
+      });
+      const json = '{"parameters": {' +
         '  "paramWithDefault": {' +
         '    "description": "Parameter with default value",' +
         '    "default": "default",' +
@@ -412,7 +412,7 @@ describe('Generator', () => {
 
       expect(gen.templateParams).toStrictEqual({
         test: true,
-        paramWithDefault: "default"
+        paramWithDefault: 'default'
       });
     });
 
@@ -422,7 +422,7 @@ describe('Generator', () => {
           test: true
         }
       });
-      let json = '{"parameters": {' +
+      const json = '{"parameters": {' +
         '  "test": {' +
         '    "description": "Parameter with default value",' +
         '    "default": false,' +

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -391,22 +391,23 @@ describe('Generator', () => {
           test: true
         }
       });
-      const json = '{"parameters": {' +
-        '  "paramWithDefault": {' +
-        '    "description": "Parameter with default value",' +
-        '    "default": "default",' +
-        '    "required": false' +
-        '  },' +
-        '  "paramWithoutDefault": {' +
-        '    "description": "Parameter without default value",' +
-        '    "required": false' +
-        '  },' +
-        '  "test": {' +
-        '    "description": "test",' +
-        '    "required": false' +
-        '  }' +
-        '}}';
-      gen.templateConfig = JSON.parse(json);
+      gen.templateConfig  = {
+        parameters: {
+          paramWithDefault: {
+            description: 'Parameter with default value',
+            default: 'default',
+            required: false
+          },
+          paramWithoutDefault: {
+            description: 'Parameter without default value',
+            required: false
+          },
+          test: {
+            description: 'test',
+            required: false
+          }
+        }
+      };
 
       await gen.loadDefaultValues();
 
@@ -422,14 +423,41 @@ describe('Generator', () => {
           test: true
         }
       });
-      const json = '{"parameters": {' +
-        '  "test": {' +
-        '    "description": "Parameter with default value",' +
-        '    "default": false,' +
-        '    "required": false' +
-        '  }' +
-        '}}';
-      gen.templateConfig = JSON.parse(json);
+      gen.templateConfig = {
+        parameters: {
+          test: {
+            description: 'Parameter with default value',
+            default: false,
+            required: false
+          }
+        }
+      };
+
+      await gen.loadDefaultValues();
+
+      expect(gen.templateParams).toStrictEqual({
+        test: true
+      });
+    });
+
+    it('no default values', async () => {
+      const gen = new Generator('testTemplate', __dirname, {
+        templateParams: {
+          test: true
+        }
+      });
+      gen.templateConfig = {
+        parameters: {
+          test: {
+            description: 'Parameter with default value',
+            required: false
+          },
+          anotherParam: {
+            description: 'Yeat another param',
+            required: false
+          }
+        }
+      };
 
       await gen.loadDefaultValues();
 

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -383,4 +383,59 @@ describe('Generator', () => {
       expect(content).toBe(utils.__files[filePath]);
     });
   });
+
+  describe('#loadDefaultValues', () => {
+    it('default value of parameter is set', async () => {
+      const gen = new Generator('testTemplate', __dirname, {
+                                  templateParams: {
+                                    test: true
+                                  }
+                                });
+      let json = '{"parameters": {' +
+        '  "paramWithDefault": {' +
+        '    "description": "Parameter with default value",' +
+        '    "default": "default",' +
+        '    "required": false' +
+        '  },' +
+        '  "paramWithoutDefault": {' +
+        '    "description": "Parameter without default value",' +
+        '    "required": false' +
+        '  },' +
+        '  "test": {' +
+        '    "description": "test",' +
+        '    "required": false' +
+        '  }' +
+        '}}';
+      gen.templateConfig = JSON.parse(json);
+
+      await gen.loadDefaultValues();
+
+      expect(gen.templateParams).toStrictEqual({
+        test: true,
+        paramWithDefault: "default"
+      });
+    });
+
+    it('default value of parameter is not override user value', async () => {
+      const gen = new Generator('testTemplate', __dirname, {
+        templateParams: {
+          test: true
+        }
+      });
+      let json = '{"parameters": {' +
+        '  "test": {' +
+        '    "description": "Parameter with default value",' +
+        '    "default": false,' +
+        '    "required": false' +
+        '  }' +
+        '}}';
+      gen.templateConfig = JSON.parse(json);
+
+      await gen.loadDefaultValues();
+
+      expect(gen.templateParams).toStrictEqual({
+        test: true
+      });
+    });
+  });
 });


### PR DESCRIPTION
**Description**

- Now you as template author could define a default value for template properties. If user pass parameter value in start command, for sure, it will be used as value of parameter. 
- Tested with https://github.com/asyncapi/java-spring-template/pull/37

**Related issue(s)**
Resolves #339 
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The 3rd option will not automatically close the issue after the merge. -->