### PR TITLE
chore: disable specific hook function(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Options:
   --debug                        enable more specific errors in the console
   -i, --install                  installs the template and its dependencies (defaults to false)
   -n, --no-overwrite <glob>      glob or path of the file(s) to skip when regenerating
-  -o, --output <outputDir>       directory where to put the generated files (defaults to current directory) (default: "C:\\AsyncAPI\\generator")
+  -o, --output <outputDir>       directory where to put the generated files (defaults to current directory)
   -p, --param <name=value>       additional param to pass to templates
   --force-write                  force writing of the generated files to given directory even if it is a git repo with unstaged files or not empty dir (defaults to false)
   --watch-template               watches the template directory and the AsyncAPI document, and re-generate the files when changes occur. Ignores the output directory. This flag should be used only for template development.
@@ -158,7 +158,7 @@ ag asyncapi.yaml @asyncapi/html-template -o ./docs -p title='Hello from param'
 
 In the template you can use it like this: ` {{ params.title }}`
 
-**Disable the given hooks:**
+**Disabling the hooks:**
 ```bash
 ag asyncapi.yaml @asyncapi/html-template -o ./docs -d generate:before generate:after=foo,bar
 ```

--- a/README.md
+++ b/README.md
@@ -105,15 +105,15 @@ Usage: ag [options] <asyncapi> <template>
 
 Options:
   -V, --version                  output the version number
-  -d, --disable-hook <hookType>  disable a specific hook type
-  --debug                        enable more specific errors in the console.
+  -d, --disable-hook [hooks...]  disable a specific hook type or hooks from given hook type
+  --debug                        enable more specific errors in the console
   -i, --install                  installs the template and its dependencies (defaults to false)
   -n, --no-overwrite <glob>      glob or path of the file(s) to skip when regenerating
-  -o, --output <outputDir>       directory where to put the generated files (defaults to current directory)
+  -o, --output <outputDir>       directory where to put the generated files (defaults to current directory) (default: "C:\\AsyncAPI\\generator")
   -p, --param <name=value>       additional param to pass to templates
   --force-write                  force writing of the generated files to given directory even if it is a git repo with unstaged files or not empty dir (defaults to false)
-  --watch-template               watches the template directory and the AsyncAPI specification file, and re-generate the files when changes occur. Ignores the output directory. This flag should be used only for template development.
-  -h, --help                     output usage information
+  --watch-template               watches the template directory and the AsyncAPI document, and re-generate the files when changes occur. Ignores the output directory. This flag should be used only for template development.
+  -h, --help                     display help for command
 ```
 
 <details>
@@ -155,7 +155,15 @@ ag asyncapi.yaml @asyncapi/html-template -o ./docs
 ```bash
 ag asyncapi.yaml @asyncapi/html-template -o ./docs -p title='Hello from param'
 ```
+
 In the template you can use it like this: ` {{ params.title }}`
+
+**Disable the given hooks:**
+```bash
+ag asyncapi.yaml @asyncapi/html-template -o ./docs -d generate:before generate:after=foo,bar
+```
+
+The generator skips all hooks of the `generate:before` type and `foo`, `bar` hooks of the `generate:after` type.
 
 **Installing the template from a folder:**
 ```bash

--- a/cli.js
+++ b/cli.js
@@ -55,7 +55,7 @@ const showErrorAndExit = err => {
 program
   .version(packageInfo.version)
   .arguments('<asyncapi> <template>')
-  .action((fileLoc, tmpl, ...rest) => {
+  .action((fileLoc, tmpl) => {
     asyncapiDocPath = fileLoc;
     template = tmpl;
   })

--- a/cli.js
+++ b/cli.js
@@ -76,9 +76,6 @@ if (!asyncapiDocPath) {
 const isAsyncapiDocLocal = isFilePath(asyncapiDocPath);
 
 xfs.mkdirp(program.output, async err => {
-  console.log(disabledHooks);
-  return;
-
   if (err) return showErrorAndExit(err);
   try {
     await generate(program.output);

--- a/cli.js
+++ b/cli.js
@@ -33,7 +33,7 @@ const noOverwriteParser = v => noOverwriteGlobs.push(v);
 
 const disableHooksParser = v => {
   const [hookType, hookNames] = v.split(/=/);
-  if (!hookType) throw new Error(`Invalid --disable-hook flag. It must be in the format of: --disable-hook <hookType> or --disable-hook <hookType>=<hookName1>,<hookName2>,...`);
+  if (!hookType) throw new Error('Invalid --disable-hook flag. It must be in the format of: --disable-hook <hookType> or --disable-hook <hookType>=<hookName1>,<hookName2>,...');
   if (hookNames) {
     disabledHooks[hookType] = hookNames.split(/,/);
   } else {

--- a/cli.js
+++ b/cli.js
@@ -33,7 +33,7 @@ const noOverwriteParser = v => noOverwriteGlobs.push(v);
 
 const disableHooksParser = v => {
   const [hookType, hookNames] = v.split(/=/);
-  if (!hookType) throw new Error(`Invalid --disable-hook flag. It must be not empty.`);
+  if (!hookType) throw new Error(`Invalid --disable-hook flag. It must be in the format of: --disable-hook <hookType> or --disable-hook <hookType>=<hookName1>,<hookName2>,...`);
   if (hookNames) {
     disabledHooks[hookType] = hookNames.split(/,/);
   } else {
@@ -59,7 +59,7 @@ program
     asyncapiDocPath = fileLoc;
     template = tmpl;
   })
-  .option('-d, --disable-hook <hookType?=hookNames>', 'disable a specific hook type', disableHooksParser)
+  .option('-d, --disable-hook [hooks...]', 'disable a specific hook type or hooks from given hook type', disableHooksParser)
   .option('--debug', 'enable more specific errors in the console')
   .option('-i, --install', 'installs the template and its dependencies (defaults to false)')
   .option('-n, --no-overwrite <glob>', 'glob or path of the file(s) to skip when regenerating', noOverwriteParser)
@@ -76,6 +76,9 @@ if (!asyncapiDocPath) {
 const isAsyncapiDocLocal = isFilePath(asyncapiDocPath);
 
 xfs.mkdirp(program.output, async err => {
+  console.log(disabledHooks);
+  return;
+
   if (err) return showErrorAndExit(err);
   try {
     await generate(program.output);

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -754,11 +754,11 @@ class Generator {
     const disabledHooks = this.disabledHooks[hookName] || [];
     if (disabledHooks === true) return;
 
-    const hookNames = this.hooks[hookName];
-    if (!Array.isArray(hookNames)) return;
-    const promises = hookNames.map(async (hook) => {
+    const hooks = this.hooks[hookName];
+    if (!Array.isArray(hooks)) return;
+    const promises = hooks.map(async (hook) => {
       if (typeof hook !== 'function') return;
-      if (disabledHooks.includes(hook)) return;
+      if (disabledHooks.includes(hook.name)) return;
       return await hook(this, hookArguments);
     }).filter(Boolean);
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -75,7 +75,7 @@ class Generator {
    * @param {String} [options.templateParams]   Optional parameters to pass to the template. Each template define their own params.
    * @param {String} [options.entrypoint]       Name of the file to use as the entry point for the rendering process. Use in case you want to use only a specific template file. Note: this potentially avoids rendering every file in the template.
    * @param {String[]} [options.noOverwriteGlobs] List of globs to skip when regenerating the template.
-   * @param {Object<String, Boolean | String | String[]>} [options.disabledHooks] Object with hooks to disable. The key is a hook type. If key has "true" value, then the generator skips all hooks from the given type. If the key is a string with the name of a single hook, then the generator skips only this single hook name. If the key is an array of strings, then the generator skips only hooks from the array.
+   * @param {Object<String, Boolean | String | String[]>} [options.disabledHooks] Object with hooks to disable. The key is a hook type. If key has "true" value, then the generator skips all hooks from the given type. If the value associated with a key is a string with the name of a single hook, then the generator skips only this single hook name. If the value associated with a key is an array of strings, then the generator skips only hooks from the array.
    * @param {String} [options.output='fs'] Type of output. Can be either 'fs' (default) or 'string'. Only available when entrypoint is set.
    * @param {Boolean} [options.forceWrite=false] Force writing of the generated files to given directory even if it is a git repo with unstaged files or not empty dir. Default is set to false.
    * @param {Boolean} [options.install=false] Install the template and its dependencies, even when the template has already been installed.
@@ -96,7 +96,7 @@ class Generator {
     this.entrypoint = entrypoint;
     /** @type {String[]} List of globs to skip when regenerating the template. */
     this.noOverwriteGlobs = noOverwriteGlobs || [];
-    /** @type {Object<String, Boolean | String | String[]>} Object with hooks to disable. The key is a hook type. If key has "true" value, then the generator skips all hooks from the given type. If the key is a string with the name of a single hook, then the generator skips only this single hook name. If the key is an array of strings, then the generator skips only hooks from the array. */
+    /** @type {Object<String, Boolean | String | String[]>} Object with hooks to disable. The key is a hook type. If key has "true" value, then the generator skips all hooks from the given type. If the value associated with a key is a string with the name of a single hook, then the generator skips only this single hook name. If the value associated with a key is an array of strings, then the generator skips only hooks from the array. */
     this.disabledHooks = disabledHooks || {};
     /** @type {String} Type of output. Can be either 'fs' (default) or 'string'. Only available when entrypoint is set. */
     this.output = output;
@@ -753,9 +753,7 @@ class Generator {
   async launchHook(hookName, hookArguments) {
     let disabledHooks = this.disabledHooks[hookName] || [];
     if (disabledHooks === true) return;
-    if (typeof disabledHooks === 'string') {
-      disabledHooks = [disabledHooks];
-    }
+    if (typeof disabledHooks === 'string') disabledHooks = [disabledHooks];
 
     const hooks = this.hooks[hookName];
     if (!Array.isArray(hooks)) return;
@@ -771,27 +769,20 @@ class Generator {
   /**
    * Check if any hooks are available
    *
-   * @param {string} hookType
    * @param {string} hookName
    * @private
    */
-  isHookAvailable(hookType, hookName = '') {
-    const hooks = this.hooks[hookType];
-    let disabledHooks = this.disabledHooks[hookType] || [];
+  isHookAvailable(hookName) {
+    const hooks = this.hooks[hookName];
 
-    if (disabledHooks === true
+    if (this.disabledHooks[hookName] === true
       || !Array.isArray(hooks)
       || hooks.length === 0) return false;
 
-    if (!hookName) return true;
-    
-    if (typeof disabledHooks === 'string') {
-      disabledHooks = [disabledHooks];
-    }
-    if (disabledHooks.includes(hookName)) return false;
+    let disabledHooks = this.disabledHooks[hookName] || [];
+    if (typeof disabledHooks === 'string') disabledHooks = [disabledHooks];
 
-    if (hooks.some(hook => hook.name === hookName)) return true;
-    return false;
+    return !!hooks.filter(h => !disabledHooks.includes(h.name)).length;
   }
 
   /**

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -75,7 +75,7 @@ class Generator {
    * @param {String} [options.templateParams]   Optional parameters to pass to the template. Each template define their own params.
    * @param {String} [options.entrypoint]       Name of the file to use as the entry point for the rendering process. Use in case you want to use only a specific template file. Note: this potentially avoids rendering every file in the template.
    * @param {String[]} [options.noOverwriteGlobs] List of globs to skip when regenerating the template.
-   * @param {Object<String, Boolean | String[]>} [options.disabledHooks] Object with hooks to disable. The field is a hook type. If field has "true" value, then generator skip all hooks from given type. If field is array of strings, then generator skip only hooks from array. 
+   * @param {Object<String, Boolean | String[]>} [options.disabledHooks] Object with hooks to disable. The field is a hook type. If field has "true" value, then generator skips all hooks from given type. If field is array of strings, then generator skips only hooks from array. 
    * @param {String} [options.output='fs'] Type of output. Can be either 'fs' (default) or 'string'. Only available when entrypoint is set.
    * @param {Boolean} [options.forceWrite=false] Force writing of the generated files to given directory even if it is a git repo with unstaged files or not empty dir. Default is set to false.
    * @param {Boolean} [options.install=false] Install the template and its dependencies, even when the template has already been installed.
@@ -96,7 +96,7 @@ class Generator {
     this.entrypoint = entrypoint;
     /** @type {String[]} List of globs to skip when regenerating the template. */
     this.noOverwriteGlobs = noOverwriteGlobs || [];
-    /** @type {Object<String, Boolean | String[]>} Object with hooks to disable. The field is a hook type. If field has "true" value, then generator skip all hooks from given type. If field is array of strings, then generator skip only hooks from array. */
+    /** @type {Object<String, Boolean | String[]>} Object with hooks to disable. The field is a hook type. If field has "true" value, then generator skips all hooks from given type. If field is array of strings, then generator skips only hooks from array. */
     this.disabledHooks = disabledHooks || {};
     /** @type {String} Type of output. Can be either 'fs' (default) or 'string'. Only available when entrypoint is set. */
     this.output = output;

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -75,7 +75,7 @@ class Generator {
    * @param {String} [options.templateParams]   Optional parameters to pass to the template. Each template define their own params.
    * @param {String} [options.entrypoint]       Name of the file to use as the entry point for the rendering process. Use in case you want to use only a specific template file. Note: this potentially avoids rendering every file in the template.
    * @param {String[]} [options.noOverwriteGlobs] List of globs to skip when regenerating the template.
-   * @param {String[]} [options.disabledHooks] List of hook types to disable.
+   * @param {Object<String, Boolean | String[]>} [options.disabledHooks] Object with hooks to disable. The field is a hook type. If field has "true" value, then generator skip all hooks from given type. If field is array of strings, then generator skip only hooks from array. 
    * @param {String} [options.output='fs'] Type of output. Can be either 'fs' (default) or 'string'. Only available when entrypoint is set.
    * @param {Boolean} [options.forceWrite=false] Force writing of the generated files to given directory even if it is a git repo with unstaged files or not empty dir. Default is set to false.
    * @param {Boolean} [options.install=false] Install the template and its dependencies, even when the template has already been installed.
@@ -96,8 +96,8 @@ class Generator {
     this.entrypoint = entrypoint;
     /** @type {String[]} List of globs to skip when regenerating the template. */
     this.noOverwriteGlobs = noOverwriteGlobs || [];
-    /** @type {String[]} List of hooks to disable. */
-    this.disabledHooks = disabledHooks || [];
+    /** @type {Object<String, Boolean | String[]>} Object with hooks to disable. The field is a hook type. If field has "true" value, then generator skip all hooks from given type. If field is array of strings, then generator skip only hooks from array. */
+    this.disabledHooks = disabledHooks || {};
     /** @type {String} Type of output. Can be either 'fs' (default) or 'string'. Only available when entrypoint is set. */
     this.output = output;
     /** @type {Boolean} Force writing of the generated files to given directory even if it is a git repo with unstaged files or not empty dir. Default is set to false. */
@@ -108,7 +108,7 @@ class Generator {
     this.install = install;
     /** @type {Object} The template configuration. */
     this.templateConfig = {};
-    /** @type {Object} Hooks object with hooks functionst grouped by the hook type. */
+    /** @type {Object} Hooks object with hooks functions grouped by the hook type. */
     this.hooks = {};
 
     // Load template configuration
@@ -751,12 +751,16 @@ class Generator {
    * @private
    */
   async launchHook(hookName, hookArguments) {
-    if (this.disabledHooks.includes(hookName)) return;
-    if (!Array.isArray(this.hooks[hookName])) return;
-    const promises = this.hooks[hookName].map(async (hook) => {
+    const disabledHooks = this.disabledHooks[hookName] || [];
+    if (disabledHooks === true) return;
+
+    const hookNames = this.hooks[hookName];
+    if (!Array.isArray(hookNames)) return;
+    const promises = hookNames.map(async (hook) => {
       if (typeof hook !== 'function') return;
+      if (disabledHooks.includes(hook)) return;
       return await hook(this, hookArguments);
-    });
+    }).filter(Boolean);
 
     return Promise.all(promises);
   }

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -753,7 +753,7 @@ class Generator {
   async launchHook(hookName, hookArguments) {
     let disabledHooks = this.disabledHooks[hookName] || [];
     if (disabledHooks === true) return;
-    if (typeof disabledHooks === "string") {
+    if (typeof disabledHooks === 'string') {
       disabledHooks = [disabledHooks];
     }
 
@@ -775,7 +775,7 @@ class Generator {
    * @param {string} hookName
    * @private
    */
-  isHookAvailable(hookType, hookName = "") {
+  isHookAvailable(hookType, hookName = '') {
     const hooks = this.hooks[hookType];
     let disabledHooks = this.disabledHooks[hookType] || [];
 
@@ -785,7 +785,7 @@ class Generator {
 
     if (!hookName) return true;
     
-    if (typeof disabledHooks === "string") {
+    if (typeof disabledHooks === 'string') {
       disabledHooks = [disabledHooks];
     }
     if (disabledHooks.includes(hookName)) return false;

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -75,7 +75,7 @@ class Generator {
    * @param {String} [options.templateParams]   Optional parameters to pass to the template. Each template define their own params.
    * @param {String} [options.entrypoint]       Name of the file to use as the entry point for the rendering process. Use in case you want to use only a specific template file. Note: this potentially avoids rendering every file in the template.
    * @param {String[]} [options.noOverwriteGlobs] List of globs to skip when regenerating the template.
-   * @param {Object<String, Boolean | String[]>} [options.disabledHooks] Object with hooks to disable. The field is a hook type. If field has "true" value, then generator skips all hooks from given type. If field is array of strings, then generator skips only hooks from array. 
+   * @param {Object<String, Boolean | String | String[]>} [options.disabledHooks] Object with hooks to disable. The key is a hook type. If key has "true" value, then the generator skips all hooks from the given type. If the key is a string with the name of a single hook, then the generator skips only this single hook name. If the key is an array of strings, then the generator skips only hooks from the array.
    * @param {String} [options.output='fs'] Type of output. Can be either 'fs' (default) or 'string'. Only available when entrypoint is set.
    * @param {Boolean} [options.forceWrite=false] Force writing of the generated files to given directory even if it is a git repo with unstaged files or not empty dir. Default is set to false.
    * @param {Boolean} [options.install=false] Install the template and its dependencies, even when the template has already been installed.
@@ -96,7 +96,7 @@ class Generator {
     this.entrypoint = entrypoint;
     /** @type {String[]} List of globs to skip when regenerating the template. */
     this.noOverwriteGlobs = noOverwriteGlobs || [];
-    /** @type {Object<String, Boolean | String[]>} Object with hooks to disable. The field is a hook type. If field has "true" value, then generator skips all hooks from given type. If field is array of strings, then generator skips only hooks from array. */
+    /** @type {Object<String, Boolean | String | String[]>} Object with hooks to disable. The key is a hook type. If key has "true" value, then the generator skips all hooks from the given type. If the key is a string with the name of a single hook, then the generator skips only this single hook name. If the key is an array of strings, then the generator skips only hooks from the array. */
     this.disabledHooks = disabledHooks || {};
     /** @type {String} Type of output. Can be either 'fs' (default) or 'string'. Only available when entrypoint is set. */
     this.output = output;
@@ -751,8 +751,11 @@ class Generator {
    * @private
    */
   async launchHook(hookName, hookArguments) {
-    const disabledHooks = this.disabledHooks[hookName] || [];
+    let disabledHooks = this.disabledHooks[hookName] || [];
     if (disabledHooks === true) return;
+    if (typeof disabledHooks === "string") {
+      disabledHooks = [disabledHooks];
+    }
 
     const hooks = this.hooks[hookName];
     if (!Array.isArray(hooks)) return;
@@ -768,15 +771,27 @@ class Generator {
   /**
    * Check if any hooks are available
    *
+   * @param {string} hookType
    * @param {string} hookName
    * @private
    */
-  isHookAvailable(hookName) {
-    if (this.disabledHooks.includes(hookName)
-      || !Array.isArray(this.hooks[hookName])
-      || this.hooks[hookName].length === 0) return false;
+  isHookAvailable(hookType, hookName = "") {
+    const hooks = this.hooks[hookType];
+    let disabledHooks = this.disabledHooks[hookType] || [];
 
-    return true;
+    if (disabledHooks === true
+      || !Array.isArray(hooks)
+      || hooks.length === 0) return false;
+
+    if (!hookName) return true;
+    
+    if (typeof disabledHooks === "string") {
+      disabledHooks = [disabledHooks];
+    }
+    if (disabledHooks.includes(hookName)) return false;
+
+    if (hooks.some(hook => hook.name === hookName)) return true;
+    return false;
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/generator",
-  "version": "1.0.0-rc.13",
+  "version": "1.0.0-rc.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2771,9 +2771,9 @@
       }
     },
     "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
     },
     "common-sequence": {
       "version": "2.0.0",
@@ -13791,6 +13791,15 @@
       "optional": true,
       "requires": {
         "commander": "~2.20.3"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "underscore": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/generator",
-  "version": "1.0.0-rc.13",
+  "version": "1.0.0-rc.14",
   "description": "The AsyncAPI generator. It can generate documentation, code, anything!",
   "main": "./lib/generator.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/generator",
-  "version": "1.0.0-rc.14",
+  "version": "1.0.0-rc.15",
   "description": "The AsyncAPI generator. It can generate documentation, code, anything!",
   "main": "./lib/generator.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@asyncapi/raml-dt-schema-parser": "^2.0.0",
     "ajv": "^6.10.2",
     "all-contributors-cli": "^6.14.2",
-    "commander": "^2.12.2",
+    "commander": "^6.1.0",
     "filenamify": "^4.1.0",
     "fs.extra": "^1.3.2",
     "jmespath": "^0.15.0",

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -570,28 +570,20 @@ describe('Generator', () => {
       const gen = new Generator('testTemplate', __dirname, { disabledHooks: { 'test-hooks': true } });
       gen.hooks = { 'test-hooks': ['foo-bar'] };
       expect(gen.isHookAvailable('test-hooks')).toStrictEqual(false);
-      expect(gen.isHookAvailable('test-hooks', 'foo-bar')).toStrictEqual(false);
     });
 
-    it('given hook name is disabled', async () => {
+    it('for given hook type only some hooks are disabled', async () => {
       const gen = new Generator('testTemplate', __dirname, { disabledHooks: { 'test-hooks': ['fooBar'], 'string-test-hooks': 'fooBar' } });
       gen.hooks = { 'test-hooks': [function fooBar() {}, function barFoo() {}], 'string-test-hooks': [function fooBar() {}, function barFoo() {}] };
-      expect(gen.isHookAvailable('test-hooks', 'fooBar')).toStrictEqual(false);
-      expect(gen.isHookAvailable('string-test-hooks', 'fooBar')).toStrictEqual(false);
+      expect(gen.isHookAvailable('test-hooks')).toStrictEqual(true);
+      expect(gen.isHookAvailable('string-test-hooks')).toStrictEqual(true);
     });
 
-    it('given hook name is enabled', async () => {
-      const gen = new Generator('testTemplate', __dirname, { disabledHooks: { 'test-hooks': ['fooBar'], 'string-test-hooks': 'fooBar' } });
-      gen.hooks = { 'test-hooks': [function fooBar() {}, function barFoo() {}], 'string-test-hooks': [function fooBar() {}, function barFoo() {}] };
-      expect(gen.isHookAvailable('test-hooks', 'barFoo')).toStrictEqual(true);
-      expect(gen.isHookAvailable('string-test-hooks', 'barFoo')).toStrictEqual(true);
-    });
-
-    it('given hook name not exist', async () => {
-      const gen = new Generator('testTemplate', __dirname, { disabledHooks: { 'test-hooks': ['fooBar'], 'string-test-hooks': 'fooBar' } });
-      gen.hooks = { 'test-hooks': [function fooBar() {}, function barFoo() {}], 'string-test-hooks': [function fooBar() {}, function barFoo() {}] };
-      expect(gen.isHookAvailable('test-hooks', 'barFooBar')).toStrictEqual(false);
-      expect(gen.isHookAvailable('string-test-hooks', 'barFooBar')).toStrictEqual(false);
+    it('for given hook type whole hooks are disabled', async () => {
+      const gen = new Generator('testTemplate', __dirname, { disabledHooks: { 'test-hooks': ['fooBar', 'barFoo'], 'string-test-hooks': 'fooBar' } });
+      gen.hooks = { 'test-hooks': [function fooBar() {}, function barFoo() {}], 'string-test-hooks': [function fooBar() {}] };
+      expect(gen.isHookAvailable('test-hooks')).toStrictEqual(false);
+      expect(gen.isHookAvailable('string-test-hooks')).toStrictEqual(false);
     });
   });
 });

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -30,7 +30,7 @@ describe('Generator', () => {
       const gen = new Generator('testTemplate', __dirname, {
         entrypoint: 'test-entrypoint',
         noOverwriteGlobs: ['test-globs'],
-        disabledHooks: { 'test-hooks': true, "generate:after": ["foo", "bar"] },
+        disabledHooks: { 'test-hooks': true, 'generate:after': ['foo', 'bar'] },
         output: 'string',
         forceWrite: true,
         install: true,
@@ -42,7 +42,7 @@ describe('Generator', () => {
       expect(gen.targetDir).toStrictEqual(__dirname);
       expect(gen.entrypoint).toStrictEqual('test-entrypoint');
       expect(gen.noOverwriteGlobs).toStrictEqual(['test-globs']);
-      expect(gen.disabledHooks).toStrictEqual({ 'test-hooks': true });
+      expect(gen.disabledHooks).toStrictEqual({ 'test-hooks': true, 'generate:after': ['foo', 'bar'] });
       expect(gen.output).toStrictEqual('string');
       expect(gen.forceWrite).toStrictEqual(true);
       expect(gen.install).toStrictEqual(true);

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -30,7 +30,7 @@ describe('Generator', () => {
       const gen = new Generator('testTemplate', __dirname, {
         entrypoint: 'test-entrypoint',
         noOverwriteGlobs: ['test-globs'],
-        disabledHooks: { 'test-hooks': true, 'generate:after': ['foo', 'bar'], 'foo': 'bar' },
+        disabledHooks: { 'test-hooks': true, 'generate:after': ['foo', 'bar'], foo: 'bar' },
         output: 'string',
         forceWrite: true,
         install: true,
@@ -42,7 +42,7 @@ describe('Generator', () => {
       expect(gen.targetDir).toStrictEqual(__dirname);
       expect(gen.entrypoint).toStrictEqual('test-entrypoint');
       expect(gen.noOverwriteGlobs).toStrictEqual(['test-globs']);
-      expect(gen.disabledHooks).toStrictEqual({ 'test-hooks': true, 'generate:after': ['foo', 'bar'], 'foo': 'bar' });
+      expect(gen.disabledHooks).toStrictEqual({ 'test-hooks': true, 'generate:after': ['foo', 'bar'], foo: 'bar' });
       expect(gen.output).toStrictEqual('string');
       expect(gen.forceWrite).toStrictEqual(true);
       expect(gen.install).toStrictEqual(true);
@@ -519,75 +519,75 @@ describe('Generator', () => {
   });
 
   describe('#launchHook', () => {
-    it(`launch given hook`, async () => {
+    it('launch given hook', async () => {
       let iteration = 0;
       const gen = new Generator('testTemplate', __dirname);
-      gen.hooks = { 'test-hooks': [function a() { iteration++ }, function b() { iteration++ }] };
+      gen.hooks = { 'test-hooks': [function a() { iteration++; }, function b() { iteration++; }] };
       await gen.launchHook('test-hooks');
       expect(iteration).toStrictEqual(2);
     });
 
-    it(`launch given hook which is disabled`, async () => {
+    it('launch given hook which is disabled', async () => {
       let iteration = 0;
       const gen = new Generator('testTemplate', __dirname, { disabledHooks: { 'test-hooks': true } });
-      gen.hooks = { 'test-hooks': [function a() { iteration++ }, function b() { iteration++ }] };
+      gen.hooks = { 'test-hooks': [function a() { iteration++; }, function b() { iteration++; }] };
       await gen.launchHook('test-hooks');
       expect(iteration).toStrictEqual(0);
     });
 
-    it(`launch given hook where disabledHooks key has array format for given hook type`, async () => {
+    it('launch given hook where disabledHooks key has array format for given hook type', async () => {
       let iteration = 0;
       const gen = new Generator('testTemplate', __dirname, { disabledHooks: { 'test-hooks': ['a', 'b'] } });
-      gen.hooks = { 'test-hooks': [function a() { iteration++ }, function b() { iteration++ }, function c() { iteration++ }] };
+      gen.hooks = { 'test-hooks': [function a() { iteration++; }, function b() { iteration++; }, function c() { iteration++; }] };
       await gen.launchHook('test-hooks');
       expect(iteration).toStrictEqual(1);
     });
 
-    it(`launch given hook where disabledHooks key has array format for given hook type`, async () => {
+    it('launch given hook where disabledHooks key has array format for given hook type', async () => {
       let iteration = 0;
       const gen = new Generator('testTemplate', __dirname, { disabledHooks: { 'test-hooks': 'c' } });
-      gen.hooks = { 'test-hooks': [function a() { iteration++ }, function b() { iteration++ }, function c() { iteration++ }] };
+      gen.hooks = { 'test-hooks': [function a() { iteration++; }, function b() { iteration++; }, function c() { iteration++; }] };
       await gen.launchHook('test-hooks');
       expect(iteration).toStrictEqual(2);
     });
   });
 
   describe('#isHookAvailable', () => {
-    it(`given hook type doesn't exist or has empty array`, async () => {
+    it('given hook type not exist or has empty array', async () => {
       const gen = new Generator('testTemplate', __dirname);
       gen.hooks = { 'test-hooks': [] };
       expect(gen.isHookAvailable('foo-bar')).toStrictEqual(false);
       expect(gen.isHookAvailable('test-hooks')).toStrictEqual(false);
     });
 
-    it(`given hook type exist and has hooks`, async () => {
+    it('given hook type exist and has hooks', async () => {
       const gen = new Generator('testTemplate', __dirname);
       gen.hooks = { 'test-hooks': ['foo-bar'] };
       expect(gen.isHookAvailable('test-hooks')).toStrictEqual(true);
     });
 
-    it(`given hook type is disabled`, async () => {
+    it('given hook type is disabled', async () => {
       const gen = new Generator('testTemplate', __dirname, { disabledHooks: { 'test-hooks': true } });
       gen.hooks = { 'test-hooks': ['foo-bar'] };
       expect(gen.isHookAvailable('test-hooks')).toStrictEqual(false);
       expect(gen.isHookAvailable('test-hooks', 'foo-bar')).toStrictEqual(false);
     });
 
-    it(`given hook name is disabled`, async () => {
+    it('given hook name is disabled', async () => {
       const gen = new Generator('testTemplate', __dirname, { disabledHooks: { 'test-hooks': ['fooBar'], 'string-test-hooks': 'fooBar' } });
       gen.hooks = { 'test-hooks': [function fooBar() {}, function barFoo() {}], 'string-test-hooks': [function fooBar() {}, function barFoo() {}] };
       expect(gen.isHookAvailable('test-hooks', 'fooBar')).toStrictEqual(false);
       expect(gen.isHookAvailable('string-test-hooks', 'fooBar')).toStrictEqual(false);
     });
 
-    it(`given hook name is enabled`, async () => {
+    it('given hook name is enabled', async () => {
       const gen = new Generator('testTemplate', __dirname, { disabledHooks: { 'test-hooks': ['fooBar'], 'string-test-hooks': 'fooBar' } });
       gen.hooks = { 'test-hooks': [function fooBar() {}, function barFoo() {}], 'string-test-hooks': [function fooBar() {}, function barFoo() {}] };
       expect(gen.isHookAvailable('test-hooks', 'barFoo')).toStrictEqual(true);
       expect(gen.isHookAvailable('string-test-hooks', 'barFoo')).toStrictEqual(true);
     });
 
-    it(`given hook name doesn't exist`, async () => {
+    it('given hook name not exist', async () => {
       const gen = new Generator('testTemplate', __dirname, { disabledHooks: { 'test-hooks': ['fooBar'], 'string-test-hooks': 'fooBar' } });
       gen.hooks = { 'test-hooks': [function fooBar() {}, function barFoo() {}], 'string-test-hooks': [function fooBar() {}, function barFoo() {}] };
       expect(gen.isHookAvailable('test-hooks', 'barFooBar')).toStrictEqual(false);

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -19,7 +19,7 @@ describe('Generator', () => {
       expect(gen.targetDir).toStrictEqual(__dirname);
       expect(gen.entrypoint).toStrictEqual(undefined);
       expect(gen.noOverwriteGlobs).toStrictEqual([]);
-      expect(gen.disabledHooks).toStrictEqual([]);
+      expect(gen.disabledHooks).toStrictEqual({});
       expect(gen.output).toStrictEqual('fs');
       expect(gen.forceWrite).toStrictEqual(false);
       expect(gen.install).toStrictEqual(false);
@@ -30,7 +30,7 @@ describe('Generator', () => {
       const gen = new Generator('testTemplate', __dirname, {
         entrypoint: 'test-entrypoint',
         noOverwriteGlobs: ['test-globs'],
-        disabledHooks: ['test-hooks'],
+        disabledHooks: { 'test-hooks': true, "generate:after": ["foo", "bar"] },
         output: 'string',
         forceWrite: true,
         install: true,
@@ -42,7 +42,7 @@ describe('Generator', () => {
       expect(gen.targetDir).toStrictEqual(__dirname);
       expect(gen.entrypoint).toStrictEqual('test-entrypoint');
       expect(gen.noOverwriteGlobs).toStrictEqual(['test-globs']);
-      expect(gen.disabledHooks).toStrictEqual(['test-hooks']);
+      expect(gen.disabledHooks).toStrictEqual({ 'test-hooks': true });
       expect(gen.output).toStrictEqual('string');
       expect(gen.forceWrite).toStrictEqual(true);
       expect(gen.install).toStrictEqual(true);
@@ -58,7 +58,7 @@ describe('Generator', () => {
       const t = () => new Generator('testTemplate', __dirname, {
         entrypoint: 'test-entrypoint',
         noOverwriteGlobs: ['test-globs'],
-        disabledHooks: ['test-hooks'],
+        disabledHooks: { 'test-hooks': true },
         output: 'string',
         forceWrite: true,
         forceInstall: true,
@@ -73,7 +73,7 @@ describe('Generator', () => {
       const t = () => new Generator('testTemplate', __dirname, {
         entrypoint: 'test-entrypoint',
         noOverwriteGlobs: ['test-globs'],
-        disabledHooks: ['test-hooks'],
+        disabledHooks: { 'test-hooks': true },
         output: 'string',
         write: true,
         forceInstall: true,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Extend `--disable-hook` flag to disable specific hook function(s). Example usage:

```text
--disable-hook generate:before generate:after=foo,bar
```

then generator will disable all hooks of `generate:before` type and `foo`, `bar` hooks of `generate:after` type.

However, the logic in the code overrides previous values for given type, so using flag such as: `--disable-hook generate:before generate:before=foo,bar` disables only `foo`, `bar` hooks of `generate:before` type, not whole type.

- update Readme.md
- update tests

**Related issue(s)**
Resolves https://github.com/asyncapi/generator/issues/333