### PR TITLE
fix: update the default context for docker publishing

### DIFF
--- a/.changeset/breezy-falcons-hammer.md
+++ b/.changeset/breezy-falcons-hammer.md
@@ -2,4 +2,4 @@
 "@asyncapi/generator": patch
 ---
 
-Removed package name from version tag for Docker tagging
+Fix docker image publishing. Removed package name from version tag for Docker tagging.

--- a/.changeset/breezy-falcons-hammer.md
+++ b/.changeset/breezy-falcons-hammer.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/generator": patch
+---
+
+Removed package name from version tag for Docker tagging

--- a/.changeset/breezy-falcons-hammer.md
+++ b/.changeset/breezy-falcons-hammer.md
@@ -1,5 +1,0 @@
----
-"@asyncapi/generator": patch
----
-
-Fix docker image publishing. Removed package name from version tag for Docker tagging.

--- a/.changeset/proud-brooms-accept.md
+++ b/.changeset/proud-brooms-accept.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/generator": patch
+---
+
+update the git context for the docker versioning.

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -14,7 +14,7 @@ jobs:
         id: version
         run: |
           VERSION=${{github.event.release.tag_name}}
-          VERSION_WITHOUT_V=${VERSION:1}
+          VERSION_WITHOUT_V="${VERSION##*@}"
           echo "value=${VERSION_WITHOUT_V}" >> $GITHUB_OUTPUT
 
       - name: Set Up QEMU

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build Image
         uses: docker/build-push-action@v4
         with:
-          context: './apps/generator'
+          context: "{{defaultContext}}:apps/generator"
           push: true
           load: false
           build-args: |

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -14,7 +14,7 @@ jobs:
         id: version
         run: |
           VERSION=${{github.event.release.tag_name}}
-          VERSION_WITHOUT_V="${VERSION##*@}"
+          VERSION_WITHOUT_V=${VERSION##*@}
           echo "value=${VERSION_WITHOUT_V}" >> $GITHUB_OUTPUT
 
       - name: Set Up QEMU


### PR DESCRIPTION
Changes Added.

1. updated the default git context for docker.   

Related issue(s)

Related to: https://github.com/asyncapi/generator/issues/1044