### PR TITLE
chore: add test for getMessageExamples helper

### DIFF
--- a/packages/helpers/test/operations.test.js
+++ b/packages/helpers/test/operations.test.js
@@ -1,17 +1,21 @@
 const path = require('path');
 const { Parser, fromFile } = require('@asyncapi/parser');
-const { getOperationMessages } = require('@asyncapi/generator-helpers');
+const { getOperationMessages, getMessageExamples } = require('@asyncapi/generator-helpers');
 
 const parser = new Parser();
 const asyncapi_v3_path = path.resolve(__dirname, './__fixtures__/asyncapi-websocket-query.yml');
 
+async function getOperationsFromParsedDoc() {
+  const parseResult = await fromFile(parser, asyncapi_v3_path).parse();
+  const parsedAsyncAPIDocument = parseResult.document;
+  return parsedAsyncAPIDocument.operations();
+}
+
 describe('getOperationMessages integration test with AsyncAPI', () => {
-  let parsedAsyncAPIDocument, operations;
+  let operations;
 
   beforeAll(async () => {
-    const parseResult = await fromFile(parser, asyncapi_v3_path).parse();
-    parsedAsyncAPIDocument = parseResult.document;
-    operations = parsedAsyncAPIDocument.operations();
+    (operations = await getOperationsFromParsedDoc());
   });
 
   it('should return all messages of an operation when operation exists', () => {
@@ -33,6 +37,41 @@ describe('getOperationMessages integration test with AsyncAPI', () => {
 
   it('should throw error when operation is undefined', () => {
     expect(() => getOperationMessages(undefined)).toThrow('Operation object must be provided.');
+  });
+});
+
+describe('getMessageExamples integration test with AsyncAPI', () => {
+  let operations;
+
+  beforeAll(async () => {
+    (operations = await getOperationsFromParsedDoc());
+  });
+  
+  it('Should throw an error when message is null', () => {
+    expect(() => getMessageExamples(null)).toThrow('Message object must be provided.');
+  });
+
+  it('Should return all messages examples of an operation when operation exists', () => {
+    const operation = operations.get('multipleExamples');
+    const messages = operation.messages().all();
+    for (const message of messages) {
+      const expectedMessageExamples = message.examples();
+      const actualMessageExamples = getMessageExamples(message);
+      expect(actualMessageExamples).toStrictEqual(expectedMessageExamples);
+    }
+  }
+  );
+  it('Should return null when no examples present for a message', () => {
+    const operation = operations.get('noMessageExamples');
+    const messages = operation.messages().all();
+    for (const message of messages) {
+      const actualMessageExamples = getMessageExamples(message);
+      expect(actualMessageExamples).toBeNull();
+    }
+  });
+
+  it('should throw error when message is undefined', () => {
+    expect(() => getMessageExamples(undefined)).toThrow('Message object must be provided.');
   });
 });
 


### PR DESCRIPTION

<img width="1068" alt="Screenshot 2025-05-21 at 3 39 25 PM" src="https://github.com/user-attachments/assets/b7169382-73dd-403c-82e5-1c6f0e949e45" />


* adds test for getMessageExamples helper function.
* refactors current file to avoid sonarqube code duplication error warning.


Resolves #1561 