### PR TITLE
feat: add support for asynchronous filters in Nunjucks

### DIFF
--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -343,7 +343,7 @@ You can use the filter function in your template as in the following example:
 const {{ channelName | camelCase }} = '{{ channelName }}';
 ```
 
-The generator supports also asynchronous filters. Asynchronous filters receive as last argument a callback to resume rendering. Asynchronous filters must be annotated with the `async` keyword. See the example of how to use asynchronous filters:
+The generator supports also asynchronous filters. Asynchronous filters receive as last argument a callback to resume rendering. Asynchronous filters must be annotated with the `async` keyword. Make sure to call the callback with two arguments: `callback(err, res)`. `err` can be `null`. See the example of how to use asynchronous filters:
 
 ```js
 async function asyncCamelCase(str, callback) {

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -343,4 +343,21 @@ You can use the filter function in your template as in the following example:
 const {{ channelName | camelCase }} = '{{ channelName }}';
 ```
 
+The generator supports also asynchronous filters. Asynchronous filters receive as last argument a callback to resume rendering. Asynchronous filters must be annotated with the `async` keyword. See the example of how to use asynchronous filters:
+
+```js
+async function asyncCamelCase(str, callback) {
+  try {
+    const result = // logic for camel casing str
+    callback(null, result);
+  } catch (error) {
+    callback(error);
+  }
+}
+filter.renderAsyncContent = renderAsyncContent;
+
+// using in template
+{{ channelName | asyncCamelCase }}
+```
+
 In case you have more than one template and want to reuse filters, you can put them in a single library. You can configure such a library in the template configuration under `filters` property. You can also use the official AsyncAPI [filters library](https://github.com/asyncapi/generator-filters). To learn how to add such filters to configuration [read more about the configuration file](#configuration-file).

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -346,6 +346,8 @@ const {{ channelName | camelCase }} = '{{ channelName }}';
 The generator also supports asynchronous filters. Asynchronous filters receive as last argument a callback to resume rendering. Asynchronous filters must be annotated with the `async` keyword. Make sure to call the callback with two arguments: `callback(err, res)`. `err` can be `null`. See the following example of how to use asynchronous filters:
 
 ```js
+const filter = module.exports;
+
 async function asyncCamelCase(str, callback) {
   try {
     const result = // logic for camel casing str

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -360,4 +360,14 @@ filter.renderAsyncContent = renderAsyncContent;
 {{ channelName | asyncCamelCase }}
 ```
 
+Unfornatelly, if you need to use Promise, filter still must be annotated with the `async` keyword:
+
+```js
+async function asyncCamelCase(str, callback) {
+  return new Promise((resolve, reject) => {
+    // logic with callback
+  });
+}
+```
+
 In case you have more than one template and want to reuse filters, you can put them in a single library. You can configure such a library in the template configuration under `filters` property. You can also use the official AsyncAPI [filters library](https://github.com/asyncapi/generator-filters). To learn how to add such filters to configuration [read more about the configuration file](#configuration-file).

--- a/docs/authoring.md
+++ b/docs/authoring.md
@@ -343,7 +343,7 @@ You can use the filter function in your template as in the following example:
 const {{ channelName | camelCase }} = '{{ channelName }}';
 ```
 
-The generator supports also asynchronous filters. Asynchronous filters receive as last argument a callback to resume rendering. Asynchronous filters must be annotated with the `async` keyword. Make sure to call the callback with two arguments: `callback(err, res)`. `err` can be `null`. See the example of how to use asynchronous filters:
+The generator also supports asynchronous filters. Asynchronous filters receive as last argument a callback to resume rendering. Asynchronous filters must be annotated with the `async` keyword. Make sure to call the callback with two arguments: `callback(err, res)`. `err` can be `null`. See the following example of how to use asynchronous filters:
 
 ```js
 async function asyncCamelCase(str, callback) {

--- a/lib/filtersRegistry.js
+++ b/lib/filtersRegistry.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const xfs = require('fs.extra');
-const { isLocalTemplate } = require('./utils');
+const { isLocalTemplate, isAsyncFunction } = require('./utils');
 
 /**
  * Registers all template filters.
@@ -90,6 +90,10 @@ function addFilters(nunjucks, filters) {
     const value = filters[key];
     if (!(value instanceof Function)) return;
 
-    nunjucks.addFilter(key, value);
+    if (isAsyncFunction(value)) {
+      nunjucks.addFilter(key, value, true);
+    } else {
+      nunjucks.addFilter(key, value);
+    }
   });      
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -154,11 +154,11 @@ utils.getInvalidOptions = (generatorOptions, options) => {
 };
 
 /**
- * Determine whether the given `fn` is a async function.
+ * Determine whether the given `fn` is an async function.
  * @private
  * @param {*} fn
  * @returns {Boolean}
  */
 utils.isAsyncFunction = (fn) => {  
   return fn instanceof asyncFunctionCtor;
-}
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,6 +15,8 @@ utils.copyFile = util.promisify(fs.copyFile);
 utils.exists = util.promisify(fs.exists);
 utils.readDir = util.promisify(fs.readdir);
 
+const asyncFunctionCtor = (async () => {}).constructor;
+
 /**
  * Checks if a string is a filesystem path.
  * @private
@@ -150,3 +152,13 @@ utils.getInvalidOptions = (generatorOptions, options) => {
   if (typeof options !== 'object') return [];
   return Object.keys(options).filter(param => !generatorOptions.includes(param));
 };
+
+/**
+ * Determine whether the given `fn` is a async function.
+ * @private
+ * @param {*} fn
+ * @returns {Boolean}
+ */
+utils.isAsyncFunction = (fn) => {  
+  return fn instanceof asyncFunctionCtor;
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -152,10 +152,10 @@ utils.getInvalidOptions = (generatorOptions, options) => {
 };
 
 /**
- * Determine whether the given `fn` is an async function.
+ * Determine whether the given function is asynchronous.
  * @private
- * @param {*} fn
- * @returns {Boolean}
+ * @param {*} fn to check 
+ * @returns {Boolean} is function asynchronous
  */
 utils.isAsyncFunction = (fn) => {  
   return fn && fn.constructor && fn.constructor.name === 'AsyncFunction';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,8 +15,6 @@ utils.copyFile = util.promisify(fs.copyFile);
 utils.exists = util.promisify(fs.exists);
 utils.readDir = util.promisify(fs.readdir);
 
-const asyncFunctionCtor = (async () => {}).constructor;
-
 /**
  * Checks if a string is a filesystem path.
  * @private
@@ -160,5 +158,5 @@ utils.getInvalidOptions = (generatorOptions, options) => {
  * @returns {Boolean}
  */
 utils.isAsyncFunction = (fn) => {  
-  return fn && fn.constructor && fn.constructor.name === "AsyncFunction";
+  return fn && fn.constructor && fn.constructor.name === 'AsyncFunction';
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -160,5 +160,5 @@ utils.getInvalidOptions = (generatorOptions, options) => {
  * @returns {Boolean}
  */
 utils.isAsyncFunction = (fn) => {  
-  return fn instanceof asyncFunctionCtor;
+  return fn && fn.constructor && fn.constructor.name === "AsyncFunction";
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7609,14 +7609,6 @@
         "is-glob": "^4.0.1"
       }
     },
-    "global-npm": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/global-npm/-/global-npm-0.3.0.tgz",
-      "integrity": "sha1-fFEVOUpnfRJFxOO6C3i7Z1J5fuA=",
-      "requires": {
-        "which": "^1.2.1"
-      }
-    },
     "globals": {
       "version": "12.4.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -14927,14 +14919,29 @@
       "resolved": "https://registry.npmjs.org/npmi/-/npmi-4.0.0.tgz",
       "integrity": "sha512-qNyW7pgCNbdhDFl3WmEEIZwp87RKwD9Y9SiJ/eZPGCUM7iwgvXXNVby+3JEYAfV6KxONnitDNFXuZlr2fSpV/g==",
       "requires": {
-        "global-npm": "^0.4.1",
         "semver": "^5.4.1"
       },
       "dependencies": {
+        "global-npm": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/global-npm/-/global-npm-0.4.1.tgz",
+          "integrity": "sha512-/XasD4hg2kbBfxxLjCaqa4acGeaO4WshW7Mo7CCfZLgpHH3Jpdl0OKxhgob/8s842Sd9VrU7+E6ph65Yzn5wmQ==",
+          "requires": {
+            "which": "^2.0.2"
+          }
+        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
         }
       }
     },
@@ -17763,6 +17770,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Add support for asynchronous filters in Nunjucks:
- check before saving filter to registry that function is asynchronous, if yes, add as third argument to `addFilter` function `true` - it indicates that to filter should be always added callback with signature `callback(err, result)`.
- update docs with example.

In Nunjucks docs we can read:
![image](https://user-images.githubusercontent.com/20404945/108968936-b5546d80-7681-11eb-94fb-27c0f032353d.png)

**Related issue(s)**
Resolves https://github.com/asyncapi/generator/issues/515