### PR TITLE
fix: do not register a ts-node if an env. variable with ts_node_dev is set 

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -152,7 +152,8 @@ utils.registerSourceMap = () => {
 utils.registerTypeScript = () => {
   const { REGISTER_INSTANCE, register } = require('ts-node');
   // if the ts-node has already been registered before, do not register it again.
-  if (process[REGISTER_INSTANCE]) {
+  // Check the env. TS_NODE_ENV if ts-node started via ts-node-dev package
+  if (process[REGISTER_INSTANCE] || process.env.TS_NODE_DEV) {
     return;
   }
   register();


### PR DESCRIPTION
Signed-off-by: Hasan Oezdemir <21654050+nodify-at@users.noreply.github.com>

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Fixes an issues caused indirectly by generator library which re-register the ts-node if ts-node called by ts-node-dev.

**Related issue(s)**
See: https://github.com/asyncapi/generator/issues/759