### PR TITLE
docs: add dotnet-nats-template to list of generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Template Name | Description | Source code
 `@asyncapi/markdown-template` | Generates documentation in Markdown file | [click here](https://github.com/asyncapi/markdown-template)
 `@asyncapi/ts-nats-template` | Generates TypeScript NATS client | [click here](https://github.com/asyncapi/ts-nats-template/)
 `@asyncapi/go-watermill-template` | Generates Go client using Watermill | [click here](https://github.com/asyncapi/go-watermill-template)
+`@asyncapi/dotnet-nats-template` | Generates .NET C# client using NATS | [click here](https://github.com/asyncapi/dotnet-nats-template)
 
 <!-- TEMPLATES-LIST:END -->
 


### PR DESCRIPTION
C# template is not listed in the readme.