### PR TITLE
docs: update github actions link and cli installation redirect link

### DIFF
--- a/apps/generator/docs/installation-guide.md
+++ b/apps/generator/docs/installation-guide.md
@@ -8,7 +8,7 @@ You can use the generator library to generate whatever you want in your event-dr
 - [Generator library in Node.js apps](#generator-library-in-nodejs-apps)
   
 ## Prerequisites
-Before you install and use the AsyncAPI CLI and the generator library, ensure you meet the prerequisites below, then [install the CLI](#installation).
+Before you install and use the AsyncAPI CLI and the generator library, ensure you meet the prerequisites below, then [install the CLI](https://www.asyncapi.com/docs/tools/cli/installation).
 1. Node.js v18.12.0 or higher
 2. Npm v8.19.0 or higher
    
@@ -27,7 +27,7 @@ If you have the correct versions installed, proceed to the CLI installation guid
 ## AsyncAPI CLI
 The AsyncAPI CLI tool allows you to do many different things with the [AsyncAPI document](asyncapi-document). You can generate message-based API boilerplate code, documentation, or anything else you need as long as you specify it in your [template](template) or the existing template already supports it. To use the generator via the AsyncAPI CLI, you need to install the AsyncAPI CLI tool. For the latest installation instructions, visit the official AsyncAPI CLI [installation guide](https://www.asyncapi.com/docs/tools/cli/installation).
 
-> :memo: **Note:**  To use the generator in your CI/CD pipeline to automate whatever you generate for your event-driven architecture apps, install the AsyncAPI CLI in your pipeline. If you are using GitHub Actions, use [Github Actions for Generator](https://github.com/marketplace/actions/generator-for-asyncapi-documents).
+> :memo: **Note:**  To use the generator in your CI/CD pipeline to automate whatever you generate for your event-driven architecture apps, install the AsyncAPI CLI in your pipeline. If you are using GitHub Actions, use [Github Actions for Generator](https://github.com/marketplace/actions/generator-validator-converter-and-others-all-in-one-for-your-asyncapi-docs).
 
 ## Generator library in Node.js apps
 Use the generator library in your Node.js projects by installing it via the following command: `npm install @asyncapi/generator`.

--- a/apps/generator/docs/installation-guide.md
+++ b/apps/generator/docs/installation-guide.md
@@ -8,7 +8,7 @@ You can use the generator library to generate whatever you want in your event-dr
 - [Generator library in Node.js apps](#generator-library-in-nodejs-apps)
   
 ## Prerequisites
-Before you install and use the AsyncAPI CLI and the generator library, ensure you meet the prerequisites below, then [install the CLI](https://www.asyncapi.com/docs/tools/cli/installation).
+Before you install and use the AsyncAPI CLI and the generator library, ensure you meet the prerequisites below, then [install the CLI](https://github.com/marketplace/actions/asyncapi-cli-action).
 1. Node.js v18.12.0 or higher
 2. Npm v8.19.0 or higher
    

--- a/apps/generator/docs/installation-guide.md
+++ b/apps/generator/docs/installation-guide.md
@@ -8,7 +8,7 @@ You can use the generator library to generate whatever you want in your event-dr
 - [Generator library in Node.js apps](#generator-library-in-nodejs-apps)
   
 ## Prerequisites
-Before you install and use the AsyncAPI CLI and the generator library, ensure you meet the prerequisites below, then [install the CLI](https://github.com/marketplace/actions/asyncapi-cli-action).
+Before you install and use the AsyncAPI CLI and the generator library, ensure you meet the prerequisites below, then [install the CLI](https://www.asyncapi.com/docs/tools/cli/installation).
 1. Node.js v18.12.0 or higher
 2. Npm v8.19.0 or higher
    
@@ -27,7 +27,7 @@ If you have the correct versions installed, proceed to the CLI installation guid
 ## AsyncAPI CLI
 The AsyncAPI CLI tool allows you to do many different things with the [AsyncAPI document](asyncapi-document). You can generate message-based API boilerplate code, documentation, or anything else you need as long as you specify it in your [template](template) or the existing template already supports it. To use the generator via the AsyncAPI CLI, you need to install the AsyncAPI CLI tool. For the latest installation instructions, visit the official AsyncAPI CLI [installation guide](https://www.asyncapi.com/docs/tools/cli/installation).
 
-> :memo: **Note:**  To use the generator in your CI/CD pipeline to automate whatever you generate for your event-driven architecture apps, install the AsyncAPI CLI in your pipeline. If you are using GitHub Actions, use [Github Actions for Generator](https://github.com/marketplace/actions/generator-validator-converter-and-others-all-in-one-for-your-asyncapi-docs).
+> :memo: **Note:**  To use the generator in your CI/CD pipeline to automate whatever you generate for your event-driven architecture apps, install the AsyncAPI CLI in your pipeline. If you are using GitHub Actions, use [Github Actions for Generator](https://github.com/marketplace/actions/asyncapi-cli-action).
 
 ## Generator library in Node.js apps
 Use the generator library in your Node.js projects by installing it via the following command: `npm install @asyncapi/generator`.

--- a/packages/templates/clients/js/websocket/example.js
+++ b/packages/templates/clients/js/websocket/example.js
@@ -1,4 +1,4 @@
-const WSClient = require('./test/temp/snapshotTestResult/client-postman');
+const WSClient = require('./tests/temp/snapshotTestResult/client-postman.js');
 // Example usage
 const wsClient = new WSClient();
 
@@ -6,7 +6,7 @@ const wsClient = new WSClient();
 function myHandler(message) {
   console.log('====================');
   console.log('Just proving I got the message in myHandler:', message);
-  console.log('====================');  
+  console.log('====================');
 }
 
 // Example of custom error handler

--- a/packages/templates/clients/js/websocket/example.js
+++ b/packages/templates/clients/js/websocket/example.js
@@ -1,4 +1,4 @@
-const WSClient = require('./tests/temp/snapshotTestResult/client-postman.js');
+const WSClient = require('./test/temp/snapshotTestResult/client-postman');
 // Example usage
 const wsClient = new WSClient();
 


### PR DESCRIPTION


**Description**

Fixes the hyperlink for " install the cli " by redirecting to installation page of the CLI menu
Fixes the hyperlink for " Github Actions for Generator " by redirecting to the available Asyncapi document generator online


**Fix:-**
Fixes issue #1389 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated installation guide links to direct users to the correct resources for CLI installation and CI/CD integration.
- **Chores**
	- Made internal adjustments for improved consistency and formatting in sample client code, including a correction in the import path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->