### PR TITLE
fix: remove package name from version tag for Docker tagging

### DIFF
--- a/.changeset/breezy-falcons-hammer.md
+++ b/.changeset/breezy-falcons-hammer.md
@@ -2,4 +2,4 @@
 "@asyncapi/generator": patch
 ---
 
-Removed package name from version tag for Docker tagging
+Fix docker image publishing. Removed package name from version tag for Docker tagging.

--- a/.changeset/breezy-falcons-hammer.md
+++ b/.changeset/breezy-falcons-hammer.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/generator": patch
+---
+
+Removed package name from version tag for Docker tagging

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -14,7 +14,7 @@ jobs:
         id: version
         run: |
           VERSION=${{github.event.release.tag_name}}
-          VERSION_WITHOUT_V=${VERSION:1}
+          VERSION_WITHOUT_V="${VERSION##*@}"
           echo "value=${VERSION_WITHOUT_V}" >> $GITHUB_OUTPUT
 
       - name: Set Up QEMU

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -14,7 +14,7 @@ jobs:
         id: version
         run: |
           VERSION=${{github.event.release.tag_name}}
-          VERSION_WITHOUT_V="${VERSION##*@}"
+          VERSION_WITHOUT_V=${VERSION##*@}
           echo "value=${VERSION_WITHOUT_V}" >> $GITHUB_OUTPUT
 
       - name: Set Up QEMU


### PR DESCRIPTION
Changes Added.

1. Removed the package name for the version tag. 

Related issue(s)

Related to: https://github.com/asyncapi/generator/issues/1044