### PR TITLE
fix: skip unnecessary test runs for bot-generated and non-critical PRs

### DIFF
--- a/.github/workflows/pr-testing-with-test-project.yml
+++ b/.github/workflows/pr-testing-with-test-project.yml
@@ -7,7 +7,26 @@ on:
 
 jobs:
   test:
-    if: github.event.pull_request.draft == false
+    if: >
+      github.event.pull_request.draft == false &&
+      !(
+        (github.actor == 'asyncapi-bot' && (
+          startsWith(github.event.pull_request.title, 'ci: update of files from global .github repo') || 
+          startsWith(github.event.pull_request.title, 'chore(release):')
+        )) ||
+        (github.actor == 'asyncapi-bot-eve' && (
+          startsWith(github.event.pull_request.title, 'ci: update of files from global .github repo') || 
+          startsWith(github.event.pull_request.title, 'chore(release):')
+        )) ||
+        (github.actor == 'allcontributors[bot]' && 
+          startsWith(github.event.pull_request.title, 'docs: add')
+        ) ||
+        (github.event.pull_request.files.*.path == 'README.md') ||
+        (github.event.pull_request.files.*.path == 'docs/**') ||
+        (github.event.pull_request.files.*.path == '.github/**') ||
+        (github.event.pull_request.files.*.path == 'CONTRIBUTING.md') ||
+        (github.event.pull_request.files.*.path == 'Development.md')
+      )
     name: Test generator as dependency with Node ${{ matrix.node }}
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->
**Related issue(s)**
fixes #1335
**Description**
This PR updates the pr-testing-with-test-project.yml workflow to skip unnecessary test runs for:

- PRs from asyncapi-bot, asyncapi-bot-eve, and allcontributors[bot] with specific titles (e.g., ci: update of files from global .github repo, chore(release):, docs: add).
-  PRs that only modify non-critical files (e.g., README.md, docs/, .github/, CONTRIBUTING.md, Development.md).
-  PRs that are marked as drafts.


<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The 3rd option will not automatically close the issue after the merge. -->