### PR TITLE
fix: bring back git verification

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -168,7 +168,7 @@ class Generator {
    */
   async generate(asyncapiDocument, parseOptions = {}) {
     this.validateAsyncAPIDocument(asyncapiDocument);
-    this.setupOutput();
+    await this.setupOutput();
     this.setLogLevel();
 
     await this.installAndSetupTemplate();
@@ -200,13 +200,15 @@ class Generator {
    *
    * @example
    * const generator = new Generator();
-   * generator.setupOutput();
-   *
+   * await generator.setupOutput();
+   * 
+   * @async
+   * 
    * @throws {Error} If 'output' is set to 'string' without providing 'entrypoint'.
    */
-  setupOutput() {
+  async setupOutput() {
     if (this.output === 'fs') {
-      this.setupFSOutput();
+      await this.setupFSOutput();
     } else if (this.output === 'string' && this.entrypoint === undefined) {
       throw new Error('Parameter entrypoint is required when using output = "string"');
     }


### PR DESCRIPTION
This PR https://github.com/asyncapi/generator/pull/1047/ broke feature that validates if output dir for generation points to directory with not staged changes

Related: https://github.com/asyncapi/cli/pull/908