### PR TITLE
refactor: add missing config for templates list checker

### DIFF
--- a/.github/templates-list-validator/action.yml
+++ b/.github/templates-list-validator/action.yml
@@ -1,0 +1,9 @@
+name: 'Templates list validator'
+description: 'Use this action to generate docs or code from your AsyncAPI document. Use default templates or provide your custom ones.'
+inputs:
+  token: 
+    description: 'GitHub Token used to call GitHub API for list of templates'
+    required: true
+runs:
+  using: 'node12'
+  main: 'dist/index.js'


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Templates list checker fails as I did not provide `action.yml`. I forgot it is also needed for actions that are not going to the marketplace