### PR TITLE
feat: added missing unit tests for Utils.js

### DIFF
--- a/apps/generator/test/utils.test.js
+++ b/apps/generator/test/utils.test.js
@@ -73,4 +73,141 @@ describe('Utils', () => {
       expect(exists).toBeFalsy();
     });
   });
-});
+
+ describe('#isFileSystemPath', () => {
+      it('returns true for absolute paths', () => {
+        expect(utils.isFileSystemPath('/absolute/path')).toBe(true);
+      });
+  
+      it('returns true for relative paths', () => {
+        expect(utils.isFileSystemPath('./relative/path')).toBe(true);
+        expect(utils.isFileSystemPath('../relative/path')).toBe(true);
+      });
+  
+      it('returns true for home directory paths', () => {
+        expect(utils.isFileSystemPath('~/home/path')).toBe(true);
+      });
+  
+      it('returns false for URLs', () => {
+        expect(utils.isFileSystemPath('https://example.com')).toBe(false);
+      });
+    });
+  
+    describe('#convertMapToObject', () => {
+      it('converts a Map to an object', () => {
+        const map = new Map([
+          ['key1', 'value1'],
+          ['key2', 'value2'],
+        ]);
+        const result = utils.convertMapToObject(map);
+        expect(result).toEqual({ key1: 'value1', key2: 'value2' });
+      });
+    });
+  
+    describe('#isLocalTemplate', () => {
+      it('returns true for symbolic links', async () => {
+        jest.spyOn(fs, 'lstat').mockResolvedValue({ isSymbolicLink: () => true });
+        const result = await utils.isLocalTemplate('/path/to/template');
+        expect(result).toBe(true);
+      });
+  
+      it('returns false for non-symbolic links', async () => {
+        jest.spyOn(fs, 'lstat').mockResolvedValue({ isSymbolicLink: () => false });
+        const result = await utils.isLocalTemplate('/path/to/template');
+        expect(result).toBe(false);
+      });
+    });
+  
+    describe('#isReactTemplate', () => {
+      it('returns true for React templates', () => {
+        const templateConfig = { renderer: 'react' };
+        expect(utils.isReactTemplate(templateConfig)).toBe(true);
+      });
+  
+      it('returns false for non-React templates', () => {
+        const templateConfig = { renderer: 'html' };
+        expect(utils.isReactTemplate(templateConfig)).toBe(false);
+      });
+    });
+  
+    describe('#fetchSpec', () => {
+      it('fetches content from a URL', async () => {
+        const mockResponse = 'AsyncAPI content';
+        jest.spyOn(global, 'fetch').mockResolvedValue({ text: () => mockResponse });
+        const result = await utils.fetchSpec('https://example.com/asyncapi.yaml');
+        expect(result).toBe(mockResponse);
+      });
+    });
+  
+    describe('#isFilePath', () => {
+      it('returns true for file paths', () => {
+        expect(utils.isFilePath('./path/to/file')).toBe(true);
+      });
+  
+      it('returns false for URLs', () => {
+        expect(utils.isFilePath('https://example.com')).toBe(false);
+      });
+    });
+  
+    describe('#isJsFile', () => {
+      it('returns true for JavaScript files', () => {
+        expect(utils.isJsFile('file.js')).toBe(true);
+        expect(utils.isJsFile('file.jsx')).toBe(true);
+        expect(utils.isJsFile('file.cjs')).toBe(true);
+      });
+  
+      it('returns false for non-JavaScript files', () => {
+        expect(utils.isJsFile('file.txt')).toBe(false);
+      });
+    });
+  
+    describe('#getGeneratorVersion', () => {
+      it('returns the generator version', () => {
+        const version = utils.getGeneratorVersion();
+        expect(version).toBeDefined();
+        expect(typeof version).toBe('string');
+      });
+    });
+  
+    describe('#isAsyncFunction', () => {
+      it('returns true for async functions', () => {
+        const asyncFn = async () => {};
+        expect(utils.isAsyncFunction(asyncFn)).toBe(true);
+      });
+  
+      it('returns false for non-async functions', () => {
+        const syncFn = () => {};
+        expect(utils.isAsyncFunction(syncFn)).toBe(false);
+      });
+    });
+  
+    describe('#registerTypeScript', () => {
+      it('registers TypeScript for .ts files', () => {
+        const tsNode = require('ts-node');
+        jest.spyOn(tsNode, 'register');
+        utils.registerTypeScript('file.ts');
+        expect(tsNode.register).toHaveBeenCalled();
+      });
+  
+      it('does not register TypeScript for non-.ts files', () => {
+        const tsNode = require('ts-node');
+        jest.spyOn(tsNode, 'register');
+        utils.registerTypeScript('file.js');
+        expect(tsNode.register).not.toHaveBeenCalled();
+      });
+    });
+  
+    describe('#convertCollectionToObject', () => {
+      it('converts an array to an object', () => {
+        const array = [
+          { id: () => 'key1', value: 'value1' },
+          { id: () => 'key2', value: 'value2' },
+        ];
+        const result = utils.convertCollectionToObject(array, (item) => item.id());
+        expect(result).toEqual({
+          key1: { id: () => 'key1', value: 'value1' },
+          key2: { id: () => 'key2', value: 'value2' },
+        });
+      });
+    });
+  });


### PR DESCRIPTION
Added Tests
    isFileSystemPath:
        Tests to verify if a string is a valid file system path.

    convertMapToObject:
        Tests to verify if a Map is correctly converted to an object.

    isLocalTemplate:
        Tests to verify if a template path is local or symbolic.

    isReactTemplate:
        Tests to verify if a template configuration is for a React template.

    fetchSpec:
        Tests to verify if an AsyncAPI document is fetched correctly from a URL.

    isFilePath:
        Tests to verify if a string is a file path or a URL.

    isJsFile:
        Tests to verify if a file path points to a JavaScript file.

    getGeneratorVersion:
        Tests to verify if the generator version is correctly retrieved.

    isAsyncFunction:
        Tests to verify if a function is asynchronous.

    registerTypeScript:
        Tests to verify if TypeScript is registered correctly.

    convertCollectionToObject:
        Tests to verify if a collection (array) is converted to an object.
closes #1374 