### PR TITLE
chore: use @asyncapi/multi-parser instead of @smoya/multi-parser

### DIFF
--- a/apps/generator/lib/parser.js
+++ b/apps/generator/lib/parser.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const { convertToOldAPI } = require('@asyncapi/parser');
-const { ConvertDocumentParserAPIVersion, NewParser } = require('@smoya/multi-parser');
+const { ConvertDocumentParserAPIVersion, NewParser } = require('@asyncapi/multi-parser');
 
 const parser = module.exports;
 

--- a/apps/generator/package.json
+++ b/apps/generator/package.json
@@ -49,11 +49,12 @@
   "license": "Apache-2.0",
   "homepage": "https://github.com/asyncapi/generator",
   "dependencies": {
+    "@asyncapi/generator-react-sdk": "^1.0.18",
+    "@asyncapi/multi-parser": "^2.1.1",
+    "@asyncapi/nunjucks-filters": "*",
+    "@asyncapi/parser": "^3.0.14",
     "@npmcli/arborist": "5.6.3",
     "@npmcli/config": "^8.0.2",
-    "@asyncapi/generator-react-sdk": "^1.0.18",
-    "@asyncapi/parser": "^3.0.14",
-    "@smoya/multi-parser": "^5.0.0",
     "ajv": "^8.12.0",
     "chokidar": "^3.4.0",
     "commander": "^6.1.0",
@@ -74,14 +75,13 @@
     "simple-git": "^3.3.0",
     "source-map-support": "^0.5.19",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.3",
-    "@asyncapi/nunjucks-filters": "*"
+    "typescript": "^4.9.3"
   },
   "devDependencies": {
     "eslint": "^6.8.0",
     "eslint-plugin-jest": "^23.8.2",
-    "eslint-plugin-sonarjs": "^0.5.0",
     "eslint-plugin-react": "^7.34.1",
+    "eslint-plugin-sonarjs": "^0.5.0",
     "jest": "^27.3.1",
     "jsdoc-to-markdown": "^7.1.1",
     "markdown-toc": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,15 +20,15 @@
     },
     "apps/generator": {
       "name": "@asyncapi/generator",
-      "version": "2.1.2",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/generator-react-sdk": "^1.0.18",
+        "@asyncapi/multi-parser": "^2.1.1",
         "@asyncapi/nunjucks-filters": "*",
         "@asyncapi/parser": "^3.0.14",
         "@npmcli/arborist": "5.6.3",
         "@npmcli/config": "^8.0.2",
-        "@smoya/multi-parser": "^5.0.0",
         "ajv": "^8.12.0",
         "chokidar": "^3.4.0",
         "commander": "^6.1.0",
@@ -159,7 +159,8 @@
     },
     "node_modules/@asyncapi/avro-schema-parser": {
       "version": "3.0.24",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/avro-schema-parser/-/avro-schema-parser-3.0.24.tgz",
+      "integrity": "sha512-YMyr2S2heMrWHRyECknjHeejlZl5exUSv9nD1gTejAT13fSf0PqIRydZ9ZuoglCLBg55AeehypR2zLIBu/9kHQ==",
       "dependencies": {
         "@asyncapi/parser": "^3.1.0",
         "@types/json-schema": "^7.0.11",
@@ -233,13 +234,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@asyncapi/multi-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@asyncapi/multi-parser/-/multi-parser-2.1.1.tgz",
+      "integrity": "sha512-nGf9ete+KHKQ/VdaLQ/AoqIAm6/L5oehyx5Cam/hUpybPNRyBkOCqiikDreoc2PiduaAcYkLbZdQceoKpEbSdg==",
+      "dependencies": {
+        "@asyncapi/avro-schema-parser": "^3.0.3",
+        "@asyncapi/openapi-schema-parser": "^3.0.4",
+        "@asyncapi/parser": "*",
+        "@asyncapi/protobuf-schema-parser": "^3.0.0",
+        "@asyncapi/raml-dt-schema-parser": "^4.0.4",
+        "parserapiv1": "npm:@asyncapi/parser@^2.1.0",
+        "parserapiv2": "npm:@asyncapi/parser@3.0.0-next-major-spec.8"
+      }
+    },
     "node_modules/@asyncapi/nunjucks-filters": {
       "resolved": "apps/nunjucks-filters",
       "link": true
     },
     "node_modules/@asyncapi/openapi-schema-parser": {
       "version": "3.0.24",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/openapi-schema-parser/-/openapi-schema-parser-3.0.24.tgz",
+      "integrity": "sha512-7wz2yVDedJMS+TzOuqCvRWJMc6pNHICKZcOhnW6ZvyVLAh7hYIqQE1WA4OoXT4cKVbwSU3V2Q4bZagSsAIQd6Q==",
       "dependencies": {
         "@asyncapi/parser": "^3.1.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
@@ -330,7 +346,8 @@
     },
     "node_modules/@asyncapi/protobuf-schema-parser": {
       "version": "3.2.14",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/protobuf-schema-parser/-/protobuf-schema-parser-3.2.14.tgz",
+      "integrity": "sha512-7v64Jxhz2IBfaQECUhfwuLRMFQTysvmqtvT+Esgd9NooIPRnkEzgCbBnC25oGjzSB6Sju28G406lQpO15HHaEw==",
       "dependencies": {
         "@asyncapi/parser": "^3.1.0",
         "@types/protocol-buffers-schema": "^3.4.1",
@@ -339,7 +356,8 @@
     },
     "node_modules/@asyncapi/raml-dt-schema-parser": {
       "version": "4.0.24",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/raml-dt-schema-parser/-/raml-dt-schema-parser-4.0.24.tgz",
+      "integrity": "sha512-Fy9IwCXPpXoG4Mkm7sXgWucSwYg8POwdx16xuHAmV6AerpcM8nk5mT/tARLtR3wrMst3OBwReEVYzwT3esSb8g==",
       "dependencies": {
         "@asyncapi/parser": "^3.1.0",
         "js-yaml": "^4.1.0",
@@ -349,11 +367,13 @@
     },
     "node_modules/@asyncapi/raml-dt-schema-parser/node_modules/argparse": {
       "version": "2.0.1",
-      "license": "Python-2.0"
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/@asyncapi/raml-dt-schema-parser/node_modules/js-yaml": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3238,23 +3258,28 @@
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -3262,23 +3287,28 @@
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -3330,19 +3360,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
-      }
-    },
-    "node_modules/@smoya/multi-parser": {
-      "version": "5.0.9",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@asyncapi/avro-schema-parser": "^3.0.3",
-        "@asyncapi/openapi-schema-parser": "^3.0.4",
-        "@asyncapi/protobuf-schema-parser": "^3.0.0",
-        "@asyncapi/raml-dt-schema-parser": "^4.0.4",
-        "parserapiv1": "npm:@asyncapi/parser@^2.1.0",
-        "parserapiv2": "npm:@asyncapi/parser@3.0.0-next-major-spec.8",
-        "parserapiv3": "npm:@asyncapi/parser@^3.1.0"
       }
     },
     "node_modules/@stoplight/better-ajv-errors": {
@@ -3773,7 +3790,8 @@
     },
     "node_modules/@types/protocol-buffers-schema": {
       "version": "3.4.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/protocol-buffers-schema/-/protocol-buffers-schema-3.4.3.tgz",
+      "integrity": "sha512-8cCg6BiIj4jS0LXUFq3sndmd46yyPLYqMzvXLcTM1MRubh3sfZlQiehoCjGDxSHTqGSjjx8EtVNryIAl0njQWg==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -10118,14 +10136,16 @@
     },
     "node_modules/json-schema-migrate": {
       "version": "0.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/json-schema-migrate/-/json-schema-migrate-0.2.0.tgz",
+      "integrity": "sha512-dq4/oHWmtw/+0ytnXsDqVn+VsVweTEmzm5jLgguPn9BjSzn6/q58ZiZx3BHiQyJs612f0T5Z+MrUEUUY5DHsRg==",
       "dependencies": {
         "ajv": "^5.0.0"
       }
     },
     "node_modules/json-schema-migrate/node_modules/ajv": {
       "version": "5.5.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
       "dependencies": {
         "co": "^4.6.0",
         "fast-deep-equal": "^1.0.0",
@@ -10135,11 +10155,13 @@
     },
     "node_modules/json-schema-migrate/node_modules/fast-deep-equal": {
       "version": "1.1.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha512-fueX787WZKCV0Is4/T2cyAdM4+x1S3MXXOAhavE1ys/W42SHAPacLTQhucja22QBYrfGw50M2sRiXPtTGv9Ymw=="
     },
     "node_modules/json-schema-migrate/node_modules/json-schema-traverse": {
       "version": "0.3.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA=="
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -10412,7 +10434,8 @@
     },
     "node_modules/long": {
       "version": "5.2.3",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -11588,7 +11611,8 @@
     "node_modules/parserapiv1": {
       "name": "@asyncapi/parser",
       "version": "2.1.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-2.1.2.tgz",
+      "integrity": "sha512-2pHKnr2P8EujcrvZo4x4zNwsEIAg5vb1ZEhl2+OH0YBg8EYH/Xx73XZ+bbwLaYIg1gvFjm29jNB9UL3CMeDU5w==",
       "dependencies": {
         "@asyncapi/specs": "^5.1.0",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
@@ -11613,18 +11637,21 @@
     },
     "node_modules/parserapiv1/node_modules/@asyncapi/specs": {
       "version": "5.1.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-5.1.0.tgz",
+      "integrity": "sha512-yffhETqehkim43luMnPKOwzY0D0YtU4bKpORIXIaid6p5Y5kDLrMGJaEPkNieQp03HMjhjFrnUPtT8kvqe0+aQ==",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
     },
     "node_modules/parserapiv1/node_modules/argparse": {
       "version": "2.0.1",
-      "license": "Python-2.0"
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/parserapiv1/node_modules/js-yaml": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -11634,7 +11661,8 @@
     },
     "node_modules/parserapiv1/node_modules/node-fetch": {
       "version": "2.6.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -11652,15 +11680,18 @@
     },
     "node_modules/parserapiv1/node_modules/tr46": {
       "version": "0.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/parserapiv1/node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/parserapiv1/node_modules/whatwg-url": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -11669,7 +11700,8 @@
     "node_modules/parserapiv2": {
       "name": "@asyncapi/parser",
       "version": "3.0.0-next-major-spec.8",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/parser/-/parser-3.0.0-next-major-spec.8.tgz",
+      "integrity": "sha512-d8ebYM08BCsx3Q4AeLke6naU/NrcAXFEVpS6b3EWcKRdUDce+v0X5k9aDH+YXWCaQApEF28UzcxhlSOJvhIFgQ==",
       "dependencies": {
         "@asyncapi/specs": "^6.0.0-next-major-spec.9",
         "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
@@ -11692,18 +11724,21 @@
     },
     "node_modules/parserapiv2/node_modules/@asyncapi/specs": {
       "version": "6.7.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.7.1.tgz",
+      "integrity": "sha512-jEaW2vgAwD9GboCdO/TI1zN2k+iowL8YFYwiZwTIr4U4KDmsgo3BLypScl6Jl4+IvY9RdsWE67nuzVX7jooiqQ==",
       "dependencies": {
         "@types/json-schema": "^7.0.11"
       }
     },
     "node_modules/parserapiv2/node_modules/argparse": {
       "version": "2.0.1",
-      "license": "Python-2.0"
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/parserapiv2/node_modules/js-yaml": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -11713,7 +11748,8 @@
     },
     "node_modules/parserapiv2/node_modules/node-fetch": {
       "version": "2.6.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -11731,96 +11767,18 @@
     },
     "node_modules/parserapiv2/node_modules/tr46": {
       "version": "0.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/parserapiv2/node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/parserapiv2/node_modules/whatwg-url": {
       "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
-    "node_modules/parserapiv3": {
-      "name": "@asyncapi/parser",
-      "version": "3.1.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@asyncapi/specs": "^6.7.1",
-        "@openapi-contrib/openapi-schema-to-json-schema": "~3.2.0",
-        "@stoplight/json": "^3.20.2",
-        "@stoplight/json-ref-readers": "^1.2.2",
-        "@stoplight/json-ref-resolver": "^3.1.5",
-        "@stoplight/spectral-core": "^1.16.1",
-        "@stoplight/spectral-functions": "^1.7.2",
-        "@stoplight/spectral-parsers": "^1.0.2",
-        "@stoplight/spectral-ref-resolver": "^1.0.3",
-        "@stoplight/types": "^13.12.0",
-        "@types/json-schema": "^7.0.11",
-        "@types/urijs": "^1.19.19",
-        "ajv": "^8.11.0",
-        "ajv-errors": "^3.0.0",
-        "ajv-formats": "^2.1.1",
-        "avsc": "^5.7.5",
-        "js-yaml": "^4.1.0",
-        "jsonpath-plus": "^7.2.0",
-        "node-fetch": "2.6.7"
-      }
-    },
-    "node_modules/parserapiv3/node_modules/@asyncapi/specs": {
-      "version": "6.7.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.11"
-      }
-    },
-    "node_modules/parserapiv3/node_modules/argparse": {
-      "version": "2.0.1",
-      "license": "Python-2.0"
-    },
-    "node_modules/parserapiv3/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/parserapiv3/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/parserapiv3/node_modules/tr46": {
-      "version": "0.0.3",
-      "license": "MIT"
-    },
-    "node_modules/parserapiv3/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/parserapiv3/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -12159,8 +12117,9 @@
     },
     "node_modules/protobufjs": {
       "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.2.tgz",
+      "integrity": "sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -12225,7 +12184,8 @@
     },
     "node_modules/ramldt2jsonschema": {
       "version": "1.2.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/ramldt2jsonschema/-/ramldt2jsonschema-1.2.3.tgz",
+      "integrity": "sha512-+wLDAV2NNv9NkfEUOYStaDu/6RYgYXeC1zLtXE+dMU/jDfjpN4iJnBGycDwFTFaIQGosOQhxph7fEX6Mpwxdug==",
       "dependencies": {
         "commander": "^5.0.0",
         "js-yaml": "^3.14.0",
@@ -12239,7 +12199,8 @@
     },
     "node_modules/ramldt2jsonschema/node_modules/commander": {
       "version": "5.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "engines": {
         "node": ">= 6"
       }
@@ -14381,14 +14342,16 @@
     },
     "node_modules/webapi-parser": {
       "version": "0.5.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/webapi-parser/-/webapi-parser-0.5.0.tgz",
+      "integrity": "sha512-fPt6XuMqLSvBz8exwX4QE1UT+pROLHa00EMDCdO0ybICduwQ1V4f7AWX4pNOpCp+x+0FjczEsOxtQU0d8L3QKw==",
       "dependencies": {
         "ajv": "6.5.2"
       }
     },
     "node_modules/webapi-parser/node_modules/ajv": {
       "version": "6.5.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+      "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
       "dependencies": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -14398,7 +14361,8 @@
     },
     "node_modules/webapi-parser/node_modules/fast-deep-equal": {
       "version": "2.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w=="
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",


### PR DESCRIPTION
**Description**

[@smoya/multi-parser](https://github.com/smoya/multi-parser-js) has been deprecated. Now its source code is included and released as part of https://github.com/asyncapi/parser-js monorepo.