### PR TITLE
fix: update cli Generator forceInstall parameter to install

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -142,7 +142,7 @@ function generate(targetDir) {
         noOverwriteGlobs,
         disabledHooks,
         forceWrite: program.forceWrite,
-        forceInstall: program.install,
+        install: program.install,
         debug: program.debug
       });
 

--- a/lib/__mocks__/utils.js
+++ b/lib/__mocks__/utils.js
@@ -1,4 +1,7 @@
 const utils = jest.genMockFromModule('../utils');
+const { getInvalidOptions } = require.requireActual('../utils');
+
+utils.getInvalidOptions = getInvalidOptions;
 
 utils.__files = {};
 utils.readFile = jest.fn(async (filePath) => {

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -23,7 +23,8 @@ const {
   writeFile,
   copyFile,
   exists,
-  fetchSpec
+  fetchSpec,
+  getInvalidOptions
 } = require('./utils');
 const { registerFilters } = require('./filtersRegistry');
 const { registerHooks } = require('./hooksRegistry');
@@ -45,6 +46,7 @@ const PACKAGE_JSON_FILENAME = 'package.json';
 const ROOT_DIR = path.resolve(__dirname, '..');
 const DEFAULT_TEMPLATES_DIR = path.resolve(ROOT_DIR, 'node_modules');
 const TEMPLATE_CONTENT_DIRNAME = 'template';
+const GENERATOR_OPTIONS = ['debug', 'disabledHooks', 'entrypoint', 'forceWrite', 'install', 'noOverwriteGlobs', 'output', 'templateParams'];
 
 const shouldIgnoreFile = filePath =>
   filePath.startsWith(`.git${path.sep}`);
@@ -82,10 +84,12 @@ class Generator {
    * @param {Boolean} [options.debug=false] Enable more specific errors in the console. At the moment it only shows specific errors about filters. Keep in mind that as a result errors about template are less descriptive.
    */
   constructor(templateName, targetDir, { templateParams = {}, entrypoint, noOverwriteGlobs, disabledHooks, output = 'fs', forceWrite = false, install = false, debug = false } = {}) {
+    const invalidOptions = getInvalidOptions(GENERATOR_OPTIONS, arguments[arguments.length - 1] || []);
+    if (invalidOptions.length) throw new Error(`These options are not supported by the generator: ${invalidOptions.join(', ')}`);
     if (!templateName) throw new Error('No template name has been specified.');
     if (!entrypoint && !targetDir) throw new Error('No target directory has been specified.');
     if (!['fs', 'string'].includes(output)) throw new Error(`Invalid output type ${output}. Valid values are 'fs' and 'string'.`);
-    
+
     /** @type {String} Name of the template to generate. */
     this.templateName = templateName;
     /** @type {String} Path to the directory where the files will be generated. */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -119,3 +119,13 @@ utils.getGeneratorVersion = () => {
   return packageJson.version;
 };
 
+/**
+ * Filters out the Generator invalid options given
+ *
+ * @param {Array}
+ * @returns {Array}
+ */
+utils.getInvalidOptions = (generatorOptions, options) => {
+  if (typeof options !== 'object') return [];
+  return Object.keys(options).filter(param => !generatorOptions.includes(param));
+};

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -53,6 +53,36 @@ describe('Generator', () => {
       expect(gen.templateParams.test).toStrictEqual(true);
     });
 
+    it('throws an error indicating an unexpected param was given', () => {
+      const t = () => new Generator('testTemplate', __dirname, {
+        entrypoint: 'test-entrypoint',
+        noOverwriteGlobs: ['test-globs'],
+        disabledHooks: ['test-hooks'],
+        output: 'string',
+        forceWrite: true,
+        forceInstall: true,
+        templateParams: {
+          test: true,
+        }
+      });
+      expect(t).toThrow('These options are not supported by the generator: forceInstall');
+    });
+
+    it('throws an error indicating multiple unexpected params were given', () => {
+      const t = () => new Generator('testTemplate', __dirname, {
+        entrypoint: 'test-entrypoint',
+        noOverwriteGlobs: ['test-globs'],
+        disabledHooks: ['test-hooks'],
+        output: 'string',
+        write: true,
+        forceInstall: true,
+        templateParams: {
+          test: true,
+        }
+      });
+      expect(t).toThrow('These options are not supported by the generator: write, forceInstall');
+    });
+
     it('fails if no templateName is given', () => {
       const t = () => new Generator();
       expect(t).toThrow('No template name has been specified.');


### PR DESCRIPTION
This is a very small change. As the cli instantiates a new `Generator` object with the given parameters, it uses `forceInstall` as the option to install the given template or not. But in the generator file the constructor definition it's done by deconstructing the third argument and the argument for installing the template is `forceInstall` not `install`.

So, no matter if you specify you want to install the template, `Generator.install` is always `false`.

I could've modified all the matches to `forceInstall` to make it clear you want to force the installation of the template, but I don't know if that's the case - as `forceWrite` is indeed forcing to write the changes. I better modified a single line to make the `forceInstall` option to be just `install`.

I noticed this "failed" silently as the cli file isn't tested, which makes me ask, would it be better to add full coverage to that file in order to merge this? Or, would it be easier to add a guard clause in the `Generator` constructor body to return if it receives an unexpected parameter (I think it'd be easier)?

By the way, thanks for this amazing tool.