### PR TITLE
PR fixes React key prop warnings in the WebSocket client template components

### DIFF
--- a/packages/templates/clients/websocket/javascript/components/AvailableOperations.js
+++ b/packages/templates/clients/websocket/javascript/components/AvailableOperations.js
@@ -10,7 +10,7 @@ export function AvailableOperations({ operations }) {
     <>
       <Text newLines={2}>### Available Operations</Text>
       {operations.map((operation) => (
-        <Text newLines={2}>
+        <Text key={operation.id()} newLines={2}>
           <OperationHeader operation={operation} />
           <MessageExamples operation={operation} />
         </Text>

--- a/packages/templates/clients/websocket/javascript/components/MessageExamples.js
+++ b/packages/templates/clients/websocket/javascript/components/MessageExamples.js
@@ -15,8 +15,8 @@ export default function MessageExamples({operation}) {
   });
   return (
     <Text>
-      {messageExamples.map(example => (
-        <Text>
+      {messageExamples.map((example, index) => (
+        <Text key={index}>
           {example}
         </Text>
       ))}

--- a/packages/templates/clients/websocket/javascript/components/SendOperation.js
+++ b/packages/templates/clients/websocket/javascript/components/SendOperation.js
@@ -8,7 +8,7 @@ export function SendOperation({ sendOperations, clientName }) {
   return (
     <>
       {sendOperations.map((operation) => (
-        <Text newLines={2} indent={2}>
+        <Text key={operation.id()} newLines={2} indent={2}>
           {`
 /**
  * Sends a ${operation.id()} message over the WebSocket connection.


### PR DESCRIPTION
This PR fixes React key prop warnings in the WebSocket client template components:

- Added key prop to SendOperation component using operation.id()
- Added key prop to MessageExamples component using array index
- Added key prop to AvailableOperations component using operation.id()

These changes help React optimize its rendering and reconciliation process by providing unique identifiers for list items. The warnings were appearing in the test output and have been resolved.

Testing:
- All tests are passing
- No more React key prop warnings in the console

Fixes #1586