### PR TITLE
feat: show latest compatible generator version in template  compatibility errors

### DIFF
--- a/apps/generator/lib/versions.js
+++ b/apps/generator/lib/versions.js
@@ -1,0 +1,32 @@
+const https = require('https');
+
+async function getVersionsList() {
+  try {
+    const versions = await fetchNpmVersions('@asyncapi/generator');
+    return versions;
+  } catch (error) {
+    const { getGeneratorVersion } = require('./utils');
+    return [getGeneratorVersion()];
+  }
+}
+
+function fetchNpmVersions(packageName) {
+  return new Promise((resolve, reject) => {
+    https.get(`https://registry.npmjs.org/${packageName}`, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => {
+        try {
+          const versions = Object.keys(JSON.parse(data).versions);
+          resolve(versions);
+        } catch (error) {
+          reject(error);
+        }
+      });
+    }).on('error', reject);
+  });
+}
+
+module.exports = {
+  getVersionsList
+};

--- a/test-template/asyncapi.yml
+++ b/test-template/asyncapi.yml
@@ -1,0 +1,10 @@
+asyncapi: '2.0.0'
+info:
+  title: Example API
+  version: '1.0.0'
+channels:
+  exampleChannel:
+    publish:
+      message:
+        payload:
+          type: string

--- a/test-template/template.yml
+++ b/test-template/template.yml
@@ -1,0 +1,2 @@
+version: 1.0.0
+generator: '>=3.0.0'  # This forces incompatibility with a 2.x.x generator.


### PR DESCRIPTION
solves this [issue](https://github.com/asyncapi/generator/issues/310#issue-608168878)
Issue - When using a template that's not compatible with the current version of the generator, we get an error with a message saying it's not compatible.
It would be great to get an error message saying which is the latest compatible version of the template in regards to the generator version the user is using

Proposed Solution -
Made a new file and added version fetching from NPM registry in versions.js
Updated templateConfigValidator.js to fetch compatible versions and show latest compatible version

Test cases are not included in this PR. Looking for maintainer feedback on this proposed solution.