### PR TITLE
refactor: move `rimraf` to `devDependencies` inside templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16800,7 +16800,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-helpers": "*",
+        "@asyncapi/generator-helpers": "1.0.0",
         "@asyncapi/generator-react-sdk": "^1.1.2"
       },
       "devDependencies": {
@@ -16818,7 +16818,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-helpers": "*",
+        "@asyncapi/generator-helpers": "1.0.0",
         "@asyncapi/generator-react-sdk": "^1.1.2"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16801,8 +16801,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/generator-helpers": "*",
-        "@asyncapi/generator-react-sdk": "^1.1.2",
-        "rimraf": "^3.0.2"
+        "@asyncapi/generator-react-sdk": "^1.1.2"
       },
       "devDependencies": {
         "@asyncapi/generator": "*",
@@ -16811,7 +16810,8 @@
         "@babel/core": "^7.26.0",
         "@babel/preset-env": "^7.26.0",
         "@babel/preset-react": "^7.25.9",
-        "jest-esm-transformer": "^1.0.0"
+        "jest-esm-transformer": "^1.0.0",
+        "rimraf": "^3.0.2"
       }
     },
     "packages/templates/clients/python/websocket": {
@@ -16819,8 +16819,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/generator-helpers": "*",
-        "@asyncapi/generator-react-sdk": "^1.1.2",
-        "rimraf": "^3.0.2"
+        "@asyncapi/generator-react-sdk": "^1.1.2"
       },
       "devDependencies": {
         "@asyncapi/generator": "*",
@@ -16829,7 +16828,8 @@
         "@babel/core": "^7.26.0",
         "@babel/preset-env": "^7.26.0",
         "@babel/preset-react": "^7.25.9",
-        "jest-esm-transformer": "^1.0.0"
+        "jest-esm-transformer": "^1.0.0",
+        "rimraf": "^3.0.2"
       }
     }
   }

--- a/packages/templates/clients/js/websocket/package.json
+++ b/packages/templates/clients/js/websocket/package.json
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@asyncapi/generator-react-sdk": "^1.1.2",
-    "@asyncapi/generator-helpers": "*"
+    "@asyncapi/generator-helpers": "1.0.0"
   },
   "devDependencies": {
     "@asyncapi/parser": "^3.0.14",

--- a/packages/templates/clients/js/websocket/package.json
+++ b/packages/templates/clients/js/websocket/package.json
@@ -11,8 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@asyncapi/generator-react-sdk": "^1.1.2",
-    "@asyncapi/generator-helpers": "*",
-    "rimraf": "^3.0.2"
+    "@asyncapi/generator-helpers": "*"
   },
   "devDependencies": {
     "@asyncapi/parser": "^3.0.14",
@@ -21,7 +20,8 @@
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-react": "^7.25.9",
     "jest-esm-transformer": "^1.0.0",
-    "@asyncapi/generator": "*"
+    "@asyncapi/generator": "*",
+    "rimraf": "^3.0.2"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/packages/templates/clients/python/websocket/package.json
+++ b/packages/templates/clients/python/websocket/package.json
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@asyncapi/generator-react-sdk": "^1.1.2",
-    "@asyncapi/generator-helpers": "*"
+    "@asyncapi/generator-helpers": "1.0.0"
   },
   "devDependencies": {
     "@asyncapi/parser": "^3.0.14",

--- a/packages/templates/clients/python/websocket/package.json
+++ b/packages/templates/clients/python/websocket/package.json
@@ -11,8 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@asyncapi/generator-react-sdk": "^1.1.2",
-    "@asyncapi/generator-helpers": "*",
-    "rimraf": "^3.0.2"
+    "@asyncapi/generator-helpers": "*"
   },
   "devDependencies": {
     "@asyncapi/parser": "^3.0.14",
@@ -21,7 +20,8 @@
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-react": "^7.25.9",
     "jest-esm-transformer": "^1.0.0",
-    "@asyncapi/generator": "*"
+    "@asyncapi/generator": "*",
+    "rimraf": "^3.0.2"
   },
   "jest": {
     "moduleFileExtensions": [


### PR DESCRIPTION
Fixes  #1453 
This PR moves the rimraf package inside templates to devDependencies for both JS and Python clients. This way the bundle size of the production installation is reduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Reorganized dependency management in client templates by moving a utility from production settings to development-only usage, ensuring a cleaner production bundle and improving the development workflow.
	- Updated the version of the `@asyncapi/generator-helpers` dependency to `1.0.0` for better stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->