### PR TITLE
refactor: use an object spread instead of `Object.assign` in filters

### DIFF
--- a/apps/nunjucks-filters/src/index.js
+++ b/apps/nunjucks-filters/src/index.js
@@ -1,4 +1,7 @@
 const customFilters = require('./customFilters');
 const lodashFilters = require('./lodashFilters');
 
-module.exports = Object.assign({}, lodashFilters, customFilters);
+module.exports = {
+    ...lodashFilters,
+    ...customFilters
+  };

--- a/apps/nunjucks-filters/src/index.js
+++ b/apps/nunjucks-filters/src/index.js
@@ -2,6 +2,5 @@ const customFilters = require('./customFilters');
 const lodashFilters = require('./lodashFilters');
 
 module.exports = {
-    ...lodashFilters,
-    ...customFilters
-  };
+  ...lodashFilters,
+  ...customFilters};


### PR DESCRIPTION
Description
refactored apps/nunjucks-filters/src/index.js mentioned in this [issue](https://sonarcloud.io/project/issues?languages=js&issueStatuses=OPEN%2CCONFIRMED&id=asyncapi_generator&open=AZD-TPs2DKL_zKkK1XuA)

Changes Made
Removed object assign and used object spread

related https://github.com/asyncapi/generator/issues/1272