### PR TITLE
docs: fix link that is giving 404 

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -149,4 +149,4 @@ try {
 }
 ```
 
-See the [API documentation](api.md) for more examples and full API reference information.
+See the [API documentation](api) for more examples and full API reference information.


### PR DESCRIPTION
This PR addresses a 404 link in the Generator docs that was reported in the following docs feedback post:
https://github.com/orgs/asyncapi/discussions/1080 