### PR TITLE
fix: align version of docker tag with the version of released generator

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -14,9 +14,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: master
-      - name: Get version from package.json
+      - name: Get version without v character
         id: version
-        run: echo "::set-output name=value::$(npm run get:version --silent)"
+        run: |
+          VERSION=${{github.event.release.tag_name}}
+          VERSION_WITHOUT_V=${VERSION:1}
+          echo "::set-output name=value::$(echo $VERSION_WITHOUT_V)"
       - name: Release to Docker
         run: | 
           echo ${{secrets.DOCKER_PASSWORD}} | docker login -u ${{secrets.DOCKER_USERNAME}} --password-stdin


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

The release workflow for docker picked a tag name from package.json version while it was not yet updated with latest version. This is why when we were releasing 0.2.0, it was released under tag indicating it is 0.1.0

Now we pick up release tag from release even as we already do in other workflows https://github.com/asyncapi/asyncapi-react/blob/master/.github/workflows/release-wc-and-playground.yml#L37

I only had to make sure we alwasy remove `v`. It was not needed in other workflows as others do npm and `npm publish` removes `v` on its own

**Related issue(s)**
Fixes #577 