### PR TITLE
fix: move definition of asyncapi to code path of all generate* methods.

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -166,6 +166,8 @@ class Generator {
   async generate(asyncapiDocument) {
     if (!(asyncapiDocument instanceof AsyncAPIDocument)) throw new Error('Parameter "asyncapiDocument" must be an AsyncAPIDocument object.');
 
+    this.asyncapi = asyncapiDocument;
+
     if (this.output === 'fs') {
       xfs.mkdirpSync(this.targetDir);
       if (!this.forceWrite) await this.verifyTargetDir(this.targetDir);
@@ -260,8 +262,8 @@ class Generator {
     this.originalAsyncAPI = asyncapiString;
 
     /** @type {AsyncAPIDocument} Parsed AsyncAPI schema. See {@link https://github.com/asyncapi/parser-js/blob/master/API.md#module_@asyncapi/parser+AsyncAPIDocument|AsyncAPIDocument} for details on object structure. */
-    this.asyncapi = await parse(asyncapiString, parserOptions);
-    return this.generate(this.asyncapi);
+    const asyncapi = await parse(asyncapiString, parserOptions);
+    return this.generate(asyncapi);
   }
 
   /**


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

As things stand before my change:
- The `generate()` method does not set `this.asyncapi`
- `generateFromString()` sets `this.asyncapi` then calls `generate()`
- `generateFromUrl()` and `generateFromFile()` both call `generateFromString()`

Therefore, `generate()` cannot function when called directly, yet the other methods work by virtue of `generateFromString()`. I simply moved the definition of `this.asyncapi` to the `generate()` method as it is the root of the other methods.

**Related issue(s)**

https://github.com/asyncapi/html-template/issues/252