### PR TITLE
fix: sorting issue for suggested params

### DIFF
--- a/lib/templateConfigValidator.js
+++ b/lib/templateConfigValidator.js
@@ -65,9 +65,17 @@ function isRequiredParamProvided(configParams, templateParams) {
  * @param {Object} configParams Parameters specified in template configuration
  */
 function provideAdvice(wrongParams, configParams) {
+  const suggestion = (p) => {
+    const sortInt = (a, b) => {
+      return a[0] - b[0];
+    };
+    const arr = Object.keys(configParams).map(param => [levenshtein(p, param), param]);
+
+    return arr.sort(sortInt)[0][1];
+  };
+  
   if (configParams) {
-    wrongParams.forEach(wp => console.warn(`Did you mean "${Object.keys(configParams)
-      .map(param => [levenshtein(wp, param), param]).sort()[0][1]}"?`));
+    wrongParams.forEach(wp => console.warn(`Did you mean "${suggestion(wp)}"?`));
   } else {
     console.warn('This template doesn\'t have any params!');
   }

--- a/test/templateConfigValidator.test.js
+++ b/test/templateConfigValidator.test.js
@@ -51,17 +51,20 @@ describe('Template Configuration Validator', () => {
   it('Validation throw error if provided param is not in the list of params supported by the template', () => {
     console.warn = jest.fn();
     const templateParams = {
-      test1: 'myTest'
+      tsets: 'myTest'
     };
     const templateConfig  = {
       parameters: {
         test: {
-          description: 'test'
+          description: 'this param distance to test1 equals 3 according to levenshtein-edit-distance'
+        },
+        thisissomethingsodifferent: {
+          description: 'this param distance to test1 equals 21 according to levenshtein-edit-distance'
         }
       }
     };
     validateTemplateConfig(templateConfig, templateParams);
-    expect(console.warn).toHaveBeenCalledWith('Warning: This template doesn\'t have the following params: test1.');
+    expect(console.warn).toHaveBeenCalledWith('Warning: This template doesn\'t have the following params: tsets.');
     expect(console.warn).toHaveBeenCalledWith('Did you mean "test"?');
   });
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- by default `sort()` takes number into string, so in case 3 and 11, 11 is first. I added custom sort comparison and extended tests