### PR TITLE
chore: revert `ci: ensure PR testing runs correctly based on conditions`

### DIFF
--- a/.github/workflows/pr-testing-with-test-project.yml
+++ b/.github/workflows/pr-testing-with-test-project.yml
@@ -8,8 +8,6 @@ on:
 jobs:
   changes:
     runs-on: ubuntu-latest
-    outputs:
-      should_test: ${{ steps.filter.outputs.modified_files !='[]' }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3 https://github.com/actions/checkout/releases/tag/v3
       - uses: rohansingh/paths-filter@084ca29929a4e7e708a4aa8b790347facfd830c9 # fork with predicate-quantifier fix
@@ -29,7 +27,7 @@ jobs:
 
   test:
     needs: changes
-    if: ${{ needs.changes.outputs.should_test == 'true' && github.event.pull_request.draft == false }}
+    if: ${{ github.event.pull_request.draft == false }}
     name: Test generator as dependency with Node ${{ matrix.node }}
     runs-on: ubuntu-latest
     strategy:
@@ -41,7 +39,7 @@ jobs:
       - name: Determine if tests should run
         id: should_run
         if: >
-          !github.event.pull_request.draft && !(
+          !(
             (github.actor == 'asyncapi-bot' && (
               startsWith(github.event.pull_request.title, 'ci: update of files from global .github repo') ||
                startsWith(github.event.pull_request.title, 'chore(release):')

--- a/.github/workflows/pr-testing-with-test-project.yml
+++ b/.github/workflows/pr-testing-with-test-project.yml
@@ -9,7 +9,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      should_test: ${{ steps.filter.outputs.modified_files }}
+      should_test: ${{ steps.filter.outputs.modified_files !='[]' }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3 https://github.com/actions/checkout/releases/tag/v3
       - uses: rohansingh/paths-filter@084ca29929a4e7e708a4aa8b790347facfd830c9 # fork with predicate-quantifier fix
@@ -29,7 +29,7 @@ jobs:
 
   test:
     needs: changes
-    if: ${{ github.event.pull_request.draft == false }}
+    if: ${{ needs.changes.outputs.should_test == 'true' && github.event.pull_request.draft == false }}
     name: Test generator as dependency with Node ${{ matrix.node }}
     runs-on: ubuntu-latest
     strategy:
@@ -41,7 +41,6 @@ jobs:
       - name: Determine if tests should run
         id: should_run
         if: >
-          needs.changes.outputs.should_test == 'true' &&
           !github.event.pull_request.draft && !(
             (github.actor == 'asyncapi-bot' && (
               startsWith(github.event.pull_request.title, 'ci: update of files from global .github repo') ||


### PR DESCRIPTION
Reverts asyncapi/generator#1486

looks like now every PR skips complex tests: filter always gives `false`: https://github.com/asyncapi/generator/actions/runs/14452715108/job/40528956943?pr=1492

![](https://files.slack.com/files-pri/T34F2JRQU-F08N6UCBLG4/screenshot_2025-04-14_at_17.18.42.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enhanced the CI logic to execute tests only when relevant changes occur and the pull request is no longer a draft.
  - Streamlined conditions to improve clarity and control over the testing process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->