### PR TITLE
refactor: Use official release in Dockerfile instead of sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,9 @@ RUN apk --update add git && \
     rm -rf /var/lib/apt/lists/* && \
     rm /var/cache/apk/*
 
-# Install dependencies
-COPY package*.json ./
-
 # Installing latest version of npm 6. The one packaged with node:12.16.1-alpine3.11 has a bug.
 RUN npm install -g npm@6
-RUN npm install
 
-# Copy sources
-COPY . .
+RUN npm install -g @asyncapi/generator
 
-ENTRYPOINT [ "node", "/app/cli" ]
+ENTRYPOINT [ "ag" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apk --update add git && \
 # Installing latest version of npm 6. The one packaged with node:12.16.1-alpine3.11 has a bug.
 RUN npm install -g npm@6
 
+# Installing latest released npm package
 RUN npm install -g @asyncapi/generator
 
 ENTRYPOINT [ "ag" ]

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ You might want to update your local installation of generator for different reas
 ### CLI usage
 
 ```bash
-Usage: cli [options] <asyncapi> <template>
+Usage: ag [options] <asyncapi> <template>
 
 - <asyncapi>: Local path or URL pointing to AsyncAPI specification file
 - <template>: Name of the generator template like for example @asyncapi/html-template or https://github.com/asyncapi/html-template

--- a/README.md
+++ b/README.md
@@ -178,11 +178,12 @@ docker run --rm -it \
 -v [ASYNCAPI SPEC FILE LOCATION]:/app/asyncapi.yml \
 -v [GENERATED FILES LOCATION]:/app/output \
 asyncapi/generator [COMMAND HERE]
+
 # Example that you can run inside generator directory after cloning this repository. First you specify mount in location of your AsyncAPI specification file and then you mount in directory where generation result should be saved.
 docker run --rm -it \
 -v ${PWD}/test/docs/dummy.yml:/app/asyncapi.yml \
 -v ${PWD}/output:/app/output \
-asyncapi/generator -o ./output asyncapi.yml @asyncapi/html-template --force-write
+asyncapi/generator -o /app/output /app/asyncapi.yml @asyncapi/html-template --force-write
 ```
 
 ### CLI usage with npx instead of npm


### PR DESCRIPTION
**Description**

- Adjusted the Dockerfile so that it uses the official npm package instead of building from local source code.
- Updated the README accordingly (+ found a small inconsistency in a code example for the cli)

**Related issue(s)**
Resolves #399 