### PR TITLE
chore(ci): create PR when receiving release event from parser-js

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -36,11 +36,9 @@ jobs:
     steps:
       - name: Automerging
         uses: pascalgn/automerge-action@v0.7.5
-        if: github.actor == 'asyncapi-bot' || github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
         env:
           GITHUB_TOKEN: "${{ secrets.GH_TOKEN }}"
           GITHUB_LOGIN: asyncapi-bot
-          MERGE_LABELS: ""
           MERGE_METHOD: "squash"
           MERGE_COMMIT_MESSAGE: "pull-request-title"
           MERGE_RETRIES: "10"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,3 +61,4 @@ jobs:
           title: 'chore(release): ${{ steps.extractver.outputs.version }}'
           body: 'Version bump in package.json and package-lock.json for release [${{ steps.extractver.outputs.version }}](https://github.com/${{github.repository}}/releases/tag/v${{ steps.extractver.outputs.version }})'
           branch: version-bump/${{ steps.extractver.outputs.version }}
+          labels: 'automerge'

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -1,0 +1,32 @@
+name: Update dependencies
+
+on:
+  repository_dispatch:
+    types: [asyncapi/parser-js/release]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - name: Update dependency version
+        run: npm i ${{ github.event.client_payload.name }}@${{ github.event.client_payload.version }}
+
+      - name: Create Pull Request with updated package files
+        uses: peter-evans/create-pull-request@v3
+        with:
+          base: master
+          token: ${{ secrets.GH_TOKEN }}
+          commit-message: 'chore(deps): update ${{ github.event.client_payload.name }} to ${{ github.event.client_payload.version }}'
+          committer: asyncapi-bot <info@asyncapi.io>
+          author: asyncapi-bot <info@asyncapi.io>
+          title: 'chore(deps): update ${{ github.event.client_payload.name }} to ${{ github.event.client_payload.version }}'
+          body: 'Version update in package.json and package-lock.json dependencies: ${{ github.event.client_payload.name }}@${{ github.event.client_payload.version }}.'
+          branch: update-deps/${{ github.event.client_payload.name }}-${{ github.event.client_payload.version }}

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -1,4 +1,4 @@
-name: Update dependencies
+name: Update npm package dependencies
 
 on:
   repository_dispatch:


### PR DESCRIPTION
**Description**

Creates a PR updating package.json and package-lock.json whenever Github Actions receives a release event from `asyncapi/parser-js`.

It also changes the release workflow a little bit. Instead of automerging PRs created by our bots it will only merge PRs with label `automerge`.

**Related issue(s)**
This is the counterpart on the JS Parser: https://github.com/asyncapi/parser-js/pull/205.