### PR TITLE
fix: refactor `asyncapiDocument.server()` to `asyncapiDocument.servers().get()` to fix `conditionalFiles`

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -879,7 +879,7 @@ class Generator {
     if (!shouldOverwriteFile) return;
 
     if (this.templateConfig.conditionalFiles && this.templateConfig.conditionalFiles[relativeSourceFile]) {
-      const server = this.templateParams.server && asyncapiDocument.servers().get(this.templateParams.server)
+      const server = this.templateParams.server && asyncapiDocument.servers().get(this.templateParams.server);
       const source = jmespath.search({
         ...asyncapiDocument.json(),
         ...{

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -879,7 +879,7 @@ class Generator {
     if (!shouldOverwriteFile) return;
 
     if (this.templateConfig.conditionalFiles && this.templateConfig.conditionalFiles[relativeSourceFile]) {
-      const server = this.templateParams.server && asyncapiDocument.server(this.templateParams.server);
+      const server = this.templateParams.server && asyncapiDocument.servers().get(this.templateParams.server)
       const source = jmespath.search({
         ...asyncapiDocument.json(),
         ...{


### PR DESCRIPTION
removed `asyncapiDocument.server(this.templateParams.server)` and used `asyncapiDocument.servers().get(this.templateParams.server)`

**Related issue(s)**
Fixes #1206 