### PR TITLE
refactor: optional chaining instead of expression in `parser.js`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,7 @@ extends:
   - plugin:sonarjs/recommended
 
 parserOptions:
-  ecmaVersion: 2018
+  ecmaVersion: 2020
   sourceType: module
   ecmaFeatures: 
     jsx: true

--- a/apps/generator/lib/parser.js
+++ b/apps/generator/lib/parser.js
@@ -63,7 +63,7 @@ function convertOldOptionsToNew(oldOptions, generator) {
   }
 
   const resolvers = [];
-  if (generator && generator.mapBaseUrlToFolder && generator.mapBaseUrlToFolder.url) {
+  if (generator?.mapBaseUrlToFolder?.url) {
     resolvers.push(...getMapBaseUrlToFolderResolvers(generator.mapBaseUrlToFolder));
   }
   if (oldOptions.resolve) {


### PR DESCRIPTION
Description
refactored apps/generator/lib/parser.js mentioned in this [issue](https://sonarcloud.io/project/issues?fileUuids=AZB4seZIgviDxNeZYbJz&issueStatuses=OPEN%2CCONFIRMED&id=asyncapi_generator&open=AZB4sej0gviDxNeZYbKi&tab=code)

Changes Made-
used optional chaining to maintain readability.