### PR TITLE
fix: remove restriction to node<15 and npm<7 to enable testing on newer versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,12 @@ You can find above templates and the ones provided by the community in **[this l
 
 ## Requirements
 
-* v12.16+ < Node.js < 15
-* v6.13.7+ < npm < 7
+* v12.16+ < Node.js
+* v6.13.7+ < npm
 
 Install both packages using [official installer](https://nodejs.org/en/download/). After installation make sure both packages have proper version by running `node -v` and `npm -v`. To upgrade invalid npm version run `npm install npm@latest -g`
+
+**Please note that non-LTS versions of Node and npm are not supported. **
 
 ## Using from the command-line interface (CLI)
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ You can find above templates and the ones provided by the community in **[this l
 
 Install both packages using [official installer](https://nodejs.org/en/download/). After installation make sure both packages have proper version by running `node -v` and `npm -v`. To upgrade invalid npm version run `npm install npm@latest -g`
 
-**Please note that non-LTS versions of Node and npm are not supported. **
+**Generator is tested at the moment against Node 14 and NPM 6. Using newer versions is enabled but we do not guarantee they work well. Please provide feedback on the issues.**
+
+how about this?
 
 ## Using from the command-line interface (CLI)
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,7 @@ You can find above templates and the ones provided by the community in **[this l
 
 Install both packages using [official installer](https://nodejs.org/en/download/). After installation make sure both packages have proper version by running `node -v` and `npm -v`. To upgrade invalid npm version run `npm install npm@latest -g`
 
-**Generator is tested at the moment against Node 14 and NPM 6. Using newer versions is enabled but we do not guarantee they work well. Please provide feedback on the issues.**
-
-how about this?
+> Generator is tested at the moment against Node 14 and NPM 6. Using newer versions is enabled but we do not guarantee they work well. Please provide feedback on the issues.
 
 ## Using from the command-line interface (CLI)
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "ag": "./cli.js"
   },
   "engines": {
-    "node": ">12.16 <15",
-    "npm": ">6.13.7 <7"
+    "node": ">12.16",
+    "npm": ">6.13.7"
   },
   "scripts": {
     "test": "jest --coverage",


### PR DESCRIPTION
Resolves #480