### PR TITLE
fix(ci): correct naming in Slack notification workflow for discussions

### DIFF
--- a/.github/workflows/issues-prs-notifications.yml
+++ b/.github/workflows/issues-prs-notifications.yml
@@ -53,15 +53,15 @@ jobs:
 
   discussion:
     if: github.event_name == 'discussion' && github.actor != 'asyncapi-bot' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-    name: Notify slack on every new pull request
+    name: Notify slack on every new discussion
     runs-on: ubuntu-latest
     steps:
-      - name: Convert markdown to slack markdown for pull request
+      - name: Convert markdown to slack markdown for discussion
         uses: asyncapi/.github/.github/actions/slackify-markdown@master
         id: discussionmarkdown
         with:
           markdown: "[${{github.event.discussion.title}}](${{github.event.discussion.html_url}}) \n ${{github.event.discussion.body}}"
-      - name: Send info about pull request
+      - name: Send info about discussion
         uses: rtCamp/action-slack-notify@v2
         env:
           SLACK_WEBHOOK: ${{secrets.SLACK_GITHUB_NEWISSUEPR}}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The 3rd option will not automatically close the issue after the merge. -->

This PR updates the Slack notification workflow to correctly reference discussions instead of pull requests in the discussion job.
fix #1392 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated Slack notifications now alert teams on new discussions, delivering pertinent discussion details directly via Slack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->