### PR TITLE
feat: add parser API v3 support

### DIFF
--- a/docs/configuration-file.md
+++ b/docs/configuration-file.md
@@ -8,7 +8,7 @@ The `generator` property from `package.json` file must contain a JSON object tha
 |Name|Type|Description|
 |---|---|---|
 |`renderer`| String | Its value can be either `react` or `nunjucks` (default).
-|`apiVersion`| String | Determines which **major** version of the [Parser-API](https://github.com/asyncapi/parser-api) the template uses. For example, `v2` for `v2.x.x`. If not specified, the Generator assumes the template is not compatible with the Parser-API so it will use the [Parser-JS v1 API](https://github.com/asyncapi/parser-js/tree/v1.18.1#api-documentation). For templates that need to support AsyncAPI specification v3 make sure to use `v2` [Parser-API](https://github.com/asyncapi/parser-api). If the template uses a version of the Parser-API that is not supported by the Generator, the Generator will throw an error.
+|`apiVersion`| String | Determines which **major** version of the [Parser-API](https://github.com/asyncapi/parser-api) the template uses. For example, `v2` for `v2.x.x`. If not specified, the Generator assumes the template is not compatible with the Parser-API so it will use the [Parser-JS v1 API](https://github.com/asyncapi/parser-js/tree/v1.18.1#api-documentation). For templates that need to support AsyncAPI specification v3 make sure to use `v3` [Parser-API](https://github.com/asyncapi/parser-api). If the template uses a version of the Parser-API that is not supported by the Generator, the Generator will throw an error.
 |`supportedProtocols`| [String] | A list with all the protocols this template supports.
 |`parameters`| Object[String, Object] | An object with all the parameters that can be passed when generating the template. When using the command line, it's done by indicating `--param name=value` or `-p name=value`.
 |`parameters[param].description`| String | A user-friendly description about the parameter.
@@ -28,7 +28,7 @@ The `generator` property from `package.json` file must contain a JSON object tha
 "generator":
 {
   "renderer": "react",
-  "apiVersion": "v2",
+  "apiVersion": "v3",
   "supportedProtocols": ["amqp", "mqtt"],
   "parameters": {
     "server": {

--- a/lib/templateConfigValidator.js
+++ b/lib/templateConfigValidator.js
@@ -11,7 +11,8 @@ const ajv = new Ajv({ allErrors: true });
 // See https://github.com/asyncapi/parser-api
 const supportedParserAPIMajorVersions = [
   'v1',
-  'v2'
+  'v2',
+  'v3'
 ];
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.14.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-react-sdk": "^0.2.23",
+        "@asyncapi/generator-react-sdk": "^1.0.1",
         "@asyncapi/parser": "^2.1.1",
         "@npmcli/arborist": "^2.2.4",
         "@smoya/multi-parser": "^4.0.0",
@@ -23,7 +23,6 @@
         "js-yaml": "^3.13.1",
         "levenshtein-edit-distance": "^2.0.5",
         "loglevel": "^1.6.8",
-        "markdown-it": "^12.3.2",
         "minimatch": "^3.0.4",
         "node-fetch": "^2.6.0",
         "nunjucks": "^3.2.0",
@@ -66,49 +65,22 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
-      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@asyncapi/avro-schema-parser": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-3.0.3.tgz",
-      "integrity": "sha512-XprbDYPFJ0nc963hPCjbEmM3iu6ypKg/70EFVl0MZJCLbLw/+gBbPy95uV3Qaofm5UQgSI+aTobGhc8rMre4VA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-3.0.4.tgz",
+      "integrity": "sha512-2EwTS+0deHsqIJG41dJGE2/O9pD1RJZpUCahz24tgZzcK/GQM1HBuoVvqBkPcloS9EeOXo/ZcfCMAvflj5UB/g==",
       "dependencies": {
-        "@asyncapi/parser": "^2.1.0",
+        "@asyncapi/parser": "^2.1.1",
         "@types/json-schema": "^7.0.11",
         "avsc": "^5.7.6"
       }
     },
     "node_modules/@asyncapi/generator-react-sdk": {
-      "version": "0.2.25",
-      "resolved": "https://registry.npmjs.org/@asyncapi/generator-react-sdk/-/generator-react-sdk-0.2.25.tgz",
-      "integrity": "sha512-zmVdNaMPTDoUHnAIp33+dkGspEuLIi3BaaHFXY5lmL1XmaD9bU1rK/HLpNKhV32Os6Wp50CuskOwDsoRCeSGow==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/generator-react-sdk/-/generator-react-sdk-1.0.1.tgz",
+      "integrity": "sha512-bklhrOGpK20nlNB5+Jq2NGKgKwetPMez9pKl3h/Kwo1hcysWXVYSJRFS57M7oTagQIo1or6zpg+KYXjzkW+7ZQ==",
       "dependencies": {
-        "@asyncapi/parser": "^1.15.1",
+        "@asyncapi/parser": "^2.1.1",
         "@babel/core": "7.12.9",
         "@babel/preset-env": "^7.12.7",
         "@babel/preset-react": "^7.12.7",
@@ -118,30 +90,6 @@
         "react": "^17.0.1",
         "rollup": "^2.60.1",
         "source-map-support": "^0.5.19"
-      }
-    },
-    "node_modules/@asyncapi/generator-react-sdk/node_modules/@asyncapi/parser": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-1.18.1.tgz",
-      "integrity": "sha512-7sU9DajLV+vA2vShTYmD5lbtbTY6TOcGxB4Z4IcpRp8x5pejOsN32iU05eIYCnuamsi5SMscFxoi6fIO2vPK3Q==",
-      "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "^9.0.6",
-        "@asyncapi/specs": "^4.1.1",
-        "@fmvilas/pseudo-yaml-ast": "^0.3.1",
-        "ajv": "^6.10.1",
-        "js-yaml": "^3.13.1",
-        "json-to-ast": "^2.1.0",
-        "lodash.clonedeep": "^4.5.0",
-        "node-fetch": "^2.6.0",
-        "tiny-merge-patch": "^0.1.2"
-      }
-    },
-    "node_modules/@asyncapi/generator-react-sdk/node_modules/@asyncapi/specs": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-4.3.1.tgz",
-      "integrity": "sha512-EfexhJu/lwF8OdQDm28NKLJHFkx0Gb6O+rcezhZYLPIoNYKXJMh2J1vFGpwmfAcTTh+ffK44Oc2Hs1Q4sLBp+A==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.11"
       }
     },
     "node_modules/@asyncapi/generator-react-sdk/node_modules/@babel/core": {
@@ -174,26 +122,6 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@asyncapi/generator-react-sdk/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@asyncapi/generator-react-sdk/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-    },
     "node_modules/@asyncapi/generator-react-sdk/node_modules/semver": {
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
@@ -211,11 +139,11 @@
       }
     },
     "node_modules/@asyncapi/openapi-schema-parser": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@asyncapi/openapi-schema-parser/-/openapi-schema-parser-3.0.4.tgz",
