### PR TITLE
feat: map schema references from baseUrl to folder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Contributions are more than welcome. If you want to contribute, please make sure
 Before creating a Pull Request you should validate your code with ESLint.
 
 ```
-npm run eslint
+npm run lint
 ```
 
 ## Developing with Docker

--- a/cli.js
+++ b/cli.js
@@ -19,6 +19,7 @@ let template;
 const params = {};
 const noOverwriteGlobs = [];
 const disabledHooks = {};
+const mapBaseUrlToFolder = { url: '', folder: process.cwd()};
 
 const parseOutput = dir => path.resolve(dir);
 
@@ -39,6 +40,13 @@ const disableHooksParser = v => {
   } else {
     disabledHooks[hookType] = true;
   }
+};
+
+const mapFromBaseUrlParser = v => {
+  mapBaseUrlToFolder.url = v;
+};
+const mapToBaseFolderParser = v => {
+  mapBaseUrlToFolder.folder = v;
 };
 
 const showError = err => {
@@ -67,6 +75,8 @@ program
   .option('-p, --param <name=value>', 'additional param to pass to templates', paramParser)
   .option('--force-write', 'force writing of the generated files to given directory even if it is a git repo with unstaged files or not empty dir (defaults to false)')
   .option('--watch-template', 'watches the template directory and the AsyncAPI document, and re-generate the files when changes occur. Ignores the output directory. This flag should be used only for template development.')
+  .option('--mapFromBaseUrl <url>','maps all schema references with this base url to folder specified by --mapToBaseFolder',mapFromBaseUrlParser)
+  .option('--mapToBaseFolder <baseFolder>','maps all schema references starting with url specified by --mapFromBaseUrl to this folder',mapToBaseFolderParser)
   .parse(process.argv);
 
 if (!asyncapiDocPath) {
@@ -105,7 +115,7 @@ xfs.mkdirp(program.output, async err => {
     if (!await isLocalTemplate(path.resolve(Generator.DEFAULT_TEMPLATES_DIR, templateName))) {
       console.warn(`WARNING: ${template} is a remote template. Changes may be lost on subsequent installations.`);
     }
-    
+
     watcher.watch(watcherHandler, (paths) => {
       showErrorAndExit({ message: `[WATCHER] Could not find the file path ${paths}, are you sure it still exists? If it has been deleted or moved please rerun the generator.` });
     });
@@ -125,7 +135,8 @@ function generate(targetDir) {
         disabledHooks,
         forceWrite: program.forceWrite,
         install: program.install,
-        debug: program.debug
+        debug: program.debug,
+        mapBaseUrlToFolder
       });
 
       if (isAsyncapiDocLocal) {

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -49,7 +49,7 @@ const DEFAULT_TEMPLATES_DIR = path.resolve(ROOT_DIR, 'node_modules');
 
 const TRANSPILED_TEMPLATE_LOCATION = '__transpiled';
 const TEMPLATE_CONTENT_DIRNAME = 'template';
-const GENERATOR_OPTIONS = ['debug', 'disabledHooks', 'entrypoint', 'forceWrite', 'install', 'noOverwriteGlobs', 'output', 'templateParams'];
+const GENERATOR_OPTIONS = ['debug', 'disabledHooks', 'entrypoint', 'forceWrite', 'install', 'noOverwriteGlobs', 'output', 'templateParams', 'mapBaseUrlToFolder'];
 
 const shouldIgnoreFile = filePath =>
   filePath.startsWith(`.git${path.sep}`);
@@ -86,7 +86,7 @@ class Generator {
    * @param {Boolean} [options.install=false] Install the template and its dependencies, even when the template has already been installed.
    * @param {Boolean} [options.debug=false] Enable more specific errors in the console. At the moment it only shows specific errors about filters. Keep in mind that as a result errors about template are less descriptive.
    */
-  constructor(templateName, targetDir, { templateParams = {}, entrypoint, noOverwriteGlobs, disabledHooks, output = 'fs', forceWrite = false, install = false, debug = false } = {}) {
+  constructor(templateName, targetDir, { templateParams = {}, entrypoint, noOverwriteGlobs, disabledHooks, output = 'fs', forceWrite = false, install = false, debug = false, mapBaseUrlToFolder = {} } = {}) {
     const invalidOptions = getInvalidOptions(GENERATOR_OPTIONS, arguments[arguments.length - 1] || []);
     if (invalidOptions.length) throw new Error(`These options are not supported by the generator: ${invalidOptions.join(', ')}`);
     if (!templateName) throw new Error('No template name has been specified.');
@@ -115,6 +115,8 @@ class Generator {
     this.templateConfig = {};
     /** @type {Object} Hooks object with hooks functions grouped by the hook type. */
     this.hooks = {};
+    /** @type {Object} Maps schema URL to folder. */
+    this.mapBaseUrlToFolder = mapBaseUrlToFolder;
 
     // Load template configuration
     /** @type {Object} The template parameters. The structure for this object is based on each individual template. */
@@ -131,6 +133,44 @@ class Generator {
         }
       });
     });
+
+    this.mapBaseUrlToFolderResolver = {};
+    if (mapBaseUrlToFolder && mapBaseUrlToFolder.url) {
+      this.mapBaseUrlToFolderResolver =  {
+        order: 1,
+        canRead (file) {
+          console.log(`my file resolver: ${file.url} ${file.extension}`);
+          return true;
+        },
+        read(file, callback, $refs) {
+          const baseUrl = mapBaseUrlToFolder.url;
+          const baseDir = mapBaseUrlToFolder.folder;
+
+          console.log('root dir %s',DEFAULT_TEMPLATES_DIR);
+
+          return new Promise(((resolve, reject) => {
+
+            let path = file.url;
+            console.log('converting %s ...', path);
+            path = path.replace(baseUrl,baseDir);
+            console.log('... to file %s', path);
+
+            try {
+              fs.readFile(path, (err, data) => {
+                if (err) {
+                  reject(`Error opening file "${path}"`);
+                } else {
+                  resolve(data);
+                }
+              });
+            } catch (err) {
+              reject(`Error opening file "${path}"`);
+            }
+          }));
+        }
+      };
+    };
+
   }
 
   /**
@@ -246,7 +286,13 @@ class Generator {
    * @return {Promise}
    */
   async generateFromString(asyncapiString, parserOptions = {}) {
+    console.log('generateFromString %s',asyncapiString);
+
     if (!asyncapiString || typeof asyncapiString !== 'string') throw new Error('Parameter "asyncapiString" must be a non-empty string.');
+
+    if (this.mapBaseUrlToFolderResolver) {
+      parserOptions.resolve = {idresolver: this.mapBaseUrlToFolderResolver};
+    }
 
     /** @type {String} AsyncAPI string to use as a source. */
     this.originalAsyncAPI = asyncapiString; 
@@ -467,7 +513,7 @@ class Generator {
   /**
    * Makes sure that during directory structure generation ignored dirs are not modified
    * @private
-   * 
+   *
    * @param  {String} root Dir name.
    * @param  {String} stats Information about the file.
    * @param  {Function} next Callback function
@@ -484,7 +530,7 @@ class Generator {
   /**
    * Makes sure that during directory structure generation ignored dirs are not modified
    * @private
-   * 
+   *
    * @param  {AsyncAPIDocument} asyncapiDocument AsyncAPI document to use as the source.
    * @param  {String} objectMap Map of schemas of type object
    * @param  {String} root Dir name.


### PR DESCRIPTION
**Description**

introdce two new cli parameters

- `--mapFromBaseUrl <url>`: maps all schema references with this base url to folder specified by `--mapToBaseFolder`
- `--mapToBaseFolder <baseFolder>`: maps all schema references starting with url specified by `--mapFromBaseUrl` to this folder

**Related issue(s)**
Resolves #512
