### PR TITLE
refactor: fix the file path for the import of websocket client in node `example.js`

### DIFF
--- a/packages/templates/clients/js/websocket/example.js
+++ b/packages/templates/clients/js/websocket/example.js
@@ -1,4 +1,4 @@
-const WSClient = require('./tests/temp/snapshotTestResult/client-postman.js');
+const WSClient = require('./test/temp/snapshotTestResult/client-postman');
 // Example usage
 const wsClient = new WSClient();
 


### PR DESCRIPTION
**Describe the bug.**

As per describe in the [ReadME](https://github.com/asyncapi/generator/tree/master/packages/templates/clients/js/websocket#javascript-websocket-client) we can start example script that uses a client library generated by the test: node example.js
But the command is throwing an error.

Expected behavior
The command should start example script that uses a client library generated by the test.

**Before & After**

**Before:-**
When trying to run " node example.js " in the websocket folder, it was giving an error:-
![420868096-09e50ee6-3686-4a2a-baf4-4b2e0cfb5001](https://github.com/user-attachments/assets/e7089500-9659-4a35-87d7-6f911d20ca5a)

**After:-**
The error was caused because of an incorrect file path.
The error was fixed by making sure that the websocket client is imported from the correct folder with the correct file path.
![Screenshot From 2025-03-11 09-38-44](https://github.com/user-attachments/assets/64ec86e2-d1e2-4ba2-94cb-3c4f9bad9f83)



**Description:-**
This PR fixes the websocket bug in issue #1396 caused by incorrect file path.

**How to test**
Run the project locally 
Navigate to the websocket folder
Run " node example.js " to start a websocket server



**Checklist:-**
All tests in the websocket folder using " npm run test " are passed with no errors or warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal module references to enhance code consistency and maintainability without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->