### PR TITLE
docs: add `--user=root` in docker command

### DIFF
--- a/apps/generator/docs/usage.md
+++ b/apps/generator/docs/usage.md
@@ -94,12 +94,14 @@ Install [Docker](https://docs.docker.com/get-docker/) first, then use docker to 
 
 ```bash
 docker run --rm -it \
+--user=root \
 -v [ASYNCAPI SPEC FILE LOCATION]:/app/asyncapi.yml \
 -v [GENERATED FILES LOCATION]:/app/output \
-asyncapi/cli [COMMAND HERE]
+asyncapi/cli # docker image [COMMAND HERE]
 
 # Example that you can run inside the cli directory after cloning this repository. First, you specify the mount in the location of your AsyncAPI specification file and then you mount it in the directory where the generation result should be saved.
 docker run --rm -it \
+   --user=root \
    -v ${PWD}/test/fixtures/asyncapi_v1.yml:/app/asyncapi.yml \
    -v ${PWD}/output:/app/output \
    asyncapi/cli generate fromTemplate -o /app/output /app/asyncapi.yml @asyncapi/html-template@3.0.0 --use-new-generator --force-write


### PR DESCRIPTION
**Description**
Added --user=root in docker command on the [page](https://www.asyncapi.com/docs/tools/generator/usage#cli-usage-with-docker).

**Related issue(s)**
Fixes: #1384 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced Docker usage instructions in the guide with updated command examples.
  - Included the `--user=root` option for proper container permissions.
  - Revised the command syntax to provide clearer execution guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->