### PR TITLE
docs: minor updation in generated files output folder path

### DIFF
--- a/apps/generator/docs/generator-template.md
+++ b/apps/generator/docs/generator-template.md
@@ -159,7 +159,7 @@ To see this in action, navigate to the **python-mqtt-client-template** directory
 
 ``` cmd
 Generation in progress. Keep calm and wait a bit... done
-Check out your shiny new generated files at output.
+Check out your shiny new generated files at test/project.
 ```
 
 Navigating to the **test/project** directory. You should see a **client.py** file; the only content is `Temperature Service`.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

While following the [generator template tutorial ](https://www.asyncapi.com/docs/tools/generator/generator-template) I found a minor fix to be done in docs.

After running the command `asyncapi generate fromTemplate test/fixtures/asyncapi.yml ./ -o test/project` the template files are  created in `test/project` folder instead of `output` folder as stated in docs.

**Related issue(s)**
N/A