### PR TITLE
refactor: Moved function from watcher before the for loop (#416)

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -23,15 +23,25 @@ class Watcher {
   }
 
   /**
+   * Initiates watch on a path.
+   * @param {*} path The path the watcher is listening on.
+   * @param {*} changeCallback Callback to call when changed occur.
+   * @param {*} errorCallback Calback to call when it is no longer possible to watch a file.
+   */
+  initiateWatchOnPath(path, changeCallback, errorCallback) {
+    const watcher = chokidar.watch(path, {ignoreInitial: true, ignored: this.ignorePath});
+    watcher.on('all', (eventType, changedPath) => this.fileChanged(path, changedPath, eventType, changeCallback, errorCallback));
+    this.watchers[path] = watcher;
+  }
+
+  /**
    * This method initiate the watch for change in all files
    * @param {*} callback called when the file(s) change
    */
   async watch(changeCallback, errorCallback) {
     for (const index in this.paths) {
       const path = this.paths[index];
-      const watcher = chokidar.watch(path, {ignoreInitial: true, ignored: this.ignorePath});
-      watcher.on('all', (eventType, changedPath) => this.fileChanged(path, changedPath, eventType, changeCallback, errorCallback));
-      this.watchers[path] = watcher;
+      this.initiateWatchOnPath(path, changeCallback, errorCallback);
     }
   }
 


### PR DESCRIPTION
**Description**
This should fix SonarCloud issue:

`Defining a function inside of a loop can yield unexpected results. Such a function keeps references to the variables which are 
defined in outer scopes. All function instances created inside the loop therefore see the same values for these variables, which is 
probably not expected.`

**Related issue(s)**
#416