### PR TITLE
feat: show warning for wrong spelled params

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -718,7 +718,7 @@ class Generator {
 
     const wrongParams = Object.keys(this.templateParams || {}).filter(key => parameters[key] === undefined);
     if (wrongParams.length) {
-      console.warn(`Warning: This template doesn't have following params: ${wrongParams}.`)
+      console.warn(`Warning: This template doesn't have following params: ${wrongParams}.`);
     }
   }
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -718,7 +718,7 @@ class Generator {
 
     const wrongParams = Object.keys(this.templateParams || {}).filter(key => parameters[key] === undefined);
     if (wrongParams.length) {
-      console.warn(`Warning: This template doesn't have following params: ${wrongParams}.`);
+      console.warn(`Warning: This template doesn't have the following params: ${wrongParams}.`);
     }
   }
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -643,7 +643,6 @@ class Generator {
       this.templateConfig = {};
     }
     await this.loadDefaultValues();
-    await this.validateTemplateConfig();
   }
 
   /**
@@ -680,12 +679,7 @@ class Generator {
       throw new Error(`This template is not compatible with the current version of the generator (${packageJson.version}). This template is compatible with the following version range: ${generator}.`);
     }
 
-    const requiredParams = Object.keys(parameters || {}).filter(key => parameters[key].required === true);
-
-    const missingParams = requiredParams.filter(rp => this.templateParams[rp] === undefined);
-    if (missingParams.length) {
-      throw new Error(`This template requires the following missing params: ${missingParams}.`);
-    }
+    this.verifyParameters(parameters);
 
     if (typeof conditionalFiles === 'object') {
       const fileNames = Object.keys(conditionalFiles) || [];
@@ -706,6 +700,25 @@ class Generator {
       if (server && Array.isArray(supportedProtocols) && !supportedProtocols.includes(server.protocol())) {
         throw new Error(`Server "${this.templateParams.server}" uses the ${server.protocol()} protocol but this template only supports the following ones: ${supportedProtocols}.`);
       }
+    }
+  }
+
+  /**
+   * Checks that all required parameters are set and all specified by user parameters are present in template.
+   *
+   * @private
+   * @param  {Array} [parameters] parameters known from template configuration.
+   */
+  verifyParameters(parameters) {
+    const missingParams = Object.keys(parameters || {})
+      .filter(key => parameters[key].required === true && this.templateParams[key] === undefined);
+    if (missingParams.length) {
+      throw new Error(`This template requires the following missing params: ${missingParams}.`);
+    }
+
+    const wrongParams = Object.keys(this.templateParams || {}).filter(key => parameters[key] === undefined);
+    if (wrongParams.length) {
+      console.warn(`Warning: This template doesn't have following params: ${wrongParams}.`)
     }
   }
 

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -466,4 +466,44 @@ describe('Generator', () => {
       });
     });
   });
+
+  describe('#verifyParameters', () => {
+    it('required parameter is missed', () => {
+      const gen = new Generator('testTemplate', __dirname, {
+        templateParams: {
+          test: true
+        }
+      });
+      const params = {
+        requiredParam: {
+          required: true
+        },
+        test: {
+          required: false
+        }
+      };
+
+      expect(() => {
+        gen.verifyParameters(params);
+      }).toThrow(/requiredParam/);
+    });
+    it('wrong parameter is passed', () => {
+      const gen = new Generator('testTemplate', __dirname, {
+        templateParams: {
+          notExistInConf: true
+        }
+      });
+      const params = {
+        existInConf: {
+          required: false
+        }
+      };
+      console.warn = jest.fn();
+
+      gen.verifyParameters(params);
+
+      expect(console.warn).toBeCalledWith(expect.stringContaining('notExistInConf'));
+      expect(console.warn).toBeCalledWith(expect.not.stringContaining('existInConf'));
+    });
+  });
 });


### PR DESCRIPTION
**Description**

- show warning for wrong spelled params

Example:
```bash
ag asyncapi.yaml @asyncapi/html-template -p baseHef=/doc -o output
Warning: This template doesn't have following params: baseHef.
```

**Related issue(s)**
Resolves: #345 
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The 3rd option will not automatically close the issue after the merge. -->