### PR TITLE
feat: add the different directories for postman-echo and hopscotch-echo 

### DIFF
--- a/packages/templates/clients/js/websocket/test/snapshot.test.js
+++ b/packages/templates/clients/js/websocket/test/snapshot.test.js
@@ -7,7 +7,8 @@ const { readFile } = require('fs').promises;
 const Generator = require('@asyncapi/generator');
 const asyncapi_v3_path_postman = path.resolve(__dirname, './__fixtures__/asyncapi-postman-echo.yml');
 const asyncapi_v3_path_hoppscotch = path.resolve(__dirname, './__fixtures__/asyncapi-hoppscotch-echo.yml');
-const testResultPath = path.resolve(__dirname, './temp/snapshotTestResult');
+const testResultPathPostman = path.resolve(__dirname, './temp/snapshotTestResult/postman-echo/');
+const testResultPathHopscotch = path.resolve(__dirname, './temp/snapshotTestResult/hopscotch-echo/');
 const template = './';
 
 describe('testing if generated client match snapshot', () => {
@@ -16,7 +17,7 @@ describe('testing if generated client match snapshot', () => {
   it('generate simple client for postman echo', async () => {
     const testOutputFile = 'client-postman.js';
 
-    const generator = new Generator(template, testResultPath, {
+    const generator = new Generator(template, testResultPathPostman, {
       forceWrite: true,
       templateParams: {
         server: 'echoServer',
@@ -26,14 +27,14 @@ describe('testing if generated client match snapshot', () => {
 
     await generator.generateFromFile(asyncapi_v3_path_postman);
 
-    const client = await readFile(path.join(testResultPath, testOutputFile), 'utf8');
+    const client = await readFile(path.join(testResultPathPostman, testOutputFile), 'utf8');
     expect(client).toMatchSnapshot();
   });
 
   it('generate simple client for hoppscotch echo', async () => {
     const testOutputFile = 'client-hoppscotch.js';
 
-    const generator = new Generator(template, testResultPath, {
+    const generator = new Generator(template, testResultPathHopscotch, {
       forceWrite: true,
       templateParams: {
         server: 'echoServer',
@@ -43,7 +44,7 @@ describe('testing if generated client match snapshot', () => {
 
     await generator.generateFromFile(asyncapi_v3_path_hoppscotch);
 
-    const client = await readFile(path.join(testResultPath, testOutputFile), 'utf8');
+    const client = await readFile(path.join(testResultPathHopscotch, testOutputFile), 'utf8');
     expect(client).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
It is regarding the issue #1373 . This PR is currently only making sure that Both postman-client and Hopscotch -client are made in their respective directories with their respective README.md. 


**Related issue(s)**
#1373 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test result management by separating snapshot outputs for different client integrations, enhancing organization and maintainability of the testing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->