### PR TITLE
test: simplify test-project's docker compose command and add Window's version

### DIFF
--- a/.github/workflows/pr-testing-with-test-project.yml
+++ b/.github/workflows/pr-testing-with-test-project.yml
@@ -37,7 +37,7 @@ jobs:
         node: ["18", "20"]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - name: Determine if tests should run
         id: should_run
         if: >
@@ -58,5 +58,5 @@ jobs:
         shell: bash
       - if: steps.should_run.outputs.shouldrun == 'true'
         name: Run test
-        run: NODE_IMAGE_TAG=${{ matrix.node }} docker compose up --abort-on-container-exit --remove-orphans --force-recreate
+        run: NODE_IMAGE_TAG=${{ matrix.node }} docker compose up --abort-on-container-exit --force-recreate
         working-directory: ./apps/generator/test/test-project

--- a/apps/generator/test/test-project/README.md
+++ b/apps/generator/test/test-project/README.md
@@ -3,6 +3,6 @@ The purpose of this project is to test AsyncAPI Generator library use case outsi
 
 Instead of running tests with `npm test`, make sure you have Docker Compose and run the following command:
 
-Linux: `docker-compose rm -f -s test-project verdaccio && NODE_IMAGE_TAG=18 docker-compose up --abort-on-container-exit --remove-orphans`.
+Linux/MacOS: `NODE_IMAGE_TAG=18 docker-compose up --abort-on-container-exit --force-recreate`.
 
-Windows: `docker-compose rm -f -s test-project verdaccio && set NODE_IMAGE_TAG=18&& docker-compose up --abort-on-container-exit --remove-orphans`.
+Windows: `set NODE_IMAGE_TAG=18&& docker-compose up --abort-on-container-exit --force-recreate`.

--- a/apps/generator/test/test-project/README.md
+++ b/apps/generator/test/test-project/README.md
@@ -1,4 +1,8 @@
 It is a test project where AsyncAPI Generator and test template are used as Node.js dependencies.
 The purpose of this project is to test AsyncAPI Generator library use case outside the Generator code base.
 
-Instead of running tests with `npm test`, make sure you have Docker Compose and run `docker-compose rm -f -s test-project verdaccio && NODE_IMAGE_TAG=18 docker-compose up --abort-on-container-exit --remove-orphans`.
+Instead of running tests with `npm test`, make sure you have Docker Compose and run the following command:
+
+Linux: `docker-compose rm -f -s test-project verdaccio && NODE_IMAGE_TAG=18 docker-compose up --abort-on-container-exit --remove-orphans`.
+
+Windows: `docker-compose rm -f -s test-project verdaccio && set NODE_IMAGE_TAG=18&& docker-compose up --abort-on-container-exit --remove-orphans`.


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Simplifies the docker compose command documented in the test-project README inside generator test.

- Replaces the first part of the command with force-recreate flag
- Removes unneeded remove-orphans flag
- Remove the above flag from the github workflow as well
- Adds Window's version of the command

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The 3rd option will not automatically close the issue after the merge. -->

Part of #1425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Streamlined the automated testing process by simplifying container management during test runs.

- **Documentation**
  - Updated and clarified test instructions with separate, platform-specific commands for Linux/MacOS and Windows to enhance usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->