### PR TITLE
docs: update usage doc with info about `--watch` flag and absence of `--version` flag

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,24 +8,29 @@ There are two ways to use the generator:
 - [Generator library](#using-as-a-modulepackage)
 
 ## AsyncAPI CLI
+Generates whatever you want using templates compatible with AsyncAPI Generator.
 ```bash
-Usage: asyncapi generate fromTemplate <asyncapi> <template> [<options>]
+USAGE
+  $ asyncapi generate fromTemplate [ASYNCAPI] [TEMPLATE] [-h] [-d <value>] [-i] [--debug] [-n <value>] [-o <value>] [--force-write] [-w] [-p <value>] [--map-base-url <value>]
 
-- <asyncapi>: Local path or URL pointing to AsyncAPI document for example https://bit.ly/asyncapi
-- <template>: Name of the generator template like for example @asyncapi/html-template or https://github.com/asyncapi/html-template
+ARGUMENTS
+  ASYNCAPI  - Local path, url or context-name pointing to AsyncAPI file
+  TEMPLATE  - Name of the generator template like for example @asyncapi/html-template or https://github.com/asyncapi/html-template
 
-- <options>:
-  -V, --version                  output the generator version
-  -d, --disable-hook [hooks...]  disable a specific hook type or hooks from a given hook type
-  --debug                        enable more specific errors in the console
-  -i, --install                  install the template and its dependencies (defaults to false)
-  -n, --no-overwrite <glob>      glob or path of the file(s) to skip when regenerating
-  -o, --output <outputDir>       directory to put the generated files (defaults to current directory)
-  -p, --param <name=value>       additional parameters to pass to templates
-  --force-write                  force writing of the generated files to a given directory even if it is a Git repository with unstaged files or not empty dir (defaults to false)
-  --watch-template               watches the template directory and the AsyncAPI document, and re-generates the files when changes occur. Ignores the output directory. This flag should be used only for template development.
-  --map-base-url <url:folder>    maps all schema references from base URL to local folder
-  -h, --help                     display help for command
+FLAGS
+  -d, --disable-hook=<value>...  Disable a specific hook type or hooks from a given hook type
+  -h, --help                     Show CLI help.
+  -i, --install                  Installs the template and its dependencies (defaults to false)
+  -n, --no-overwrite=<value>...  Glob or path of the file(s) to skip when regenerating
+  -o, --output=<value>           Directory where to put the generated files (defaults to current directory)
+  -p, --param=<value>...         Additional param to pass to templates
+  -w, --watch                    Watches the template directory and the AsyncAPI document, and re-generate the files when changes occur. Ignores the output directory.
+  --debug                        Enable more specific errors in the console
+  --force-write                  Force writing of the generated files to given directory even if it is a git repo with unstaged files or not empty dir (defaults to false)
+  --map-base-url=<value>         Maps all schema references from base url to local folder
+
+EXAMPLES
+  $ asyncapi generate fromTemplate asyncapi.yaml @asyncapi/html-template --param version=1.0.0 singleFile=true --output ./docs --force-write
 ```
 
 All templates are installable npm packages. Therefore, the value of `template` can be anything supported by `npm install`. Here's a summary of the possibilities:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -154,4 +154,4 @@ try {
 }
 ```
 
-See the [API documentation](/docs/tools/generator/api) for more examples and full API reference information.
+See the [API documentation](api) for more examples and full API reference information.


### PR DESCRIPTION
To reflect changes in asyncapi generate fromTemplate command for --watch option

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

Documentation update to follow `asyncapi generate fromTemplate --help`
