### PR TITLE
chore: change the order of codeowner usernames

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,7 @@
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
 
+* @fmvilas @derberg @magicmatatjahu @jonaslagoni @asyncapi-bot-eve
+
 # All .md files
 *.md @Florence-Njeri @pratik2315
-
-* @fmvilas @derberg @magicmatatjahu @jonaslagoni @asyncapi-bot-eve


### PR DESCRIPTION
**Description**

- Changed the order of codeowner usernames in the CODEOWNERS file, so that only docs maintainers are pinged when documentation-related PRs are created.
- Reference [documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)