### PR TITLE
fix: use fs.stats instead of deprecated fs.exists which uses invalid …

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,8 +18,18 @@ utils.readlink = util.promisify(fs.readlink);
 utils.readFile = util.promisify(fs.readFile);
 utils.writeFile = util.promisify(fs.writeFile);
 utils.copyFile = util.promisify(fs.copyFile);
-utils.exists = util.promisify(fs.exists);
 utils.readDir = util.promisify(fs.readdir);
+
+utils.exists = async (path) => {
+  try {
+    await fs.promises.stat(path, fs.constants.F_OK);
+    return true;
+  } catch (error) {
+    // File does not exist.
+    log.debug(`File ${path} couldn't be found. Error: ${error.message}`);
+    return false;
+  }
+};
 
 /**
  * Checks if a string is a filesystem path.

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -25,7 +25,7 @@ describe('Utils', () => {
       const result = utils.getTemplateDetails(templatePath, 'package.json');
       expect(log.debug).toHaveBeenCalledWith(logMessage.NODE_MODULES_INSTALL);
       expect(result).toStrictEqual({
-        name: templateNpmName, 
+        name: templateNpmName,
         pkgPath: path.resolve('./testTemplate')
       });
     });
@@ -39,7 +39,7 @@ describe('Utils', () => {
       expect(log.debug).not.toHaveBeenCalledWith(logMessage.NODE_MODULES_INSTALL);
       expect(log.debug).not.toHaveBeenCalledWith(logMessage.templateNotFound(templateNpmName));
       expect(result).toStrictEqual({
-        name: templateNpmName, 
+        name: templateNpmName,
         pkgPath: packagePath
       });
     });
@@ -59,6 +59,18 @@ describe('Utils', () => {
       resolveFrom.__resolveFromValue = undefined;
       const result = utils.getTemplateDetails(templateNpmName, 'package.json');
       expect(result).toStrictEqual(undefined);
+    });
+  });
+
+  describe('#exists', () => {
+    it('should return true if file exist', async () => {
+      const exists = await utils.exists(`${process.cwd()}/package.json`);
+      expect(exists).toBeTruthy();
+    });
+
+    it('should return false if file does not exist', async () => {
+      const exists = await utils.exists('./invalid-file');
+      expect(exists).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
…callback args.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
Replaces fs.exists with fs.stats, wrapped utils.exists to keep the code base stable.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The 3rd option will not automatically close the issue after the merge. -->
Resolves #836