### PR TITLE
fix: updates test:cleanup command for python websocket template

### DIFF
--- a/packages/templates/clients/python/websocket/package.json
+++ b/packages/templates/clients/python/websocket/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "npm run test:cleanup && jest  --coverage",
     "test:update": "jest --updateSnapshot",
-    "test:cleanup": "rimraf \"tests/temp\""
+    "test:cleanup": "rimraf \"test/temp\""
   },
   "author": "Lukasz Gornicki <lpgornicki@gmail.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
this PR fixes the `test:cleanup` command for the Python websocket client template.

Fixes #1438


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the testing cleanup process to reflect a revised temporary file directory structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->