### PR TITLE
docs: jsdoc return statement update

### DIFF
--- a/apps/generator/docs/api.md
+++ b/apps/generator/docs/api.md
@@ -39,9 +39,9 @@ Reference API documentation for AsyncAPI Generator library.
         * [.executeAfterHook()](#Generator+executeAfterHook) ⇒ `Promise.<void>`
         * [.parseInput()](#Generator+parseInput)
         * [.configureTemplate()](#Generator+configureTemplate)
-        * ~~[.generateFromString(asyncapiString, [parseOptions])](#Generator+generateFromString) ⇒ `Promise`~~
-        * [.generateFromURL(asyncapiURL)](#Generator+generateFromURL) ⇒ `Promise`
-        * [.generateFromFile(asyncapiFile)](#Generator+generateFromFile) ⇒ `Promise`
+        * ~~[.generateFromString(asyncapiString, [parseOptions])](#Generator+generateFromString) ⇒ `Promise.<(TemplateRenderResult|undefined)>`~~
+        * [.generateFromURL(asyncapiURL)](#Generator+generateFromURL) ⇒ `Promise.<(TemplateRenderResult|undefined)>`
+        * [.generateFromFile(asyncapiFile)](#Generator+generateFromFile) ⇒ `Promise.<(TemplateRenderResult|undefined)>`
         * [.installTemplate([force])](#Generator+installTemplate)
     * _static_
         * [.getTemplateFile(templateName, filePath, [templatesDir])](#Generator.getTemplateFile) ⇒ `Promise`

--- a/apps/generator/lib/generator.js
+++ b/apps/generator/lib/generator.js
@@ -436,7 +436,7 @@ class Generator {
    * @param  {String} asyncapiString AsyncAPI string to use as source.
    * @param  {Object} [parseOptions={}] AsyncAPI Parser parse options. Check out {@link https://www.github.com/asyncapi/parser-js|@asyncapi/parser} for more information.
    * @deprecated Use the `generate` function instead. Just change the function name and it works out of the box.
-   * @return {Promise}
+   * @return {Promise<TemplateRenderResult|undefined>}
    */
   async generateFromString(asyncapiString, parseOptions = {}) {
     const isParsableCompatible = asyncapiString && typeof asyncapiString === 'string';
@@ -466,7 +466,7 @@ class Generator {
    * }
    *
    * @param  {String} asyncapiURL Link to AsyncAPI file
-   * @return {Promise}
+   * @return {Promise<TemplateRenderResult|undefined>}
    */
   async generateFromURL(asyncapiURL) {
     const doc = await fetchSpec(asyncapiURL);
@@ -493,7 +493,7 @@ class Generator {
    * }
    *
    * @param  {String} asyncapiFile AsyncAPI file to use as source.
-   * @return {Promise}
+   * @return {Promise<TemplateRenderResult|undefined>}
    */
   async generateFromFile(asyncapiFile) {
     const doc = await readFile(asyncapiFile, { encoding: 'utf8' });


### PR DESCRIPTION
**Description**

Updating return statements of functions  `generateFromString`, `generateFromURL` and `generateFromFile` by adding type `TemplateRenderResult | undefined`


**Related issue(s)**

Fixes: #507

Screenshot of markdown rendered on website:

|Before|After|
|--------|--------|
|![image](https://github.com/user-attachments/assets/e53d2d72-dfcf-4b58-9cf6-d01344348179)|![Screenshot from 2025-01-11 14-30-34](https://github.com/user-attachments/assets/6fab5ff1-f22f-49e6-b911-0494ad73e338)|


cc: @derberg @ItshMoh





