### PR TITLE
chore: generator templates support prereleases

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,9 @@
 test/
 .DS_Store
 *.swp
+.github
+lib/__mocks__
+.all-contributorsrc
+.dockerignore
+.editorconfig
+jest.config.js

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ ag asyncapi.yaml @asyncapi/html-template
 
 **Generating from a URL:**
 ```bash
-ag https://raw.githubusercontent.com/asyncapi/asyncapi/2.0.0/examples/2.0.0/streetlights.yml @asyncapi/html-template
+ag https://bit.ly/asyncapi @asyncapi/html-template
 ```
 
 **Specify where to put the result:**

--- a/lib/templateConfigValidator.js
+++ b/lib/templateConfigValidator.js
@@ -39,7 +39,7 @@ module.exports.validateTemplateConfig = (templateConfig, templateParams, asyncap
  */
 function isTemplateCompatible(generator) {
   const generatorVersion = getGeneratorVersion();
-  if (typeof generator === 'string' && !semver.satisfies(generatorVersion, generator)) {
+  if (typeof generator === 'string' && !semver.satisfies(generatorVersion, generator, {includePrerelease: true})) {
     throw new Error(`This template is not compatible with the current version of the generator (${generatorVersion}). This template is compatible with the following version range: ${generator}.`);
   }  
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/generator",
-  "version": "0.53.1",
+  "version": "1.0.0-rc.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/generator",
-  "version": "0.53.1",
+  "version": "1.0.0-rc.2",
   "description": "The AsyncAPI generator. It can generate documentation, code, anything!",
   "main": "./lib/generator.js",
   "bin": {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- this is chore PR as rc2 must be pushed manually, I will not do it until this is not merged
- allowing prerelases with this merge

**Related issue(s)**
rc1 doesn't work
`Error: This template is not compatible with the current version of the generator (1.0.0-rc.1). This template is compatible with the following version range: >=0.50.0 <2.0.0.`