### PR TITLE
docs: improve AsyncAPI Generator version vs template version Document…

### DIFF
--- a/apps/generator/docs/versioning.md
+++ b/apps/generator/docs/versioning.md
@@ -18,8 +18,10 @@ It is better to lock a specific version of the template and the generator if you
 Generate HTML with the latest AsyncAPI CLI using the html-template.
 ```
 npm install -g @asyncapi/cli
-asyncapi generate fromTemplate asyncapi.yaml @asyncapi/html-template -o ./docs
+asyncapi generate fromTemplate asyncapi.yaml @asyncapi/html-template@3.0.0 --use-new-generator
 ```
+
+> AsyncAPI CLI has multiple versions of the generator, and to use the latest version, you may need to pass the `--use-new-generator` flag. For more details you can also check [asyncapi generate fromTemplate ASYNCAPI TEMPLATE](https://www.asyncapi.com/docs/tools/cli/usage#asyncapi-generate-fromtemplate-asyncapi-template)
 
 Generate HTML using a particular version of the AsyncAPI CLI using the html-template.
 


### PR DESCRIPTION

**Description**
Improve docs of AsyncAPI Generator version vs template version Documentation by adding removing a non-functional command and adding command with `--use-new-generator` flag.


**Related issue(s)**
Fixes: #1367 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced guidance on version compatibility between generator versions and templates.
	- Introduced the requirement of the new flag when generating from templates.
	- Updated command examples to reflect the new syntax.
	- Provided additional references for further command usage details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->