### PR TITLE
fix: updating `turbo.json` file for pipelines

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build": {
       "outputs": []
     },


### PR DESCRIPTION
**Description**
-> While running the command `npm run lint:fix` warnings were thrown in the terminal due to deprecated pipeline field in turbo.json file which is now replaced by latest tasks field

-> Run script `npm run lint:fix`

-> Docs reference:- https://turbo.build/repo/docs/reference/configuration#defining-tasks

-> Screenshots

| Before | After |
|-----------|--------|
|![image](https://github.com/user-attachments/assets/0d2fd818-593e-4ac2-8549-ce755b320ed9)|![image](https://github.com/user-attachments/assets/91988569-6ea9-4c73-8f92-29c7e0fd2e81)|

cc: @derberg 