### PR TITLE
chore: add security info to slack websocket asyncapi document

### DIFF
--- a/packages/templates/clients/websocket/test/__fixtures__/asyncapi-slack-client.yml
+++ b/packages/templates/clients/websocket/test/__fixtures__/asyncapi-slack-client.yml
@@ -45,6 +45,12 @@ servers:
     pathname: /link
     protocol: wss
     description: Slack's server in Socket Mode for real-time communication
+    security:
+    - type: http
+      scheme: bearer
+      bearerFormat: OAuth2
+      description: |
+        First you need to obtain a token and connection URL by making a HTTP request to `https://slack.com/api/apps.connections.open`. In response you receive WebSocket connection link that includes query parameters containing authorization information. Each time you connect with the WebSocket API, you need to generate a new connection link.
 channels:
   root:
     address: /


### PR DESCRIPTION
overlooked when initial slack example was added a week ago

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Slack WebSocket client specification to include details about authentication requirements and how to obtain connection tokens and URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->