### PR TITLE
docs: fix JSDoc field for object parameter templateParams in Generator constructor

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -77,7 +77,7 @@ class Generator {
    * @param {String} templateName  Name of the template to generate.
    * @param {String} targetDir     Path to the directory where the files will be generated.
    * @param {Object} options
-   * @param {String} [options.templateParams]   Optional parameters to pass to the template. Each template define their own params.
+   * @param {Object<string, string>} [options.templateParams]   Optional parameters to pass to the template. Each template define their own params.
    * @param {String} [options.entrypoint]       Name of the file to use as the entry point for the rendering process. Use in case you want to use only a specific template file. Note: this potentially avoids rendering every file in the template.
    * @param {String[]} [options.noOverwriteGlobs] List of globs to skip when regenerating the template.
    * @param {Object<String, Boolean | String | String[]>} [options.disabledHooks] Object with hooks to disable. The key is a hook type. If key has "true" value, then the generator skips all hooks from the given type. If the value associated with a key is a string with the name of a single hook, then the generator skips only this single hook name. If the value associated with a key is an array of strings, then the generator skips only hooks from the array.


### PR DESCRIPTION
**Description**

Previously, we're using `String` as the field type of `templateParams`, which was not correct, since we're bound to use `Object.keys()` on it and `Object.keys()` on string results on an array over the characters.

The different behaviors between `Object<string, string>`, `Object`, and `String` can be seen in this sandbox: https://codesandbox.io/s/bold-cache-r4tw43?file=/src/index.js.

Initially I wanted to go with just `Object` (as I mentioned on the issue), but apparently it accepts all kind of types, including string and numbers (which is wrong), so I went with `Record<string, string>`. Then, I saw the other object field types in the constructor and they are all using `Object<string, T>`, so I used that instead for consistency purposes.

https://github.com/asyncapi/generator/blob/76c106b18d53d256df5861a9b2acbb8d0963c2a0/lib/generator.js#L83

As we could see from the sandbox, the result is as the following:

```js
/**
 *
 * @param {Object<string, string>} param
 */
function testFnObjectWithTypes(param) {}

testFnObjectWithTypes(123); // TypeError
testFnObjectWithTypes(""); // TypeError
testFnObjectWithTypes({}); // ok
testFnObjectWithTypes({ hello: "world" }); // ok
```

**Related issue(s)**

Fixes https://github.com/asyncapi/generator/issues/985.