-      "integrity": "sha512-nfZbL3dTpIQ3K+/V05FBpgOPi7dDWZkqZG8e7pKwtNhwZ0YLBFWTw6RpocztlBlcieFggxZqLm4BT5I1cQbK+Q==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@asyncapi/openapi-schema-parser/-/openapi-schema-parser-3.0.5.tgz",
+      "integrity": "sha512-2CPP0arkI/ibXTdae6DqeQyor3xuSf0GOyh0+yFPqVkbiYPBkC8K2UNbQ610vt8KpcEFeijX+7YuV+FTuQ5CHg==",
       "dependencies": {
-        "@asyncapi/parser": "^2.1.0",
+        "@asyncapi/parser": "^2.1.1",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -305,21 +233,21 @@
       }
     },
     "node_modules/@asyncapi/protobuf-schema-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/protobuf-schema-parser/-/protobuf-schema-parser-3.0.0.tgz",
-      "integrity": "sha512-kjoLrll611K+xYC/iBUlSnZsCHbrhL999ItVHZhObUOjUB991XgonqbSAaihiiDXTYgceOLhJKAN5llkV/LOOA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/protobuf-schema-parser/-/protobuf-schema-parser-3.0.1.tgz",
+      "integrity": "sha512-w6y7/jvnCBwwhAee7/uv6Cb31YAbDm3I6V9s7Jj+MSStA91WOEq1rOFm4YHdJ23oYFbWaQmc5+8MLTnQBGfc4Q==",
       "dependencies": {
-        "@asyncapi/parser": "^2.1.0",
+        "@asyncapi/parser": "^2.1.1",
         "@types/protocol-buffers-schema": "^3.4.1",
         "protocol-buffers-schema": "^3.6.0"
       }
     },
     "node_modules/@asyncapi/raml-dt-schema-parser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@asyncapi/raml-dt-schema-parser/-/raml-dt-schema-parser-4.0.4.tgz",
