### PR TITLE
feat: move template config to package.json

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -49,8 +49,8 @@ const showErrorAndExit = err => {
 program
   .version(packageInfo.version)
   .arguments('<asyncapi> <template>')
-  .action((path, tmpl) => {
-    asyncapiDocPath = path;
+  .action((fileLoc, tmpl) => {
+    asyncapiDocPath = fileLoc;
     template = tmpl;
   })
   .option('-d, --disable-hook <hookType>', 'disable a specific hook type', disableHooksParser)

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -11,7 +11,7 @@ The AsyncAPI generator has been built with extensibility in mind. The package us
 1. Templates may contain [Nunjucks filters or helper functions](https://mozilla.github.io/nunjucks/templating.html#builtin-filters). [Read more about filters](#filters).
 1. Templates may contain `hooks` that are functions invoked during specific moment of the generation. In the template, they must be stored in the `.hooks` directory under the template directory. They can also be stored in other modules and external libraries and configured inside the template [Read more about hooks](#hooks).
 1. Templates may contain `partials` (reusable chunks). They must be stored in the `.partials` directory under the template directory. [Read more about partials](#partials).
-1. Templates may have a configuration file. It must be stored in the template directory and its name must be `.tp-config.json`. [Read more about the configuration file](#configuration-file).
+1. Templates can be configured. Configuration must be stored in the `package.json` file under custom `generator` property. [Read more about the configuration file](#configuration-file).
 1. There are parameters with special meaning. [Read more about special parameters](#special-parameters).
 1. The default variables you have access to in any the template file are the following:
    - `asyncapi` that is a parsed spec file object. Read the [API](https://github.com/asyncapi/parser-js/blob/master/API.md#AsyncAPIDocument) of the Parser to understand to what structure you have access in this parameter.
@@ -176,7 +176,7 @@ Files from the `.partials` directory do not end up with other generated files in
 
 ## Configuration File
 
-The `.tp-config.json` file contains a JSON object that may have the following information:
+The `generator` property from `package.json` file must contain a JSON object that may have the following information:
 
 |Name|Type|Description|
 |---|---|---|
@@ -196,6 +196,7 @@ The `.tp-config.json` file contains a JSON object that may have the following in
 ### Example
 
 ```json
+"generator":
 {
   "supportedProtocols": ["amqp", "mqtt"],
   "parameters": {

--- a/lib/__mocks__/templateConfigValidator.js
+++ b/lib/__mocks__/templateConfigValidator.js
@@ -1,0 +1,3 @@
+const templateConfigValidator = jest.genMockFromModule('../templateConfigValidator');
+
+module.exports = templateConfigValidator;

--- a/lib/__mocks__/utils.js
+++ b/lib/__mocks__/utils.js
@@ -20,7 +20,7 @@ utils.getLocalTemplateDetails = jest.fn(async () => ({
   resolvedLink: utils.__getLocalTemplateDetailsResolvedLinkValue || '',
 }));
 
-utils.__generatorVersion = '1.0.0';
+utils.__generatorVersion = '';
 utils.getGeneratorVersion = jest.fn(() => utils.__generatorVersion);
 
 module.exports = utils;

--- a/lib/__mocks__/utils.js
+++ b/lib/__mocks__/utils.js
@@ -20,4 +20,7 @@ utils.getLocalTemplateDetails = jest.fn(async () => ({
   resolvedLink: utils.__getLocalTemplateDetailsResolvedLinkValue || '',
 }));
 
+utils.__generatorVersion = '1.0.0';
+utils.getGeneratorVersion = jest.fn(() => utils.__generatorVersion);
+
 module.exports = utils;

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -8,12 +8,10 @@ const ramlDtParser = require('@asyncapi/raml-dt-schema-parser');
 const openapiSchemaParser = require('@asyncapi/openapi-schema-parser');
 const Nunjucks = require('nunjucks');
 const jmespath = require('jmespath');
-const Ajv = require('ajv');
 const filenamify = require('filenamify');
 const git = require('simple-git/promise');
 const npmi = require('npmi');
-const semver = require('semver');
-const packageJson = require('../package.json');
+const { validateTemplateConfig } = require('./templateConfigValidator');
 const {
   convertMapToObject,
   isFileSystemPath,
@@ -29,8 +27,6 @@ const {
 const { registerFilters } = require('./filtersRegistry');
 const { registerHooks } = require('./hooksRegistry');
 
-const ajv = new Ajv({ allErrors: true });
-
 parser.registerSchemaParser([
   'application/vnd.oai.openapi;version=3.0.0',
   'application/vnd.oai.openapi+json;version=3.0.0',
@@ -43,7 +39,7 @@ parser.registerSchemaParser([
 
 const FILTERS_DIRNAME = 'filters';
 const HOOKS_DIRNAME = 'hooks';
-const CONFIG_FILENAME = '.tp-config.json';
+const CONFIG_FILENAME = 'package.json';
 const PACKAGE_JSON_FILENAME = 'package.json';
 const ROOT_DIR = path.resolve(__dirname, '..');
 const DEFAULT_TEMPLATES_DIR = path.resolve(ROOT_DIR, 'node_modules');
@@ -120,7 +116,7 @@ class Generator {
         enumerable: true,
         get() {
           if (!self.templateConfig.parameters || !self.templateConfig.parameters[key]) {
-            throw new Error(`Template parameter "${key}" has not been defined in the .tp-config.json file. Please make sure it's listed there before you use it in your template.`);
+            throw new Error(`Template parameter "${key}" has not been defined in the package.json file under generator property. Please make sure it's listed there before you use it in your template.`);
           }
           return templateParams[key];
         }
@@ -166,9 +162,9 @@ class Generator {
     this.templateContentDir = path.resolve(this.templateDir, TEMPLATE_CONTENT_DIRNAME);
     this.configNunjucks();
     await this.loadTemplateConfig();
+    validateTemplateConfig(this.templateConfig, this.templateParams, asyncapiDocument);
     await registerHooks(this.hooks, this.templateConfig, this.templateDir, HOOKS_DIRNAME);
     await registerFilters(this.nunjucks, this.templateConfig, this.templateDir, FILTERS_DIRNAME);
-    await this.validateTemplateConfig(asyncapiDocument);
     await this.launchHook('generate:before');
 
     if (this.entrypoint) {
@@ -637,13 +633,13 @@ class Generator {
         return;
       }
 
-      const json = fs.readFileSync(configPath, { encoding: 'utf8' });
-      this.templateConfig = JSON.parse(json);
+      const json = await readFile(configPath, { encoding: 'utf8' });
+      const generatorProp = JSON.parse(json).generator;
+      this.templateConfig = generatorProp || {};
     } catch (e) {
       this.templateConfig = {};
     }
     await this.loadDefaultValues();
-    await this.validateTemplateConfig();
   }
 
   /**
@@ -663,50 +659,6 @@ class Generator {
         }
       })
     );
-  }
-
-  /**
-   * Validates the template configuration.
-   *
-   * @private
-   * @param  {AsyncAPIDocument} [asyncapiDocument] AsyncAPIDocument object to use as source.
-   * @return {Promise}
-   */
-  async validateTemplateConfig(asyncapiDocument) {
-    const { parameters, supportedProtocols, conditionalFiles, generator } = this.templateConfig;
-    let server;
-
-    if (typeof generator === 'string' && !semver.satisfies(packageJson.version, generator)) {
-      throw new Error(`This template is not compatible with the current version of the generator (${packageJson.version}). This template is compatible with the following version range: ${generator}.`);
-    }
-
-    const requiredParams = Object.keys(parameters || {}).filter(key => parameters[key].required === true);
-
-    const missingParams = requiredParams.filter(rp => this.templateParams[rp] === undefined);
-    if (missingParams.length) {
-      throw new Error(`This template requires the following missing params: ${missingParams}.`);
-    }
-
-    if (typeof conditionalFiles === 'object') {
-      const fileNames = Object.keys(conditionalFiles) || [];
-      fileNames.forEach(fileName => {
-        const def = conditionalFiles[fileName];
-        if (typeof def.subject !== 'string') throw new Error(`Invalid conditional file subject for ${fileName}: ${def.subject}.`);
-        if (typeof def.validation !== 'object') throw new Error(`Invalid conditional file validation object for ${fileName}: ${def.validation}.`);
-        conditionalFiles[fileName].validate = ajv.compile(conditionalFiles[fileName].validation);
-      });
-    }
-
-    if (asyncapiDocument) {
-      if (typeof this.templateParams.server === 'string') {
-        server = asyncapiDocument.server(this.templateParams.server);
-        if (!server) throw new Error(`Couldn't find server with name ${this.templateParams.server}.`);
-      }
-
-      if (server && Array.isArray(supportedProtocols) && !supportedProtocols.includes(server.protocol())) {
-        throw new Error(`Server "${this.templateParams.server}" uses the ${server.protocol()} protocol but this template only supports the following ones: ${supportedProtocols}.`);
-      }
-    }
   }
 
   /**

--- a/lib/templateConfigValidator.js
+++ b/lib/templateConfigValidator.js
@@ -1,6 +1,6 @@
 const semver = require('semver');
-const packageJson = require('../package.json');
 const Ajv = require('ajv');
+const { getGeneratorVersion } = require('./utils');
 
 const ajv = new Ajv({ allErrors: true });
 
@@ -14,12 +14,12 @@ const ajv = new Ajv({ allErrors: true });
    */
 module.exports.validateTemplateConfig = (templateConfig, templateParams, asyncapiDocument) => {
   const { parameters, supportedProtocols, conditionalFiles, generator } = templateConfig;
-
+  
+  validateConditionalFiles(conditionalFiles);
   isTemplateCompatible(generator);
 
-  isRequiredParamProvided(templateParams, parameters);
-
-  validateConditionalFiles(conditionalFiles);
+  isRequiredParamProvided(parameters, templateParams);
+  isProvidedParameterSupported(parameters, templateParams);
 
   if (asyncapiDocument) {
     const server = asyncapiDocument.server(templateParams.server);
@@ -36,28 +36,41 @@ module.exports.validateTemplateConfig = (templateConfig, templateParams, asyncap
  * @param {String} generator Information about supported generator version that is part of the template configuration
  */
 function isTemplateCompatible(generator) {
-  if (typeof generator === 'string' && !semver.satisfies(packageJson.version, generator)) {
-    throw new Error(`This template is not compatible with the current version of the generator (${packageJson.version}). This template is compatible with the following version range: ${generator}.`);
+  const generatorVersion = getGeneratorVersion();
+  if (typeof generator === 'string' && !semver.satisfies(generatorVersion, generator)) {
+    throw new Error(`This template is not compatible with the current version of the generator (${generatorVersion}). This template is compatible with the following version range: ${generator}.`);
   }  
 }
 
 /**
  * Checks if parameters described in template configuration as required are passed to the generator
  * @private
+ * @param {Object} configParams Parameters specified in template configuration
  * @param {Object} templateParams All parameters provided to generator 
- * @param {Object} parameters Parameters specified in template configuration
  */
-function isRequiredParamProvided(templateParams, parameters) {
-  if (!parameters) return;
-
-  const requiredParams = Object.keys(parameters || {}).filter(key => parameters[key].required === true);
-  const missingParams = requiredParams.filter(rp => !templateParams[rp]);
-
+function isRequiredParamProvided(configParams, templateParams) {
+  const missingParams = Object.keys(configParams || {})
+    .filter(key => configParams[key].required && !templateParams[key]);
+    
   if (missingParams.length) {
     throw new Error(`This template requires the following missing params: ${missingParams}.`);
   }
 }
 
+/**
+ * Checks if parameters provided to generator is supported by the template
+ * @private
+ * @param {Object} configParams Parameters specified in template configuration
+ * @param {Object} templateParams All parameters provided to generator 
+ */
+function isProvidedParameterSupported(configParams, templateParams) {
+  const wrongParams = Object.keys(templateParams || {}).filter(key => !configParams || !configParams[key]);
+
+  if (wrongParams.length) {
+    console.warn(`Warning: This template doesn't have the following params: ${wrongParams}.`);
+  }
+}
+  
 /**
  * Checks if given AsyncAPI document has servers with protocol that is supported by the template
  * @private

--- a/lib/templateConfigValidator.js
+++ b/lib/templateConfigValidator.js
@@ -1,0 +1,99 @@
+const semver = require('semver');
+const packageJson = require('../package.json');
+const Ajv = require('ajv');
+
+const ajv = new Ajv({ allErrors: true });
+
+/**
+   * Validates the template configuration.
+   *
+   * @param  {Object} templateConfig Template configuration.
+   * @param  {Object} templateParams Params specified when running generator.
+   * @param  {AsyncAPIDocument} asyncapiDocument AsyncAPIDocument object to use as source.
+   * @return {Boolean}
+   */
+module.exports.validateTemplateConfig = (templateConfig, templateParams, asyncapiDocument) => {
+  const { parameters, supportedProtocols, conditionalFiles, generator } = templateConfig;
+
+  isTemplateCompatible(generator);
+
+  isRequiredParamProvided(templateParams, parameters);
+
+  validateConditionalFiles(conditionalFiles);
+
+  if (asyncapiDocument) {
+    const server = asyncapiDocument.server(templateParams.server);
+    isServerProvidedInDocument(server, templateParams.server);
+    isServerProtocolSupported(server, supportedProtocols, templateParams.server);
+  }
+
+  return true;
+};
+
+/**
+ * Checks if template is compatible with the version of the generator that is used
+ * @private
+ * @param {String} generator Information about supported generator version that is part of the template configuration
+ */
+function isTemplateCompatible(generator) {
+  if (typeof generator === 'string' && !semver.satisfies(packageJson.version, generator)) {
+    throw new Error(`This template is not compatible with the current version of the generator (${packageJson.version}). This template is compatible with the following version range: ${generator}.`);
+  }  
+}
+
+/**
+ * Checks if parameters described in template configuration as required are passed to the generator
+ * @private
+ * @param {Object} templateParams All parameters provided to generator 
+ * @param {Object} parameters Parameters specified in template configuration
+ */
+function isRequiredParamProvided(templateParams, parameters) {
+  if (!parameters) return;
+
+  const requiredParams = Object.keys(parameters || {}).filter(key => parameters[key].required === true);
+  const missingParams = requiredParams.filter(rp => !templateParams[rp]);
+
+  if (missingParams.length) {
+    throw new Error(`This template requires the following missing params: ${missingParams}.`);
+  }
+}
+
+/**
+ * Checks if given AsyncAPI document has servers with protocol that is supported by the template
+ * @private
+ * @param {Object} server Server object from AsyncAPI file
+ * @param {String[]} supportedProtocols Supported protocols specified in template configuration
+ * @param {String} paramsServerName Name of the server specified as a param for the generator 
+ */
+function isServerProtocolSupported(server, supportedProtocols, paramsServerName) {
+  if (server && Array.isArray(supportedProtocols) && !supportedProtocols.includes(server.protocol())) {
+    throw new Error(`Server "${paramsServerName}" uses the ${server.protocol()} protocol but this template only supports the following ones: ${supportedProtocols}.`);
+  }
+}
+
+/**
+ * Checks if given AsyncAPI document has servers with protocol that is supported by the template
+ * @private
+ * @param {Object} server Server object from AsyncAPI file
+ * @param {String} paramsServerName Name of the server specified as a param for the generator
+ */
+function isServerProvidedInDocument(server, paramsServerName) {
+  if (typeof paramsServerName === 'string' && !server) throw new Error(`Couldn't find server with name ${paramsServerName}.`);
+}
+
+/**
+ * Checks if conditional files are specified properly in the template
+ * @private
+ * @param {Object} conditionalFiles conditions specified in the template config
+ */
+function validateConditionalFiles(conditionalFiles) {
+  if (typeof conditionalFiles === 'object') {
+    const fileNames = Object.keys(conditionalFiles) || [];
+    fileNames.forEach(fileName => {
+      const def = conditionalFiles[fileName];
+      if (typeof def.subject !== 'string') throw new Error(`Invalid conditional file subject for ${fileName}: ${def.subject}.`);
+      if (typeof def.validation !== 'object') throw new Error(`Invalid conditional file validation object for ${fileName}: ${def.validation}.`);
+      conditionalFiles[fileName].validate = ajv.compile(conditionalFiles[fileName].validation);
+    });
+  }
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -89,12 +89,12 @@ utils.getLocalTemplateDetails = async (templatePath) => {
 /**
  * Fetches an AsyncAPI document from the given URL and return its content as string
  * 
- * @param {String} url URL where the AsyncAPI document is located.
+ * @param {String} link URL where the AsyncAPI document is located.
  * @returns Promise<String>} Content of fetched file.
  */
-utils.fetchSpec = (url) => {
+utils.fetchSpec = (link) => {
   return new Promise((resolve, reject) => {
-    fetch(url)
+    fetch(link)
       .then(res => resolve(res.text()))
       .catch(reject);
   });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,8 @@ const util = require('util');
 const path = require('path');
 const fetch = require('node-fetch');
 const url = require('url');
+const packageJson = require('../package.json');
+
 const utils = module.exports;
 
 utils.lstat = util.promisify(fs.lstat);
@@ -107,3 +109,13 @@ utils.fetchSpec = (url) => {
 utils.isFilePath = (str) => {
   return !url.parse(str).hostname;
 };
+
+/**
+ *  Get version of the generator
+ * 
+ * @returns {String}
+ */
+utils.getGeneratorVersion = () => {
+  return packageJson.version;
+};
+

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -485,44 +485,4 @@ describe('Generator', () => {
       });
     });
   });
-
-  describe('#verifyParameters', () => {
-    it('required parameter is missed', () => {
-      const gen = new Generator('testTemplate', __dirname, {
-        templateParams: {
-          test: true
-        }
-      });
-      const params = {
-        requiredParam: {
-          required: true
-        },
-        test: {
-          required: false
-        }
-      };
-
-      expect(() => {
-        gen.verifyParameters(params);
-      }).toThrow(/requiredParam/);
-    });
-    it('wrong parameter is passed', () => {
-      const gen = new Generator('testTemplate', __dirname, {
-        templateParams: {
-          notExistInConf: true
-        }
-      });
-      const params = {
-        existInConf: {
-          required: false
-        }
-      };
-      console.warn = jest.fn();
-
-      gen.verifyParameters(params);
-
-      expect(console.warn).toBeCalledWith(expect.stringContaining('notExistInConf'));
-      expect(console.warn).toBeCalledWith(expect.not.stringContaining('existInConf'));
-    });
-  });
 });

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -8,6 +8,7 @@ const streetlightYAML = fs.readFileSync(path.resolve(__dirname, './docs/streetli
 jest.mock('../lib/utils');
 jest.mock('../lib/filtersRegistry');
 jest.mock('../lib/hooksRegistry');
+jest.mock('../lib/templateConfigValidator');
 
 describe('Generator', () => {
   describe('constructor', () => {
@@ -44,7 +45,7 @@ describe('Generator', () => {
       expect(gen.output).toStrictEqual('string');
       expect(gen.forceWrite).toStrictEqual(true);
       expect(gen.install).toStrictEqual(true);
-      expect(() => gen.templateParams.test).toThrow('Template parameter "test" has not been defined in the .tp-config.json file. Please make sure it\'s listed there before you use it in your template.');
+      expect(() => gen.templateParams.test).toThrow('Template parameter "test" has not been defined in the package.json file under generator property. Please make sure it\'s listed there before you use it in your template.');
 
       // Mock params on templateConfig so it doesn't fail.
       gen.templateConfig.parameters = { test: {} };
@@ -74,6 +75,7 @@ describe('Generator', () => {
     let util;
     let filtersRegistry;
     let hooksRegistry;
+    let templateConfigValidator;
 
     const mockMethods = (gen) => {
       gen.verifyTargetDir = jest.fn();
@@ -93,6 +95,7 @@ describe('Generator', () => {
       util = require('../lib/utils');
       filtersRegistry = require('../lib/filtersRegistry');
       hooksRegistry = require('../lib/hooksRegistry');
+      templateConfigValidator = require('../lib/templateConfigValidator');
       xfsMock = require('fs.extra');
       const parserMock = require('@asyncapi/parser');
       asyncApiDocumentMock = new parserMock.AsyncAPIDocument();
@@ -110,7 +113,7 @@ describe('Generator', () => {
       expect(gen.loadTemplateConfig).toHaveBeenCalled();
       expect(hooksRegistry.registerHooks).toHaveBeenCalled();
       expect(filtersRegistry.registerFilters).toHaveBeenCalled();
-      expect(gen.validateTemplateConfig).toHaveBeenCalledWith(asyncApiDocumentMock);
+      expect(templateConfigValidator.validateTemplateConfig).toHaveBeenCalled();
       expect(gen.generateDirectoryStructure).toHaveBeenCalledWith(asyncApiDocumentMock);
       expect(gen.launchHook).toHaveBeenCalledWith('generate:after');
 
@@ -132,7 +135,7 @@ describe('Generator', () => {
       expect(gen.loadTemplateConfig).toHaveBeenCalled();
       expect(hooksRegistry.registerHooks).toHaveBeenCalled();
       expect(filtersRegistry.registerFilters).toHaveBeenCalled();
-      expect(gen.validateTemplateConfig).toHaveBeenCalledWith(asyncApiDocumentMock);
+      expect(templateConfigValidator.validateTemplateConfig).toHaveBeenCalled();
       expect(gen.generateDirectoryStructure).toHaveBeenCalledWith(asyncApiDocumentMock);
       expect(gen.launchHook).toHaveBeenCalledWith('generate:after');
 
@@ -153,7 +156,7 @@ describe('Generator', () => {
       expect(gen.loadTemplateConfig).toHaveBeenCalled();
       expect(hooksRegistry.registerHooks).toHaveBeenCalled();
       expect(filtersRegistry.registerFilters).toHaveBeenCalled();
-      expect(gen.validateTemplateConfig).toHaveBeenCalledWith(asyncApiDocumentMock);
+      expect(templateConfigValidator.validateTemplateConfig).toHaveBeenCalled();
       expect(gen.generateDirectoryStructure).toHaveBeenCalledWith(asyncApiDocumentMock);
       expect(gen.launchHook).toHaveBeenCalledWith('generate:after');
 
@@ -175,7 +178,7 @@ describe('Generator', () => {
       expect(gen.loadTemplateConfig).toHaveBeenCalled();
       expect(hooksRegistry.registerHooks).toHaveBeenCalled();
       expect(filtersRegistry.registerFilters).toHaveBeenCalled();
-      expect(gen.validateTemplateConfig).toHaveBeenCalledWith(asyncApiDocumentMock);
+      expect(templateConfigValidator.validateTemplateConfig).toHaveBeenCalled();
       expect(gen.generateDirectoryStructure).toHaveBeenCalledWith(asyncApiDocumentMock);
       expect(gen.launchHook).toHaveBeenCalledWith('generate:after');
 
@@ -199,7 +202,7 @@ describe('Generator', () => {
       expect(gen.loadTemplateConfig).toHaveBeenCalled();
       expect(hooksRegistry.registerHooks).toHaveBeenCalled();
       expect(filtersRegistry.registerFilters).toHaveBeenCalled();
-      expect(gen.validateTemplateConfig).toHaveBeenCalledWith(asyncApiDocumentMock);
+      expect(templateConfigValidator.validateTemplateConfig).toHaveBeenCalled();
       expect(gen.launchHook).toHaveBeenCalledWith('generate:after');
       expect(util.exists).toHaveBeenCalledWith('/path/to/template/nameOfTestTemplate/template/file.js');
       expect(gen.generateFile).toHaveBeenCalledWith(asyncApiDocumentMock, 'file.js', '/path/to/template/nameOfTestTemplate/template');

--- a/test/templateConfigValidator.test.js
+++ b/test/templateConfigValidator.test.js
@@ -84,13 +84,13 @@ describe('Template Configuration Validator', () => {
     const templateConfig  = {
       conditionalFiles: {
         'my/path/to/file.js': {
-          subject: 'server.protocol',
-          validation: 'myprotocol'
+          subject: 'server.url',
+          validation: 'http://example.com'
         }
       }
     };
 
-    expect(() => validateTemplateConfig(templateConfig, templateParams, asyncapiDocument)).toThrow('Invalid conditional file validation object for my/path/to/file.js: myprotocol.');
+    expect(() => validateTemplateConfig(templateConfig, templateParams, asyncapiDocument)).toThrow('Invalid conditional file validation object for my/path/to/file.js: http://example.com.');
   });
 
   it('Validation enrich conditional files object with validate object', () => {

--- a/test/templateConfigValidator.test.js
+++ b/test/templateConfigValidator.test.js
@@ -1,0 +1,112 @@
+const { validateTemplateConfig } = require('../lib/templateConfigValidator');
+const fs = require('fs');
+const path = require('path');
+const streetlightYAML = fs.readFileSync(path.resolve(__dirname, './docs/streetlights.yml'), 'utf8');
+
+describe('Template Configuration Validator', () => {
+  let asyncapiDocument;
+
+  beforeAll(async () => {
+    const { parse } = jest.requireActual('@asyncapi/parser');
+    asyncapiDocument = await parse(streetlightYAML);
+  });
+      
+  it('Validation doesn\'t throw errors if params are not passed and template has no config', () => {
+    const templateParams = {};
+    const templateConfig  = {};
+
+    const isValid = validateTemplateConfig(templateConfig, templateParams, asyncapiDocument);
+
+    expect(isValid).toStrictEqual(true);
+  });
+
+  it('Validation throw error if template is not compatible', () => {
+    const templateParams = {};
+    const templateConfig  = {
+      generator: '>100'
+    };
+
+    expect(() => validateTemplateConfig(templateConfig, templateParams, asyncapiDocument)).toThrow('This template is not compatible with the current version of the generator (0.47.0). This template is compatible with the following version range: >100.');
+  });
+
+  it('Validation throw error if required params not provided', () => {
+    const templateParams = {};
+    const templateConfig  = {
+      parameters: {
+        test: {
+          description: 'test',
+          required: true
+        }
+      }
+    };
+
+    expect(() => validateTemplateConfig(templateConfig, templateParams, asyncapiDocument)).toThrow('This template requires the following missing params: test.');
+  });
+
+  it('Validation throw error if specified server is not in asyncapi document', () => {
+    const templateParams = {
+      server: 'myserver'
+    };
+    const templateConfig  = {};
+
+    expect(() => validateTemplateConfig(templateConfig, templateParams, asyncapiDocument)).toThrow('Couldn\'t find server with name myserver.');
+  });
+
+  it('Validation throw error if given protocol is not supported by template', () => {
+    const templateParams = {
+      server: 'production'
+    };
+    const templateConfig  = {
+      supportedProtocols: ['myprotocol']
+    };
+
+    expect(() => validateTemplateConfig(templateConfig, templateParams, asyncapiDocument)).toThrow('Server \"production\" uses the mqtt protocol but this template only supports the following ones: myprotocol.');
+  });
+
+  it('Validation throw error if subject in condition files is not string', () => {
+    const templateParams = {};
+    const templateConfig  = {
+      conditionalFiles: {
+        'my/path/to/file.js': {
+          subject: ['server.protocol'],
+          validation: {
+            const: 'myprotocol'
+          }
+        }
+      }
+    };
+
+    expect(() => validateTemplateConfig(templateConfig, templateParams, asyncapiDocument)).toThrow('Invalid conditional file subject for my/path/to/file.js: server.protocol.');
+  });
+
+  it('Validation throw error if validation in condition files is not object', () => {
+    const templateParams = {};
+    const templateConfig  = {
+      conditionalFiles: {
+        'my/path/to/file.js': {
+          subject: 'server.protocol',
+          validation: 'myprotocol'
+        }
+      }
+    };
+
+    expect(() => validateTemplateConfig(templateConfig, templateParams, asyncapiDocument)).toThrow('Invalid conditional file validation object for my/path/to/file.js: myprotocol.');
+  });
+
+  it('Validation enrich conditional files object with validate object', () => {
+    const templateParams = {};
+    const templateConfig  = {
+      conditionalFiles: {
+        'my/path/to/file.js': {
+          subject: 'server.protocol',
+          validation: {
+            const: 'myprotocol'
+          }
+        }
+      }
+    };
+    validateTemplateConfig(templateConfig, templateParams, asyncapiDocument);
+
+    expect(templateConfig.conditionalFiles['my/path/to/file.js']).toBeDefined();
+  });
+});


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- `.tp-config.json` is removed and config should be now done under `generator` props in the `package.json` file
- linter didn't like `validateTemplateConfig` as too complex function. Because I was working on config here so I took the liberty to refactor it and move to a separate file + add tests that cover every validation option

**MIGRATION**
This is a breaking change. Migrate by removing current config file and moving its content to `package.json` and bumping version of supported generator to the one released with this PR.
Example -> https://github.com/asyncapi/nodejs-template/pull/15

**Related issue(s)**
Resolves #228 