### PR TITLE
chore: update multi-parser to last version

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -8,17 +8,18 @@ const parser = module.exports;
  * Convert the template defined value `apiVersion: 'v1'` to only contain the numeric value `1`.
  */
 parser.sanitizeTemplateApiVersion = (apiVersion) => {
+  if (!apiVersion) return;
   if (apiVersion && apiVersion.length > 1) {
-    return apiVersion.substring(1);
+    return Number(apiVersion.substring(1));
   }
-  return apiVersion;
+  return Number(apiVersion);
 };
 
 parser.parse = async (asyncapi, oldOptions, generator) => {
   let apiVersion = this.sanitizeTemplateApiVersion(generator.templateConfig.apiVersion);
   // Defaulting to apiVersion v1 to convert it to the Parser-API v1 afterwards.
   if (!this.usesNewAPI(generator.templateConfig)) {
-    apiVersion = '1';
+    apiVersion = 1;
   }
   const options = convertOldOptionsToNew(oldOptions, generator);
   const parser = NewParser(apiVersion, {parserOptions: options, includeSchemaParsers: true});
@@ -34,7 +35,7 @@ parser.parse = async (asyncapi, oldOptions, generator) => {
  * If the template expect one of the Parser-API versions, it must be above 0
  */
 parser.usesNewAPI = (templateConfig = {}) => {
-  return Number(this.sanitizeTemplateApiVersion(templateConfig.apiVersion)) > 0;
+  return this.sanitizeTemplateApiVersion(templateConfig.apiVersion) > 0;
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@asyncapi/generator-react-sdk": "^0.2.23",
         "@asyncapi/parser": "2.1.0",
         "@npmcli/arborist": "^2.2.4",
-        "@smoya/multi-parser": "3.0.0",
+        "@smoya/multi-parser": "^4.0.0",
         "ajv": "^8.12.0",
         "chokidar": "^3.4.0",
         "commander": "^6.1.0",
@@ -3018,16 +3018,16 @@
       }
     },
     "node_modules/@smoya/multi-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smoya/multi-parser/-/multi-parser-3.0.0.tgz",
-      "integrity": "sha512-HtA/Png8FQ2vwiKKMSOqNkYGERUFqieeekwtuMsImmgnaiacyq97itehbep179qO/TvHb+3luRZAJ433fHgIxg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smoya/multi-parser/-/multi-parser-4.0.0.tgz",
+      "integrity": "sha512-NgPxSaB3YqwrIVe7AtQ/wh9I2J0BHR4lP0PdqirYYrc0XXRwdDjIRrywEc2jjECWsL7tuGU/QtGMGIVaJe6ZYA==",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.3",
         "@asyncapi/openapi-schema-parser": "^3.0.4",
         "@asyncapi/protobuf-schema-parser": "^3.0.0",
         "@asyncapi/raml-dt-schema-parser": "^4.0.4",
         "parserv2": "npm:@asyncapi/parser@^2.1.0",
-        "parserv3": "npm:@asyncapi/parser@^2.2.0-next-major-spec.2"
+        "parserv3": "npm:@asyncapi/parser@^3.0.0-next-major-spec.3"
       }
     },
     "node_modules/@stoplight/better-ajv-errors": {
@@ -11339,9 +11339,9 @@
     },
     "node_modules/parserv3": {
       "name": "@asyncapi/parser",
-      "version": "2.2.0-next-major-spec.2",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.2.0-next-major-spec.2.tgz",
-      "integrity": "sha512-KkS+sPCHFFPZrFzzx4UGiYDrDfJI583AksLFg6QUKwr5Wjq8o7cIC3Hel2ptaRVv5x1nJz0o6QzFeY7VIWCc1g==",
+      "version": "3.0.0-next-major-spec.3",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.3.tgz",
+      "integrity": "sha512-LCrAQqJpGxraMyU2k1Nh1X6Q1dz7a/YhTRRFFrQHOEo+TUT/kRdoUkRDP++e58dO7h9MBN+/hZK5TaqE+/jQiw==",
       "dependencies": {
         "@asyncapi/specs": "^6.0.0-next-major-spec.6",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   "dependencies": {
     "@asyncapi/generator-react-sdk": "^0.2.23",
     "@asyncapi/parser": "2.1.0",
-    "@smoya/multi-parser": "3.0.0",
     "@npmcli/arborist": "^2.2.4",
+    "@smoya/multi-parser": "^4.0.0",
     "ajv": "^8.12.0",
     "chokidar": "^3.4.0",
     "commander": "^6.1.0",

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -8,21 +8,21 @@ describe('Parser', () => {
   describe('sanitizeTemplateApiVersion', () => {
     it('should return version number when given `v2` syntax', () => {
       const rawVersion = 'v2';
-      const expectedVersion = '2';
+      const expectedVersion = 2;
       const sanitizedVersion = sanitizeTemplateApiVersion(rawVersion);
 
       expect(sanitizedVersion).toStrictEqual(expectedVersion);
     });
     it('should return version number when given `v1` syntax', () => {
       const rawVersion = 'v1';
-      const expectedVersion = '1';
+      const expectedVersion = 1;
       const sanitizedVersion = sanitizeTemplateApiVersion(rawVersion);
 
       expect(sanitizedVersion).toStrictEqual(expectedVersion);
     });
     it('should return version number when given `1` syntax', () => {
       const rawVersion = '1';
-      const expectedVersion = '1';
+      const expectedVersion = 1;
       const sanitizedVersion = sanitizeTemplateApiVersion(rawVersion);
 
       expect(sanitizedVersion).toStrictEqual(expectedVersion);


### PR DESCRIPTION
**Description**

This PR updates `@smoya/multi-parser` to last version (`4.0.0`).