### PR TITLE
fix: replace the deprecated function url.parse

### DIFF
--- a/apps/generator/lib/utils.js
+++ b/apps/generator/lib/utils.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const util = require('util');
 const path = require('path');
 const fetch = require('node-fetch');
-const url = require('url');
+const { URL } = require('url');
 const resolvePkg = require('resolve-pkg');
 const resolveFrom = require('resolve-from');
 const globalDirs = require('global-dirs');
@@ -101,7 +101,12 @@ utils.fetchSpec = (link) => {
  * @returns {Boolean}
  */
 utils.isFilePath = (str) => {
-  return !url.parse(str).hostname;
+  try {
+    const url = new URL(str);
+    return !url.hostname;
+  } catch (error) {
+    return true;
+  }
 };
 
 /**


### PR DESCRIPTION
**Description**
Replace the deprecated function url.parse as mention in [Nodejs Docs](https://nodejs.org/api/url.html#urlparseurlstring-parsequerystring-slashesdenotehost)

Test cases 
![image](https://github.com/user-attachments/assets/327740ef-3a9d-48b3-9136-a3e7e0dbebc2)


**Related issue(s)**
Fixes: #1376 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved file path processing reliability by enhancing error handling to more accurately distinguish valid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->