### PR TITLE
fix: copy non-JS files in the React templates by default

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -639,9 +639,7 @@ class Generator {
       }
     }
 
-    if (this.isNonRenderableFile(relativeSourceFile)) {
-      return await copyFile(sourceFile, targetFile);
-    }
+    if (this.isNonRenderableFile(relativeSourceFile)) return await copyFile(sourceFile, targetFile);
 
     await this.renderAndWriteToFile(asyncapiDocument, sourceFile, targetFile);
   }

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -28,7 +28,8 @@ const {
   exists,
   fetchSpec,
   getInvalidOptions,
-  isReactTemplate
+  isReactTemplate,
+  isJsFile,
 } = require('./utils');
 const { registerFilters } = require('./filtersRegistry');
 const { registerHooks } = require('./hooksRegistry');
@@ -637,7 +638,10 @@ class Generator {
         if (!valid) return log.debug(`${relativeSourceFile} was not generated because condition specified for this file in template configuration in conditionalFiles matched`);
       }
     }
-    if (this.isNonRenderableFile(relativeSourceFile)) return await copyFile(sourceFile, targetFile);
+
+    if (this.isNonRenderableFile(relativeSourceFile)) {
+      return await copyFile(sourceFile, targetFile);
+    }
 
     await this.renderAndWriteToFile(asyncapiDocument, sourceFile, targetFile);
   }
@@ -687,7 +691,9 @@ class Generator {
    */
   isNonRenderableFile(fileName) {
     if (!Array.isArray(this.templateConfig.nonRenderableFiles)) return false;
-    return this.templateConfig.nonRenderableFiles.some(globExp => minimatch(fileName, globExp));
+    if (this.templateConfig.nonRenderableFiles.some(globExp => minimatch(fileName, globExp))) return true;
+    if (isReactTemplate(this.templateConfig) && !isJsFile(fileName)) return true;
+    return false;
   }
 
   /**

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -688,8 +688,9 @@ class Generator {
    * @return {boolean}
    */
   isNonRenderableFile(fileName) {
-    if (!Array.isArray(this.templateConfig.nonRenderableFiles)) return false;
-    if (this.templateConfig.nonRenderableFiles.some(globExp => minimatch(fileName, globExp))) return true;
+    const nonRenderableFiles = this.templateConfig.nonRenderableFiles || [];
+    if (!Array.isArray(nonRenderableFiles)) return false;
+    if (nonRenderableFiles.some(globExp => minimatch(fileName, globExp))) return true;
     if (isReactTemplate(this.templateConfig) && !isJsFile(fileName)) return true;
     return false;
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -111,7 +111,7 @@ utils.fetchSpec = (link) => {
 };
 
 /**
- *  Checks if given string is URL and if not, we assume it is file path
+ * Checks if given string is URL and if not, we assume it is file path
  * 
  * @param {String} str Information representing file path or url
  * @returns {Boolean}
@@ -121,7 +121,18 @@ utils.isFilePath = (str) => {
 };
 
 /**
- *  Get version of the generator
+ * Checks if given file path is JS file
+ * 
+ * @param {String} filename Information representing file path
+ * @returns {Boolean}
+ */
+utils.isJsFile = (filepath) => {
+  const ext = filepath.split('.').pop() || '';
+  return ['js', 'jsx', 'cjs'].includes(ext);
+}
+
+/**
+ * Get version of the generator
  * 
  * @returns {String}
  */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -123,7 +123,7 @@ utils.isFilePath = (str) => {
 /**
  * Checks if given file path is JS file
  * 
- * @param {String} filename Information representing file path
+ * @param {String} filename information representing file path
  * @returns {Boolean}
  */
 utils.isJsFile = (filepath) => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -129,7 +129,7 @@ utils.isFilePath = (str) => {
 utils.isJsFile = (filepath) => {
   const ext = filepath.split('.').pop() || '';
   return ['js', 'jsx', 'cjs'].includes(ext);
-}
+};
 
 /**
  * Get version of the generator

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -113,7 +113,7 @@ utils.fetchSpec = (link) => {
 /**
  * Checks if given string is URL and if not, we assume it is file path
  * 
- * @param {String} str Information representing file path or url
+ * @param {String} str information representing file path or url
  * @returns {Boolean}
  */
 utils.isFilePath = (str) => {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

As in title: copy all non-JS files in the React render engine by default. Problem is described in the #466 issue:

> At the moment the Generator in the React case doesn't copy non-JS files in template, but skipped them. Workaround is add files to `nonRenderableFiles` array in configuration of template in `package.json`, but for template like https://github.com/asyncapi/nodejs-template/tree/master/template it isn't cool and has big impact to development: Each non-JS file must be added manually to an array.

Also if someone doesn't want render some `.js` file then can include it inside `nonRenderableFiles` array.

**Related issue(s)**
Resolves #466