-      "integrity": "sha512-kKam4jwYYdwqoV5zkEb3YEb8VOrN0785fc4ByazxRd+BT/RnkQTLspjTY/akdDs9DLmU4ChP73Z0vqpek6wojA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@asyncapi/raml-dt-schema-parser/-/raml-dt-schema-parser-4.0.5.tgz",
+      "integrity": "sha512-pIxaQo3p34LIi8RQzgPexv5JnydGEcDr8TVvMzyzu9Z1hPyZTX0+nOjfNAlcsNN7Nq34d18r0oKxf+Ml5rMoEQ==",
       "dependencies": {
-        "@asyncapi/parser": "^2.1.0",
+        "@asyncapi/parser": "^2.1.1",
         "js-yaml": "^4.1.0",
         "ramldt2jsonschema": "^1.2.3",
         "webapi-parser": "^0.5.0"
@@ -2069,14 +1997,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@fmvilas/pseudo-yaml-ast": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@fmvilas/pseudo-yaml-ast/-/pseudo-yaml-ast-0.3.1.tgz",
-      "integrity": "sha512-8OAB74W2a9M3k9bjYD8AjVXkX+qO8c0SqNT5HlgOqx7AxSw8xdksEcZp7gFtfi+4njSxT6+76ZR+1ubjAwQHOg==",
-      "dependencies": {
-        "yaml-ast-parser": "0.0.43"
-      }
-    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -2726,11 +2646,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@jsdevtools/ono": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
-      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
-    },
     "node_modules/@jsdoc/salty": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.5.tgz",
@@ -3022,9 +2937,9 @@
       }
     },
     "node_modules/@smoya/multi-parser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smoya/multi-parser/-/multi-parser-4.0.0.tgz",
-      "integrity": "sha512-NgPxSaB3YqwrIVe7AtQ/wh9I2J0BHR4lP0PdqirYYrc0XXRwdDjIRrywEc2jjECWsL7tuGU/QtGMGIVaJe6ZYA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@smoya/multi-parser/-/multi-parser-4.1.0.tgz",
+      "integrity": "sha512-0q4805I7ZdkKNEbNrbxmBNAdYEAH9aBYCuXiIXCbu8WC0sdRqLWmTsvg/DaNO8ZnsrGhVzy5VITf+8CKlVnGoQ==",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.3",
         "@asyncapi/openapi-schema-parser": "^3.0.4",
@@ -4516,11 +4431,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/call-me-maybe": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
-      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4790,14 +4700,6 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/code-error-fragment": {
-      "version": "0.0.230",
-      "resolved": "https://registry.npmjs.org/code-error-fragment/-/code-error-fragment-0.0.230.tgz",
-      "integrity": "sha512-cadkfKp6932H8UkhzE/gcUqhRMNf8jHzkAN7+5Myabswaghu4xABTgPHDCjW+dBAJxj/SpkTYokpzDqY4pCzQw==",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/code-point-at": {
@@ -5424,6 +5326,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
       "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -6796,11 +6699,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
