### PR TITLE
refactor: enable `url` for clients constructors

### DIFF
--- a/packages/templates/clients/websocket/javascript/components/Connect.js
+++ b/packages/templates/clients/websocket/javascript/components/Connect.js
@@ -17,13 +17,17 @@ connect() {
 
     // On receiving a message
     this.websocket.onmessage = (event) => {
-      console.log('Message received:', event.data);
-
-      this.messageHandlers.forEach(handler => {
-        if (typeof handler === 'function') {
-          this.handleMessage(event.data, handler);
-        }
-      });
+      if (this.messageHandlers.length > 0) {
+        // Call custom message handlers
+        this.messageHandlers.forEach(handler => {
+          if (typeof handler === 'function') {
+            this.handleMessage(event.data, handler);
+          }
+        });
+      } else {
+        // Default message logging
+        console.log('Message received:', event.data);
+      }
     };
 
     // On error first call custom error handlers, then default error behavior

--- a/packages/templates/clients/websocket/javascript/components/Constructor.js
+++ b/packages/templates/clients/websocket/javascript/components/Constructor.js
@@ -4,8 +4,12 @@ export function Constructor({ serverUrl }) {
   return (
     <Text indent={2}>
       {
-        `constructor() {
-  this.url = '${serverUrl}';
+        `/*
+  * Constructor to initialize the WebSocket client
+  * @param {string} url - The WebSocket server URL. Use it if the server URL is different from the default one taken from the AsyncAPI document.
+*/
+constructor(url) {
+  this.url = url || '${serverUrl}';
   this.websocket = null;
   this.messageHandlers = [];
   this.errorHandlers = [];

--- a/packages/templates/clients/websocket/javascript/test/__snapshots__/integration.test.js.snap
+++ b/packages/templates/clients/websocket/javascript/test/__snapshots__/integration.test.js.snap
@@ -13,8 +13,12 @@ const WebSocket = require('ws');
 
 class HoppscotchEchoWebSocketClient {
 
-  constructor() {
-    this.url = 'wss://echo-websocket.hoppscotch.io';
+  /*
+    * Constructor to initialize the WebSocket client
+    * @param {string} url - The WebSocket server URL. Use it if the server URL is different from the default one taken from the AsyncAPI document.
+  */
+  constructor(url) {
+    this.url = url || 'wss://echo-websocket.hoppscotch.io';
     this.websocket = null;
     this.messageHandlers = [];
     this.errorHandlers = [];
@@ -33,13 +37,17 @@ class HoppscotchEchoWebSocketClient {
 
       // On receiving a message
       this.websocket.onmessage = (event) => {
-        console.log('Message received:', event.data);
-
-        this.messageHandlers.forEach(handler => {
-          if (typeof handler === 'function') {
-            this.handleMessage(event.data, handler);
-          }
-        });
+        if (this.messageHandlers.length > 0) {
+          // Call custom message handlers
+          this.messageHandlers.forEach(handler => {
+            if (typeof handler === 'function') {
+              this.handleMessage(event.data, handler);
+            }
+          });
+        } else {
+          // Default message logging
+          console.log('Message received:', event.data);
+        }
       };
 
       // On error first call custom error handlers, then default error behavior
@@ -117,8 +125,12 @@ const WebSocket = require('ws');
 
 class PostmanEchoWebSocketClientClient {
 
-  constructor() {
-    this.url = 'wss://ws.postman-echo.com/raw';
+  /*
+    * Constructor to initialize the WebSocket client
+    * @param {string} url - The WebSocket server URL. Use it if the server URL is different from the default one taken from the AsyncAPI document.
+  */
+  constructor(url) {
+    this.url = url || 'wss://ws.postman-echo.com/raw';
     this.websocket = null;
     this.messageHandlers = [];
     this.errorHandlers = [];
@@ -137,13 +149,17 @@ class PostmanEchoWebSocketClientClient {
 
       // On receiving a message
       this.websocket.onmessage = (event) => {
-        console.log('Message received:', event.data);
-
-        this.messageHandlers.forEach(handler => {
-          if (typeof handler === 'function') {
-            this.handleMessage(event.data, handler);
-          }
-        });
+        if (this.messageHandlers.length > 0) {
+          // Call custom message handlers
+          this.messageHandlers.forEach(handler => {
+            if (typeof handler === 'function') {
+              this.handleMessage(event.data, handler);
+            }
+          });
+        } else {
+          // Default message logging
+          console.log('Message received:', event.data);
+        }
       };
 
       // On error first call custom error handlers, then default error behavior

--- a/packages/templates/clients/websocket/python/components/Connect.js
+++ b/packages/templates/clients/websocket/python/components/Connect.js
@@ -8,7 +8,6 @@ export function Connect({ title }) {
     print("Connected to ${title} server")
 
 def on_message(self, ws, message):
-    print("\\033[94mReceived raw message:\\033[0m", message)
     self.handle_message(message)
 
 def on_error(self, ws, error):

--- a/packages/templates/clients/websocket/python/components/Constructor.js
+++ b/packages/templates/clients/websocket/python/components/Constructor.js
@@ -4,8 +4,15 @@ export function Constructor({ serverUrl }) {
   return (
     <Text indent={2} newLines={2}>
       {
-        `def __init__(self):
-    self.url = "${serverUrl}"
+        `def __init__(self, url: str = "${serverUrl}"):
+    """
+    Constructor to initialize the WebSocket client.
+
+    Args:
+        url (str, optional): The WebSocket server URL. Use it if the server URL is 
+        different from the default one taken from the AsyncAPI document.
+    """
+    self.url = url
     self.ws_app = None  # Instance of WebSocketApp
     self.message_handlers = []      # Callables for incoming messages
     self.error_handlers = []        # Callables for errors

--- a/packages/templates/clients/websocket/python/components/HandleError.js
+++ b/packages/templates/clients/websocket/python/components/HandleError.js
@@ -5,9 +5,12 @@ export function HandleError() {
     <Text newLines={2} indent={2}>
       {
         `def handle_error(self, error):
-    """Pass the error to all registered error handlers."""
-    print("Handling error:", error)
-    for handler in self.error_handlers:
+    """Pass the error to all registered error handlers. Generic log message is printed if no handlers are registered."""
+    if len(self.error_handlers) == 0:
+      print("\\033[91mError occurred:\\033[0m", error)
+    else:
+      # Call custom error handlers
+      for handler in self.error_handlers:
         handler(error)`
       }
     </Text>

--- a/packages/templates/clients/websocket/python/components/HandleMessage.js
+++ b/packages/templates/clients/websocket/python/components/HandleMessage.js
@@ -5,9 +5,11 @@ export function HandleMessage() {
     <Text newLines={2} indent={2}>
       {
         `def handle_message(self, message):
-    """Pass the incoming message to all registered message handlers."""
-    print("\\033[94mProcessing message:\\033[0m", message)
-    for handler in self.message_handlers:
+    """Pass the incoming message to all registered message handlers. """
+    if len(self.message_handlers) == 0:
+      print("\\033[94mReceived raw message:\\033[0m", message)
+    else:
+      for handler in self.message_handlers:
         handler(message)`
       }
     </Text>

--- a/packages/templates/clients/websocket/python/test/__snapshots__/integration.test.js.snap
+++ b/packages/templates/clients/websocket/python/test/__snapshots__/integration.test.js.snap
@@ -16,8 +16,15 @@ import websocket
 
 class HoppscotchEchoWebSocketClient:
 
-  def __init__(self):
-      self.url = \\"wss://echo-websocket.hoppscotch.io\\"
+  def __init__(self, url: str = \\"wss://echo-websocket.hoppscotch.io\\"):
+      \\"\\"\\"
+      Constructor to initialize the WebSocket client.
+
+      Args:
+          url (str, optional): The WebSocket server URL. Use it if the server URL is 
+          different from the default one taken from the AsyncAPI document.
+      \\"\\"\\"
+      self.url = url
       self.ws_app = None  # Instance of WebSocketApp
       self.message_handlers = []      # Callables for incoming messages
       self.error_handlers = []        # Callables for errors
@@ -28,7 +35,6 @@ class HoppscotchEchoWebSocketClient:
       print(\\"Connected to Hoppscotch Echo WebSocket server\\")
 
   def on_message(self, ws, message):
-      print(\\"\\\\033[94mReceived raw message:\\\\033[0m\\", message)
       self.handle_message(message)
 
   def on_error(self, ws, error):
@@ -85,15 +91,20 @@ class HoppscotchEchoWebSocketClient:
           print(\\"Outgoing processor must be callable\\")
 
   def handle_message(self, message):
-      \\"\\"\\"Pass the incoming message to all registered message handlers.\\"\\"\\"
-      print(\\"\\\\033[94mProcessing message:\\\\033[0m\\", message)
-      for handler in self.message_handlers:
+      \\"\\"\\"Pass the incoming message to all registered message handlers. \\"\\"\\"
+      if len(self.message_handlers) == 0:
+        print(\\"\\\\033[94mReceived raw message:\\\\033[0m\\", message)
+      else:
+        for handler in self.message_handlers:
           handler(message)
 
   def handle_error(self, error):
-      \\"\\"\\"Pass the error to all registered error handlers.\\"\\"\\"
-      print(\\"Handling error:\\", error)
-      for handler in self.error_handlers:
+      \\"\\"\\"Pass the error to all registered error handlers. Generic log message is printed if no handlers are registered.\\"\\"\\"
+      if len(self.error_handlers) == 0:
+        print(\\"\\\\033[91mError occurred:\\\\033[0m\\", error)
+      else:
+        # Call custom error handlers
+        for handler in self.error_handlers:
           handler(error)
 
   def send_message(self, message):
@@ -148,8 +159,15 @@ import websocket
 
 class PostmanEchoWebSocketClientClient:
 
-  def __init__(self):
-      self.url = \\"wss://ws.postman-echo.com/raw\\"
+  def __init__(self, url: str = \\"wss://ws.postman-echo.com/raw\\"):
+      \\"\\"\\"
+      Constructor to initialize the WebSocket client.
+
+      Args:
+          url (str, optional): The WebSocket server URL. Use it if the server URL is 
+          different from the default one taken from the AsyncAPI document.
+      \\"\\"\\"
+      self.url = url
       self.ws_app = None  # Instance of WebSocketApp
       self.message_handlers = []      # Callables for incoming messages
       self.error_handlers = []        # Callables for errors
@@ -160,7 +178,6 @@ class PostmanEchoWebSocketClientClient:
       print(\\"Connected to Postman Echo WebSocket Client server\\")
 
   def on_message(self, ws, message):
-      print(\\"\\\\033[94mReceived raw message:\\\\033[0m\\", message)
       self.handle_message(message)
 
   def on_error(self, ws, error):
@@ -217,15 +234,20 @@ class PostmanEchoWebSocketClientClient:
           print(\\"Outgoing processor must be callable\\")
 
   def handle_message(self, message):
-      \\"\\"\\"Pass the incoming message to all registered message handlers.\\"\\"\\"
-      print(\\"\\\\033[94mProcessing message:\\\\033[0m\\", message)
-      for handler in self.message_handlers:
+      \\"\\"\\"Pass the incoming message to all registered message handlers. \\"\\"\\"
+      if len(self.message_handlers) == 0:
+        print(\\"\\\\033[94mReceived raw message:\\\\033[0m\\", message)
+      else:
+        for handler in self.message_handlers:
           handler(message)
 
   def handle_error(self, error):
-      \\"\\"\\"Pass the error to all registered error handlers.\\"\\"\\"
-      print(\\"Handling error:\\", error)
-      for handler in self.error_handlers:
+      \\"\\"\\"Pass the error to all registered error handlers. Generic log message is printed if no handlers are registered.\\"\\"\\"
+      if len(self.error_handlers) == 0:
+        print(\\"\\\\033[91mError occurred:\\\\033[0m\\", error)
+      else:
+        # Call custom error handlers
+        for handler in self.error_handlers:
           handler(error)
 
   def send_message(self, message):


### PR DESCRIPTION
related: https://github.com/asyncapi/generator/issues/1417

some changes in current client are needed to prepare them for testing:
- enable passing custom server url on the constructor side, so later we can do for example `const wsClient = new WSClient('ws://localhost:8081/api/ws/Hoppscotch+WebSocket+Server/1.0.0/sendTimeStampMessage');`
- remove default logging from message and error handlers and do it only if there are no custom handlers

I manually ran `example.js` and `example.py` and they are still working with newly generated clients

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced WebSocket communication to support custom handling of incoming messages with a fallback logging mechanism.
  - Improved client initialization by enabling an optional server URL parameter for flexible connections.
  - Refined error management that conditionally invokes custom error responses or displays a clear log message.

- **Documentation**
  - Added clarifying comments to constructor and error handling routines to aid in understanding their updated behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->