### PR TITLE
fix: ignore __transpiled folder in watch mode

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -88,16 +88,18 @@ xfs.mkdirp(program.output, async err => {
     let watcher;
     const watchDir = path.resolve(template);
     const outputPath = path.resolve(watchDir, program.output);
+    const transpiledTemplatePath = path.resolve(watchDir, Generator.TRANSPILED_TEMPLATE_LOCATION);
+    const ignorePaths = [outputPath, transpiledTemplatePath];
     // Template name is needed as it is not always a part of the cli commad
     // There is a use case that you run generator from a root of the template with `./` path
     const templateName = require(path.resolve(watchDir,'package.json')).name;
 
     if (isAsyncapiDocLocal) {
       console.log(`[WATCHER] Watching for changes in the template directory ${magenta(watchDir)} and in the AsyncAPI file ${magenta(asyncapiDocPath)}`);
-      watcher = new Watcher([asyncapiDocPath, watchDir], outputPath);
+      watcher = new Watcher([asyncapiDocPath, watchDir], ignorePaths);
     } else {
       console.log(`[WATCHER] Watching for changes in the template directory ${magenta(watchDir)}`);
-      watcher = new Watcher(watchDir, outputPath);
+      watcher = new Watcher(watchDir, ignorePaths);
     }
     // Must check template in its installation path in generator to use isLocalTemplate function
     if (!await isLocalTemplate(path.resolve(Generator.DEFAULT_TEMPLATES_DIR, templateName))) {

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -825,5 +825,6 @@ class Generator {
 }
 
 Generator.DEFAULT_TEMPLATES_DIR = DEFAULT_TEMPLATES_DIR;
+Generator.TRANSPILED_TEMPLATE_LOCATION = TRANSPILED_TEMPLATE_LOCATION;
 
 module.exports = Generator;

--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -5,7 +5,7 @@ const chokidar = require('chokidar');
  * Class to watch for change in certain file(s)
  */
 class Watcher {
-  constructor(paths, ignorePath) {
+  constructor(paths, ignorePaths) {
     if (Array.isArray(paths)) {
       this.paths = paths;
     } else {
@@ -19,7 +19,7 @@ class Watcher {
     this.fsWait = false;
     this.watchers = {};
     this.filesChanged = {};
-    this.ignorePath = ignorePath;
+    this.ignorePaths = ignorePaths;
   }
 
   /**
@@ -29,7 +29,7 @@ class Watcher {
    * @param {*} errorCallback Calback to call when it is no longer possible to watch a file.
    */
   initiateWatchOnPath(path, changeCallback, errorCallback) {
-    const watcher = chokidar.watch(path, {ignoreInitial: true, ignored: this.ignorePath});
+    const watcher = chokidar.watch(path, {ignoreInitial: true, ignored: this.ignorePaths});
     watcher.on('all', (eventType, changedPath) => this.fileChanged(path, changedPath, eventType, changeCallback, errorCallback));
     this.watchers[path] = watcher;
   }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

This PR contains ignoring `__transpiled` folder inside template package in watch mode. It is ignored both in React and Nunjucks, because I don't see any objections why we should ignore it only in React - prefix `__` indicates that this folder is `special`.

**Related issue(s)**
Resolves #465