-    },
-    "node_modules/grapheme-splitter": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
-      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
     },
     "node_modules/gray-matter": {
       "version": "2.1.1",
@@ -9741,18 +9639,6 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
-    "node_modules/json-to-ast": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/json-to-ast/-/json-to-ast-2.1.0.tgz",
-      "integrity": "sha512-W9Lq347r8tA1DfMvAGn9QNcgYm4Wm7Yc+k8e6vezpMnRT+NHbtlxgNBXRVjXe9YM6eTn6+p/MKOlV/aABJcSnQ==",
-      "dependencies": {
-        "code-error-fragment": "0.0.230",
-        "grapheme-splitter": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -9907,6 +9793,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
       "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dev": true,
       "dependencies": {
         "uc.micro": "^1.0.1"
       }
@@ -9954,11 +9841,6 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -10149,6 +10031,7 @@
       "version": "12.3.2",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
       "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "~2.1.0",
@@ -10173,7 +10056,8 @@
     "node_modules/markdown-it/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/markdown-link": {
       "version": "0.1.1",
@@ -10231,7 +10115,8 @@
     "node_modules/mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "dev": true
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -11264,16 +11149,20 @@
     },
     "node_modules/parserv2": {
       "name": "@asyncapi/parser",
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.0.tgz",
-      "integrity": "sha512-78jjN3eW4ZmgJEa6Ap15lofzADCeItO4wHcAY2Jod3qLB1xf1zFDZQdtm3VSHYLeLhwoC1A33bAtzEf7M5P2bg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.1.tgz",
+      "integrity": "sha512-FnJ5Du9iMu9MEb5mF90gF7z1ZkdnazisBsm3GHVFr7VaiF8luAoB+bklGYFwoMb+9QWKWr1099orY5VyXULAcQ==",
       "dependencies": {
         "@asyncapi/specs": "^5.1.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json": "^3.20.2",
+        "@stoplight/json-ref-readers": "^1.2.2",
         "@stoplight/json-ref-resolver": "^3.1.5",
         "@stoplight/spectral-core": "^1.16.1",
         "@stoplight/spectral-functions": "^1.7.2",
         "@stoplight/spectral-parsers": "^1.0.2",
+        "@stoplight/spectral-ref-resolver": "^1.0.3",
+        "@stoplight/types": "^13.12.0",
         "@types/json-schema": "^7.0.11",
         "@types/urijs": "^1.19.19",
         "ajv": "^8.11.0",
@@ -11343,11 +11232,11 @@
     },
     "node_modules/parserv3": {
       "name": "@asyncapi/parser",
-      "version": "3.0.0-next-major-spec.3",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.3.tgz",
-      "integrity": "sha512-LCrAQqJpGxraMyU2k1Nh1X6Q1dz7a/YhTRRFFrQHOEo+TUT/kRdoUkRDP++e58dO7h9MBN+/hZK5TaqE+/jQiw==",
+      "version": "3.0.0-next-major-spec.10",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.10.tgz",
+      "integrity": "sha512-z3kdevI4s7mz4+fElG/fqYtI7Kpuc7TAkrCfABTl6/h75PO0xI8bnz0IfT5xk5sSqSuitupMlfw1CPfYFfFo0g==",
       "dependencies": {
-        "@asyncapi/specs": "^6.0.0-next-major-spec.6",
+        "@asyncapi/specs": "^6.0.0-next-major-spec.9",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
         "@stoplight/json-ref-resolver": "^3.1.5",
         "@stoplight/spectral-core": "^1.16.1",
@@ -11367,9 +11256,9 @@
       }
     },
     "node_modules/parserv3/node_modules/@asyncapi/specs": {
-      "version": "6.0.0-next-major-spec.7",
-      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.0.0-next-major-spec.7.tgz",
-      "integrity": "sha512-rorau4qa1rjlIz4vGy3MuzQKSyKyJWuRa3DbFKopixDCjnAOIScVDc/M6/T8X9Ay+GQhebcYrbiPT4JUvWbFAA==",
+      "version": "6.0.0-next-major-spec.13",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.0.0-next-major-spec.13.tgz",
+      "integrity": "sha512-mnGllHVaUscCHaDnYfLGo84KK81NcTmevVFQP94RusKM2SvtYkbBuC0nwQ6ie/PAEHQy+kn2PjrJlfwwm7VgEQ==",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
@@ -13835,11 +13724,6 @@
         "xtend": "~4.0.1"
       }
     },
-    "node_modules/tiny-merge-patch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/tiny-merge-patch/-/tiny-merge-patch-0.1.2.tgz",
-      "integrity": "sha512-NLoA//tTMBPTr0oGdq+fxnvVR0tDa8tOcG9ZGbuovGzROadZ404qOV4g01jeWa5S8MC9nAOvu5bQgCW7s8tlWQ=="
-    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -14214,7 +14098,8 @@
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
     },
     "node_modules/uglify-js": {
       "version": "3.17.4",
@@ -14904,11 +14789,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-    },
-    "node_modules/yaml-ast-parser": {
-      "version": "0.0.43",
-      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
-      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="
     },
     "node_modules/yargs": {
       "version": "15.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@asyncapi/generator-react-sdk": "^1.0.1",
         "@asyncapi/parser": "^2.1.1",
         "@npmcli/arborist": "^2.2.4",
-        "@smoya/multi-parser": "^4.0.0",
+        "@smoya/multi-parser": "^5.0.0",
         "ajv": "^8.12.0",
         "chokidar": "^3.4.0",
         "commander": "^6.1.0",
@@ -2937,16 +2937,17 @@
       }
     },
     "node_modules/@smoya/multi-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smoya/multi-parser/-/multi-parser-4.1.0.tgz",
