### PR TITLE
feat: added a compile option to enable skipping default transpilation in react

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -43,7 +43,7 @@ const DEFAULT_TEMPLATES_DIR = path.resolve(ROOT_DIR, 'node_modules');
 
 const TRANSPILED_TEMPLATE_LOCATION = '__transpiled';
 const TEMPLATE_CONTENT_DIRNAME = 'template';
-const GENERATOR_OPTIONS = ['debug', 'disabledHooks', 'entrypoint', 'forceWrite', 'install', 'noOverwriteGlobs', 'output', 'templateParams', 'mapBaseUrlToFolder', 'url', 'auth', 'token', 'registry'];
+const GENERATOR_OPTIONS = ['debug', 'disabledHooks', 'entrypoint', 'forceWrite', 'install', 'noOverwriteGlobs', 'output', 'templateParams', 'mapBaseUrlToFolder', 'url', 'auth', 'token', 'registry', 'compile'];
 const logMessage = require('./logMessages');
 
 const shouldIgnoreFile = filePath =>
@@ -90,13 +90,15 @@ class Generator {
    * @param {String} [options.registry.token]     Optional parameter to pass npm registry auth token that you can grab from .npmrc file
    */
 
-  constructor(templateName, targetDir, { templateParams = {}, entrypoint, noOverwriteGlobs, disabledHooks, output = 'fs', forceWrite = false, install = false, debug = false, mapBaseUrlToFolder = {}, registry = {}} = {}) {
+  constructor(templateName, targetDir, { templateParams = {}, entrypoint, noOverwriteGlobs, disabledHooks, output = 'fs', forceWrite = false, install = false, debug = false, mapBaseUrlToFolder = {}, registry = {}, compile = false } = {}) {
     const options = arguments[arguments.length - 1];
     this.verifyoptions(options);
     if (!templateName) throw new Error('No template name has been specified.');
     if (!entrypoint && !targetDir) throw new Error('No target directory has been specified.');
     if (!['fs', 'string'].includes(output)) throw new Error(`Invalid output type ${output}. Valid values are 'fs' and 'string'.`);
 
+    /** @type {Boolean} Whether to compile the template or use the cached transpiled version. */
+    this.compile = compile;
     /** @type {Object} Npm registry information. */
     this.registry = registry;
     /** @type {String} Name of the template to generate. */
@@ -391,7 +393,7 @@ class Generator {
    */
   async configureTemplate() {
     if (isReactTemplate(this.templateConfig)) {
-      await configureReact(this.templateDir, this.templateContentDir, TRANSPILED_TEMPLATE_LOCATION);
+      await configureReact(this.templateDir, this.templateContentDir, TRANSPILED_TEMPLATE_LOCATION, this.compile);
     } else {
       this.nunjucks = configureNunjucks(this.debug, this.templateDir);
     }

--- a/lib/renderer/react.js
+++ b/lib/renderer/react.js
@@ -14,11 +14,13 @@ const reactExport = module.exports;
  * @param {string} templateContentDir where the template content are located
  * @param {string} transpiledTemplateLocation folder for the transpiled code
  */
-reactExport.configureReact = async (templateLocation, templateContentDir, transpiledTemplateLocation) => {
+reactExport.configureReact = async (templateLocation, templateContentDir, transpiledTemplateLocation, compile) => {
   const outputDir = path.resolve(templateLocation, `./${transpiledTemplateLocation}`);
-  await AsyncReactSDK.transpileFiles(templateContentDir, outputDir, {
-    recursive: true
-  });
+  if (compile) {
+    await AsyncReactSDK.transpileFiles(templateContentDir, outputDir, {
+      recursive: true
+    });
+  }
 };
 
 /**

--- a/test/generator.test.js
+++ b/test/generator.test.js
@@ -26,6 +26,7 @@ describe('Generator', () => {
       expect(gen.forceWrite).toStrictEqual(false);
       expect(gen.install).toStrictEqual(false);
       expect(gen.templateParams).toStrictEqual({});
+      expect(gen.compile).toStrictEqual(false);
     });
 
     it('works with all the params', () => {
@@ -39,6 +40,7 @@ describe('Generator', () => {
         templateParams: {
           test: true,
         },
+        compile: true,
       });
       expect(gen.templateName).toStrictEqual('testTemplate');
       expect(gen.targetDir).toStrictEqual(__dirname);
@@ -48,6 +50,7 @@ describe('Generator', () => {
       expect(gen.output).toStrictEqual('string');
       expect(gen.forceWrite).toStrictEqual(true);
       expect(gen.install).toStrictEqual(true);
+      expect(gen.compile).toStrictEqual(true);
       expect(() => gen.templateParams.test).toThrow('Template parameter "test" has not been defined in the package.json file under generator property. Please make sure it\'s listed there before you use it in your template.');
 
       // Mock params on templateConfig so it doesn't fail.


### PR DESCRIPTION

**Description**

The PR introduces a new option `compile` in the  `Generator` class contructor which is by default `false` ,by default the `React` template files are not transpiled. When setting the `compile` options to `true` the transpilation process takes place.

I have also added/updated test for it. Below are the result

![image](https://github.com/asyncapi/generator/assets/127925465/b377105d-ea7c-4aa3-981d-aca69e90c0c7)


**Related issue(s)**
Related to #521 
![image](https://github.com/asyncapi/generator/assets/127925465/69ad5399-6f8e-403e-b12e-ca78e660528b)
which added this functionality