### PR TITLE
feat: Setup Dockerfile & Docker Compose for project-wide testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Node modules
+**/node_modules
+npm-debug.log
+yarn-debug.log
+yarn-error.log
+
+# Environment variables
+.env
+.env.*
+
+# Build files
+dist
+build
+*.tgz
+
+# Git
+.git
+.gitignore
+
+# IDE files
+.idea
+.vscode
+*.sublime-project
+*.sublime-workspace
+
+# Logs
+logs
+*.log
+
+# OS specific
+.DS_Store
+Thumbs.db
+
+# Testing
+**/coverage
+.nyc_output
+test-results

--- a/Development.md
+++ b/Development.md
@@ -47,21 +47,10 @@ To run tests in an isolated Docker environment:
 2. Run the following command from the project root:
 
 ```bash
-docker run --rm -v ${PWD}:/app -w /app node:18 sh -c "
-cp -r /app /tmp/app &&
-cd /tmp/app &&
-npm install &&
-npm test
-"
+docker compose up
 ```
 
-This command above does the following:
-- Mounts the current directory to `/app` in the container
-- Copies the project to a temporary directory
-- Installs dependencies
-- Runs all tests
-
-Note: This approach ensures a clean environment for each test run by removing any existing `node_modules`.
+Note: This approach ensures a clean environment for each test run by cleanly installing dependencies and running tests in a Docker container.
 
 ### Manually testing with test templates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Stage 1: Prepare package.json files
+FROM node:18-alpine AS base
+
+WORKDIR /app
+
+# Install turbo
+RUN npm install -g turbo@1.13.3
+
+# Mount the project temporarily to use turbo prune to get all package.json files of the project
+# We have to specify the package names. Some packages are included as dependencies in others, they will be automatically included
+RUN --mount=type=bind,source=.,target=. turbo prune @asyncapi/generator @asyncapi/template-js-websocket-client @asyncapi/generator-components --docker --out-dir /out
+
+
+# ----------------------------------------
+# Stage 2: Install dependencies
+FROM base AS final
+
+# Copy package.json files extracted by turbo prune
+COPY --from=base /out/json/ .
+COPY --from=base /out/package-lock.json ./package-lock.json
+
+# Install dependencies
+RUN npm ci
+
+# Copy the rest of the source code
+COPY --from=base /out/full/ .
+
+CMD ["npm", "test"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,38 @@
-# Stage 1: Prepare package.json files
 FROM node:18-alpine AS base
 
 WORKDIR /app
 
+# ----------------------------------------
+# Stage 1: Prepare package.json files
+FROM base AS installer
+
 # Install turbo
 RUN npm install -g turbo@1.13.3
 
-# Mount the project temporarily to use turbo prune to get all package.json files of the project
-# We have to specify the package names. Some packages are included as dependencies in others, they will be automatically included
-RUN --mount=type=bind,source=.,target=. turbo prune @asyncapi/generator @asyncapi/template-js-websocket-client @asyncapi/generator-components --docker --out-dir /out
+# COPY the whole project to the container
+COPY . .
 
+# Run turbo prune to prune the project down to just package.json files of the project
+# This creates a new directory called /out with the following structure:
+# /out
+# ├── json -> package.json files of the project
+# ├── full -> full source code of the project
+# └── package-lock.json -> package-lock.json of the project
+# We have to specify the package names. Some packages are included as dependencies in others, they will be automatically included
+RUN turbo prune @asyncapi/generator @asyncapi/template-js-websocket-client @asyncapi/generator-components --docker --out-dir /out
 
 # ----------------------------------------
 # Stage 2: Install dependencies
 FROM base AS final
 
 # Copy package.json files extracted by turbo prune
-COPY --from=base /out/json/ .
-COPY --from=base /out/package-lock.json ./package-lock.json
+COPY --from=installer /out/json/ .
+COPY --from=installer /out/package-lock.json ./package-lock.json
 
-# Install dependencies
+# Install dependencies only with package.json files to make use of cache
 RUN npm ci
 
 # Copy the rest of the source code
-COPY --from=base /out/full/ .
+COPY --from=installer /out/full/ .
 
 CMD ["npm", "test"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,6 @@
+services:
+  test:
+    image: asyncapi-generator
+    pull_policy: build
+    build: .
+    command: npm test


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

This PR improves the Dockerized testing workflow by simplifying the command and making use of caching.

- Reduce the command needed to test to a simple `docker compose up`.
- Make use of caching mechanisms in Dockerfile, ensures the npm modules are not re-installed unless required, saving significant time when re-testing.
- Allowing the dockerized testing workflow to be more maintainable and easy to extend or configure.

**Screenshots**

**Design Choices**

Writing the dockerfile in a correct way to cache npm modules was the most difficult part of the PR, due to the monorepo structure. Some possible ways were:

1- Manually copying each package.json file from the project. Ex:
```docker
COPY package*.json ./
COPY apps/generator/package*.json ./apps/generator/
...
COPY packages\templates\clients\js\websocket\package.json packages\templates\clients\js\websocket\package.json
...
```

Problem: While manually copying package.json of each package could be ok, the folder structure of the package.json must be written manually and would need manual edit if changed. This problem is very apparent in the js websocket client, which has a deeply nested package.json. Refused this approach.

2- Using `turbo prune` command. Turborepo CLI has a command that can prune a project out of modules and divide it into a folder of package.json with respecting the nested structure, and a folder of source code. The first folder will be used to install npm modules, and the second will be to add source code.
```docker
RUN turbo prune @asyncapi/generator @asyncapi/template-js-websocket-client @asyncapi/generator-components --docker --out-dir /out
```

A small problem is that the command requires a scope (a package to prune as a target), and there is no `all` option, so we have to specify all package names. Some packages include other packages as dependencies so some names can be skipped. I've opened an issue anyways in their github: https://github.com/vercel/turborepo/discussions/10267

This approach gave great results, and is the chosen one.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The 3rd option will not automatically close the issue after the merge. -->
Fixes #1423