-      "integrity": "sha512-0q4805I7ZdkKNEbNrbxmBNAdYEAH9aBYCuXiIXCbu8WC0sdRqLWmTsvg/DaNO8ZnsrGhVzy5VITf+8CKlVnGoQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@smoya/multi-parser/-/multi-parser-5.0.0.tgz",
+      "integrity": "sha512-8cBG+pD478YHblQafBDngubW6lVcxJK+WJb0EtMnPYhP9upMBceRAnWRVL1RgZ5t/3C2C9DsjOo7IazW78Kf5g==",
       "dependencies": {
         "@asyncapi/avro-schema-parser": "^3.0.3",
         "@asyncapi/openapi-schema-parser": "^3.0.4",
         "@asyncapi/protobuf-schema-parser": "^3.0.0",
         "@asyncapi/raml-dt-schema-parser": "^4.0.4",
-        "parserv2": "npm:@asyncapi/parser@^2.1.0",
-        "parserv3": "npm:@asyncapi/parser@^3.0.0-next-major-spec.3"
+        "parserapiv1": "npm:@asyncapi/parser@^2.1.0",
+        "parserapiv2": "npm:@asyncapi/parser@3.0.0-next-major-spec.8",
+        "parserapiv3": "npm:@asyncapi/parser@^3.0.0-next-major-spec.10"
       }
     },
     "node_modules/@stoplight/better-ajv-errors": {
@@ -11147,7 +11148,7 @@
       "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
       "dev": true
     },
-    "node_modules/parserv2": {
+    "node_modules/parserapiv1": {
       "name": "@asyncapi/parser",
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.1.tgz",
@@ -11176,12 +11177,12 @@
         "webapi-parser": "^0.5.0"
       }
     },
-    "node_modules/parserv2/node_modules/argparse": {
+    "node_modules/parserapiv1/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
-    "node_modules/parserv2/node_modules/js-yaml": {
+    "node_modules/parserapiv1/node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
@@ -11192,7 +11193,7 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/parserv2/node_modules/node-fetch": {
+    "node_modules/parserapiv1/node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
@@ -11211,17 +11212,17 @@
         }
       }
     },
