### PR TITLE
Rename {.gitignore} and {.npmignore}

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -44,6 +44,8 @@ const FILTERS_DIRNAME = 'filters';
 const HOOKS_DIRNAME = 'hooks';
 const CONFIG_FILENAME = 'package.json';
 const PACKAGE_JSON_FILENAME = 'package.json';
+const GIT_IGNORE_FILENAME = '{.gitignore}';
+const NPM_IGNORE_FILENAME = '{.npmignore}';
 const ROOT_DIR = path.resolve(__dirname, '..');
 const DEFAULT_TEMPLATES_DIR = path.resolve(ROOT_DIR, 'node_modules');
 const TEMPLATE_CONTENT_DIRNAME = 'template';
@@ -164,7 +166,7 @@ class Generator {
     }
 
     if (this.debug) log.setLevel('debug');
-    
+
     const { name: templatePkgName, path: templatePkgPath } = await this.installTemplate(this.install);
     this.templateDir = templatePkgPath;
     this.templateName = templatePkgName;
@@ -548,7 +550,7 @@ class Generator {
   async generateFile(asyncapiDocument, fileName, baseDir) {
     const sourceFile = path.resolve(baseDir, fileName);
     const relativeSourceFile = path.relative(this.templateContentDir, sourceFile);
-    const targetFile = path.resolve(this.targetDir, relativeSourceFile);
+    const targetFile = path.resolve(this.targetDir, this.maybeRenameSourceFile(relativeSourceFile));
     const relativeTargetFile = path.relative(this.targetDir, targetFile);
 
     if (shouldIgnoreFile(relativeSourceFile)) return;
@@ -564,7 +566,7 @@ class Generator {
           server: server ? server.json() : undefined,
         },
       }, this.templateConfig.conditionalFiles[relativeSourceFile].subject);
-      
+
       if (!source) return log.debug(`${relativeSourceFile} was not generated because ${this.templateConfig.conditionalFiles[relativeSourceFile].subject} specified in template configuration in conditionalFiles was not found in provided AsyncAPI specification file`);
 
       if (source) {
@@ -578,6 +580,21 @@ class Generator {
     const parsedContent = await this.renderFile(asyncapiDocument, sourceFile);
     const stats = fs.statSync(sourceFile);
     await writeFile(targetFile, parsedContent, { encoding: 'utf8', mode: stats.mode });
+  }
+
+  /**
+   * It may rename the source file name in cases where special names are not supported, like .gitignore or .npmignore.
+   * @param {String} sourceFile Path to the source file
+   */
+  maybeRenameSourceFile(sourceFile) {
+    switch (path.basename(sourceFile)) {
+    case GIT_IGNORE_FILENAME:
+      return path.resolve(path.dirname(sourceFile), '.gitignore');
+    case NPM_IGNORE_FILENAME:
+      return path.resolve(path.dirname(sourceFile), '.npmignore');
+    default:
+      return sourceFile;
+    }
   }
 
   /**

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -551,6 +551,7 @@ class Generator {
     const sourceFile = path.resolve(baseDir, fileName);
     const relativeSourceFile = path.relative(this.templateContentDir, sourceFile);
     const targetFile = path.resolve(this.targetDir, this.maybeRenameSourceFile(relativeSourceFile));
+    console.log(targetFile);
     const relativeTargetFile = path.relative(this.targetDir, targetFile);
 
     if (shouldIgnoreFile(relativeSourceFile)) return;
@@ -589,9 +590,9 @@ class Generator {
   maybeRenameSourceFile(sourceFile) {
     switch (path.basename(sourceFile)) {
     case GIT_IGNORE_FILENAME:
-      return path.resolve(path.dirname(sourceFile), '.gitignore');
+      return path.join(path.dirname(sourceFile), '.gitignore');
     case NPM_IGNORE_FILENAME:
-      return path.resolve(path.dirname(sourceFile), '.npmignore');
+      return path.join(path.dirname(sourceFile), '.npmignore');
     default:
       return sourceFile;
     }

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -551,7 +551,6 @@ class Generator {
     const sourceFile = path.resolve(baseDir, fileName);
     const relativeSourceFile = path.relative(this.templateContentDir, sourceFile);
     const targetFile = path.resolve(this.targetDir, this.maybeRenameSourceFile(relativeSourceFile));
-    console.log(targetFile);
     const relativeTargetFile = path.relative(this.targetDir, targetFile);
 
     if (shouldIgnoreFile(relativeSourceFile)) return;
@@ -585,7 +584,11 @@ class Generator {
 
   /**
    * It may rename the source file name in cases where special names are not supported, like .gitignore or .npmignore.
+   *
+   * Since we're using npm to install templates, these files are never downloaded (that's npm behavior we can't change).
+   * @private
    * @param {String} sourceFile Path to the source file
+   * @returns {String} New path name
    */
   maybeRenameSourceFile(sourceFile) {
     switch (path.basename(sourceFile)) {


### PR DESCRIPTION
Since we're using npm to install templates, files like `.gitignore` and `.npmignore` are never downloaded (that's npm behavior we can't change).

Therefore, the only solution is to have templates rename `.gitignore` and `.npmignore` files to something different that npm will not understand. I chose `{.gitignore}` and `{.npmignore}` respectively. It's now the job of the Generator to rename them to become `.gitignore` and `.npmignore`.