### PR TITLE
fix: revert release workflow to working version

### DIFF
--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -90,7 +90,10 @@ jobs:
         name: Install dependencies
         run: npm install
       - if: steps.packagejson.outputs.exists == 'true'
-        name: Publish to any of NPM, Github, and Docker Hub
+        name: Add plugin for conventional commits
+        run: npm install conventional-changelog-conventionalcommits@5.0.0
+      - if: steps.packagejson.outputs.exists == 'true'
+        name: Publish to any of NPM, and Github
         id: release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -101,7 +104,7 @@ jobs:
           GIT_AUTHOR_EMAIL: info@asyncapi.io
           GIT_COMMITTER_NAME: asyncapi-bot
           GIT_COMMITTER_EMAIL: info@asyncapi.io
-        run: npm run release
+        run: npx semantic-release@19.0.4
       - if: failure() # Only, on failure, send a message on the 94_bot-failing-ci slack channel
         name: Report workflow run status to Slack
         uses: 8398a7/action-slack@v3


### PR DESCRIPTION
Release fails https://github.com/asyncapi/generator/actions/runs/3591963645/jobs/6047212449

We cannot release https://github.com/asyncapi/generator/pull/869 

CI got broken because of https://github.com/asyncapi/generator/pull/874 I let that happen, forgot to stop the bot for generator...

Eventually it will not be a problem once I fix https://github.com/asyncapi/.github/issues/172

`fix: ` because we need to trigger patch for https://github.com/asyncapi/generator/pull/869 