-    "node_modules/parserv2/node_modules/tr46": {
+    "node_modules/parserapiv1/node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
-    "node_modules/parserv2/node_modules/webidl-conversions": {
+    "node_modules/parserapiv1/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
-    "node_modules/parserv2/node_modules/whatwg-url": {
+    "node_modules/parserapiv1/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
@@ -11230,11 +11231,11 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-    "node_modules/parserv3": {
+    "node_modules/parserapiv2": {
       "name": "@asyncapi/parser",
-      "version": "3.0.0-next-major-spec.10",
-      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.10.tgz",
-      "integrity": "sha512-z3kdevI4s7mz4+fElG/fqYtI7Kpuc7TAkrCfABTl6/h75PO0xI8bnz0IfT5xk5sSqSuitupMlfw1CPfYFfFo0g==",
+      "version": "3.0.0-next-major-spec.8",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.8.tgz",
+      "integrity": "sha512-d8ebYM08BCsx3Q4AeLke6naU/NrcAXFEVpS6b3EWcKRdUDce+v0X5k9aDH+YXWCaQApEF28UzcxhlSOJvhIFgQ==",
       "dependencies": {
         "@asyncapi/specs": "^6.0.0-next-major-spec.9",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
@@ -11255,7 +11256,7 @@
         "webapi-parser": "^0.5.0"
       }
     },
-    "node_modules/parserv3/node_modules/@asyncapi/specs": {
+    "node_modules/parserapiv2/node_modules/@asyncapi/specs": {
       "version": "6.0.0-next-major-spec.13",
       "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.0.0-next-major-spec.13.tgz",
       "integrity": "sha512-mnGllHVaUscCHaDnYfLGo84KK81NcTmevVFQP94RusKM2SvtYkbBuC0nwQ6ie/PAEHQy+kn2PjrJlfwwm7VgEQ==",
@@ -11263,12 +11264,12 @@
         "@types/json-schema": "^7.0.11"
       }
     },
-    "node_modules/parserv3/node_modules/argparse": {
+    "node_modules/parserapiv2/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
-    "node_modules/parserv3/node_modules/js-yaml": {
+    "node_modules/parserapiv2/node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
@@ -11279,7 +11280,7 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/parserv3/node_modules/node-fetch": {
+    "node_modules/parserapiv2/node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
       "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
@@ -11298,17 +11299,104 @@
         }
       }
     },
-    "node_modules/parserv3/node_modules/tr46": {
+    "node_modules/parserapiv2/node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
-    "node_modules/parserv3/node_modules/webidl-conversions": {
+    "node_modules/parserapiv2/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
-    "node_modules/parserv3/node_modules/whatwg-url": {
+    "node_modules/parserapiv2/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/parserapiv3": {
+      "name": "@asyncapi/parser",
+      "version": "3.0.0-next-major-spec.11",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.11.tgz",
+      "integrity": "sha512-jJX2HGmeXykvJ1KfrYadeYbf0Dh4mDDvD5KNtf/SJGvVANdYRQrgCV14VlBMnv7kPVELuv8JaYEedYe6x4F8zA==",
+      "dependencies": {
+        "@asyncapi/specs": "^6.0.0-next-major-spec.9",
+        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
+        "@stoplight/json-ref-resolver": "^3.1.5",
+        "@stoplight/spectral-core": "^1.16.1",
+        "@stoplight/spectral-functions": "^1.7.2",
+        "@stoplight/spectral-parsers": "^1.0.2",
+        "@types/json-schema": "^7.0.11",
+        "@types/urijs": "^1.19.19",
+        "ajv": "^8.11.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "avsc": "^5.7.5",
+        "js-yaml": "^4.1.0",
+        "jsonpath-plus": "^7.2.0",
+        "node-fetch": "2.6.7",
+        "ramldt2jsonschema": "^1.2.3",
+        "webapi-parser": "^0.5.0"
+      }
+    },
+    "node_modules/parserapiv3/node_modules/@asyncapi/specs": {
+      "version": "6.0.0-next-major-spec.13",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.0.0-next-major-spec.13.tgz",
+      "integrity": "sha512-mnGllHVaUscCHaDnYfLGo84KK81NcTmevVFQP94RusKM2SvtYkbBuC0nwQ6ie/PAEHQy+kn2PjrJlfwwm7VgEQ==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.11"
+      }
+    },
+    "node_modules/parserapiv3/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/parserapiv3/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/parserapiv3/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/parserapiv3/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/parserapiv3/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/parserapiv3/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@asyncapi/generator-react-sdk": "^1.0.1",
     "@asyncapi/parser": "^2.1.1",
     "@npmcli/arborist": "^2.2.4",
-    "@smoya/multi-parser": "^4.0.0",
+    "@smoya/multi-parser": "^5.0.0",
     "ajv": "^8.12.0",
     "chokidar": "^3.4.0",
     "commander": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "license": "Apache-2.0",
   "homepage": "https://github.com/asyncapi/generator",
   "dependencies": {
-    "@asyncapi/generator-react-sdk": "^0.2.23",
+    "@asyncapi/generator-react-sdk": "^1.0.1",
     "@asyncapi/parser": "^2.1.1",
     "@npmcli/arborist": "^2.2.4",
     "@smoya/multi-parser": "^4.0.0",
@@ -62,7 +62,6 @@
     "js-yaml": "^3.13.1",
     "levenshtein-edit-distance": "^2.0.5",
     "loglevel": "^1.6.8",
-    "markdown-it": "^12.3.2",
     "minimatch": "^3.0.4",
     "node-fetch": "^2.6.0",
     "nunjucks": "^3.2.0",

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -6,9 +6,9 @@ const dummyV3Document = fs.readFileSync(path.resolve(__dirname, './docs/dummyV3.
 
 describe('Parser', () => {
   describe('sanitizeTemplateApiVersion', () => {
-    it('should return version number when given `v2` syntax', () => {
-      const rawVersion = 'v2';
-      const expectedVersion = 2;
+    it('should return version number when given `v99` syntax', () => {
+      const rawVersion = 'v99';
+      const expectedVersion = 99;
       const sanitizedVersion = sanitizeTemplateApiVersion(rawVersion);
 
       expect(sanitizedVersion).toStrictEqual(expectedVersion);
@@ -45,6 +45,14 @@ describe('Parser', () => {
 
       expect(isUsingNewAPI).toStrictEqual(true);
     });
+    it('should use new parser api if v3', () => {
+      const templateConfig = {
+        apiVersion: 'v3'
+      };
+      const isUsingNewAPI = usesNewAPI(templateConfig);
+
+      expect(isUsingNewAPI).toStrictEqual(true);
+    });
     it('should not use new API if no apiVersion', () => {
       const templateConfig = { };
       const isUsingNewAPI = usesNewAPI(templateConfig);
@@ -65,6 +73,12 @@ describe('Parser', () => {
       expect(parsedDocument).toBeDefined();
       expect(parsedDocument.document.version()).toEqual('2.3.0');
     });
+    it('should be able to parse AsyncAPI v2 document for parser API v3', async () => {
+      const parsedDocument = await parse(dummyV2Document, {}, {templateConfig: {apiVersion: 'v3'}});
+
+      expect(parsedDocument).toBeDefined();
+      expect(parsedDocument.document.version()).toEqual('2.3.0');
+    });
     it('should not be able to parse AsyncAPI v3 document for parser API v1', async () => {
       const parsedDocument = await parse(dummyV3Document, {}, {templateConfig: {apiVersion: 'v1'}});
 
@@ -79,6 +93,12 @@ describe('Parser', () => {
     });
     it('should be able to parse AsyncAPI v3 document for parser API v2', async () => {
       const parsedDocument = await parse(dummyV3Document, {}, {templateConfig: {apiVersion: 'v2'}});
+
+      expect(parsedDocument).toBeDefined();
+      expect(parsedDocument.document.version()).toEqual('3.0.0');
+    });
+    it('should be able to parse AsyncAPI v3 document for parser API v3', async () => {
+      const parsedDocument = await parse(dummyV3Document, {}, {templateConfig: {apiVersion: 'v3'}});
 
       expect(parsedDocument).toBeDefined();
       expect(parsedDocument.document.version()).toEqual('3.0.0');


### PR DESCRIPTION
**Description**
This PR adds parser API v3 support to the generator and fixes a bug where if you ask for parser API v2, you get v3.

**Related issue(s)**
Related to https://github.com/asyncapi/html-template/issues/456
Blocked by https://github.com/smoya/multi-parser-js/pull/5