### PR TITLE
refactor: replace if-then-else by single return statement

### DIFF
--- a/apps/generator/lib/generator.js
+++ b/apps/generator/lib/generator.js
@@ -942,10 +942,9 @@ class Generator {
    */
   isNonRenderableFile(fileName) {
     const nonRenderableFiles = this.templateConfig.nonRenderableFiles || [];
-    if (!Array.isArray(nonRenderableFiles)) return false;
-    if (nonRenderableFiles.some(globExp => minimatch(fileName, globExp))) return true;
-    if (isReactTemplate(this.templateConfig) && !isJsFile(fileName)) return true;
-    return false;
+    return Array.isArray(nonRenderableFiles) &&
+    (nonRenderableFiles.some(globExp => minimatch(fileName, globExp)) ||
+    (isReactTemplate(this.templateConfig) && !isJsFile(fileName)));
   }
 
   /**


### PR DESCRIPTION
**Description**
Replace if-then-else by single return statement in the `isNonRenderableFile` function of generator.

**Related issue(s)**
Fixes #1458 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the internal logic for filtering files by consolidating multiple checks into a single, concise evaluation. This update enhances maintainability and reduces code complexity while ensuring current public functionality remains unchanged. End users will continue to experience the same behavior, with the system's core processes now operating more robustly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->