### PR TITLE
feat: suggest possible correct parameter name

### DIFF
--- a/lib/templateConfigValidator.js
+++ b/lib/templateConfigValidator.js
@@ -1,6 +1,7 @@
 const semver = require('semver');
 const Ajv = require('ajv');
 const { getGeneratorVersion } = require('./utils');
+const levenshtein = require('levenshtein-edit-distance')
 
 const ajv = new Ajv({ allErrors: true });
 
@@ -58,6 +59,21 @@ function isRequiredParamProvided(configParams, templateParams) {
 }
 
 /**
+ * Provides a hint for a user about correct parameter name.
+ * @private
+ * @param {Object} wrongParams Incorrectly written parameters
+ * @param {Object} configParams Parameters specified in template configuration
+ */
+function provideAdvice(wrongParams, configParams) {
+  if (configParams) {
+    wrongParams.forEach(wp => console.warn('Did you mean "' + Object.keys(configParams || {})
+      .map(param => [levenshtein(wp, param), param]).sort()[0][1] + '"?'));
+  } else {
+    console.warn('This template doesn\'t have any params!');
+  }
+}
+
+/**
  * Checks if parameters provided to generator is supported by the template
  * @private
  * @param {Object} configParams Parameters specified in template configuration
@@ -68,6 +84,7 @@ function isProvidedParameterSupported(configParams, templateParams) {
 
   if (wrongParams.length) {
     console.warn(`Warning: This template doesn't have the following params: ${wrongParams}.`);
+    provideAdvice(wrongParams, configParams);
   }
 }
   

--- a/lib/templateConfigValidator.js
+++ b/lib/templateConfigValidator.js
@@ -66,8 +66,8 @@ function isRequiredParamProvided(configParams, templateParams) {
  */
 function provideAdvice(wrongParams, configParams) {
   if (configParams) {
-    wrongParams.forEach(wp => console.warn('Did you mean "' + Object.keys(configParams)
-      .map(param => [levenshtein(wp, param), param]).sort()[0][1] + '"?'));
+    wrongParams.forEach(wp => console.warn(`Did you mean "${Object.keys(configParams)
+      .map(param => [levenshtein(wp, param), param]).sort()[0][1]}"?`));
   } else {
     console.warn('This template doesn\'t have any params!');
   }

--- a/lib/templateConfigValidator.js
+++ b/lib/templateConfigValidator.js
@@ -1,7 +1,7 @@
 const semver = require('semver');
 const Ajv = require('ajv');
 const { getGeneratorVersion } = require('./utils');
-const levenshtein = require('levenshtein-edit-distance')
+const levenshtein = require('levenshtein-edit-distance');
 
 const ajv = new Ajv({ allErrors: true });
 
@@ -66,7 +66,7 @@ function isRequiredParamProvided(configParams, templateParams) {
  */
 function provideAdvice(wrongParams, configParams) {
   if (configParams) {
-    wrongParams.forEach(wp => console.warn('Did you mean "' + Object.keys(configParams || {})
+    wrongParams.forEach(wp => console.warn('Did you mean "' + Object.keys(configParams)
       .map(param => [levenshtein(wp, param), param]).sort()[0][1] + '"?'));
   } else {
     console.warn('This template doesn\'t have any params!');

--- a/package-lock.json
+++ b/package-lock.json
@@ -6707,6 +6707,11 @@
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "dev": true
     },
+    "levenshtein-edit-distance": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/levenshtein-edit-distance/-/levenshtein-edit-distance-2.0.5.tgz",
+      "integrity": "sha512-Yuraz7QnMX/JENJU1HA6UtdsbhRzoSFnGpVGVryjQgHtl2s/YmVgmNYkVs5yzVZ9aAvQR9wPBUH3lG755ylxGA=="
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "npmi": "^4.0.0",
     "nunjucks": "^3.2.0",
     "semver": "^7.3.2",
-    "simple-git": "^1.131.0"
+    "simple-git": "^1.131.0",
+    "levenshtein-edit-distance": "^2.0.5"
   },
   "devDependencies": {
     "@semantic-release/commit-analyzer": "^8.0.1",

--- a/test/templateConfigValidator.test.js
+++ b/test/templateConfigValidator.test.js
@@ -62,6 +62,7 @@ describe('Template Configuration Validator', () => {
     };
     validateTemplateConfig(templateConfig, templateParams);
     expect(console.warn).toHaveBeenCalledWith('Warning: This template doesn\'t have the following params: test1.');
+    expect(console.warn).toHaveBeenCalledWith('Did you mean "test"?');
   });
 
   it('Validation throw error if provided param is not supported by the template as template has no params specified', () => {
@@ -73,6 +74,7 @@ describe('Template Configuration Validator', () => {
 
     validateTemplateConfig(templateConfig, templateParams);
     expect(console.warn).toHaveBeenCalledWith('Warning: This template doesn\'t have the following params: test1.');
+    expect(console.warn).toHaveBeenCalledWith('This template doesn\'t have any params!');
   });
 
   it('Validation throw error if specified server is not in asyncapi document', () => {


### PR DESCRIPTION
**Description**

- generator will provide a hint to a user about most likely parameter name

Usage
```bash
ag asyncapi.yaml @asyncapi/html-template -p baseHef=/doc -o output
Warning: This template doesn't have following params: baseHef.
Did you mean "baseHref"?
```

**Related issue(s)**
Resolves: #351 
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The 3rd option will not automatically close the issue after the merge. -->