### PR TITLE
fix: remove `source-map-support` package

### DIFF
--- a/.changeset/lemon-feet-fail.md
+++ b/.changeset/lemon-feet-fail.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/generator": minor
+---
+
+Remove `source-map-support` package

--- a/.changeset/lemon-feet-fail.md
+++ b/.changeset/lemon-feet-fail.md
@@ -2,4 +2,4 @@
 "@asyncapi/generator": patch
 ---
 
-Remove `source-map-support` package
+Removed the source-map-support package from the AsyncAPI Generator, as it is no longer required for version 2, which now supports Node.js version 18.12.0 and above.

--- a/.changeset/lemon-feet-fail.md
+++ b/.changeset/lemon-feet-fail.md
@@ -1,5 +1,5 @@
 ---
-"@asyncapi/generator": minor
+"@asyncapi/generator": patch
 ---
 
 Remove `source-map-support` package

--- a/apps/generator/lib/generator.js
+++ b/apps/generator/lib/generator.js
@@ -27,7 +27,6 @@ const {
   fetchSpec,
   isReactTemplate,
   isJsFile,
-  registerSourceMap,
   getTemplateDetails,
   convertCollectionToObject,
 } = require('./utils');
@@ -56,8 +55,6 @@ const shouldIgnoreFile = filePath =>
 const shouldIgnoreDir = dirPath =>
   dirPath === '.git'
   || dirPath.startsWith(`.git${path.sep}`);
-
-registerSourceMap();
 
 class Generator {
   /**

--- a/apps/generator/lib/utils.js
+++ b/apps/generator/lib/utils.js
@@ -135,16 +135,6 @@ utils.isAsyncFunction = (fn) => {
 };
 
 /**
- * Register `source-map-support` package.
- * This package provides source map support for stack traces in Node - also for transpiled code from TS.
- *
- * @private
- */
-utils.registerSourceMap = () => {
-  require('source-map-support').install();
-};
-
-/**
  * Register TypeScript transpiler. It enables transpilation of TS filters and hooks on the fly.
  *
  * @private

--- a/apps/generator/package.json
+++ b/apps/generator/package.json
@@ -73,7 +73,6 @@
     "resolve-pkg": "^2.0.0",
     "semver": "^7.3.2",
     "simple-git": "^3.3.0",
-    "source-map-support": "^0.5.19",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.3"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
         "resolve-pkg": "^2.0.0",
         "semver": "^7.3.2",
         "simple-git": "^3.3.0",
-        "source-map-support": "^0.5.19",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.3"
       },


### PR DESCRIPTION
**Description**

- This PR removes `source-map-support` package which is not needed anymore.

**Related issue(s)**
Fixes #1067