### PR TITLE
chore: remove unused devDependencies `rimraf`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18166,8 +18166,7 @@
         "eslint-plugin-jest": "^23.8.2",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-sonarjs": "^0.5.0",
-        "jest-esm-transformer": "^1.0.0",
-        "rimraf": "^3.0.2"
+        "jest-esm-transformer": "^1.0.0"
       }
     },
     "packages/templates/clients/websocket/javascript": {
@@ -18189,8 +18188,7 @@
         "eslint-plugin-jest": "^23.8.2",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-sonarjs": "^0.5.0",
-        "jest-esm-transformer": "^1.0.0",
-        "rimraf": "^3.0.2"
+        "jest-esm-transformer": "^1.0.0"
       }
     },
     "packages/templates/clients/websocket/python": {
@@ -18212,8 +18210,7 @@
         "eslint-plugin-jest": "^23.8.2",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-sonarjs": "^0.5.0",
-        "jest-esm-transformer": "^1.0.0",
-        "rimraf": "^3.0.2"
+        "jest-esm-transformer": "^1.0.0"
       }
     },
     "packages/templates/clients/websocket/test/integration-test": {

--- a/packages/templates/clients/websocket/dart/package.json
+++ b/packages/templates/clients/websocket/dart/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "This is a template generating Dart websocket client",
   "scripts": {
-    "test": "jest  --coverage --passWithNoTests",
+    "test": "jest --coverage --passWithNoTests",
     "test:update": "npm run test -- -u",
     "lint": "eslint --max-warnings 0 --config ../../../../../.eslintrc --ignore-path ../../../../../.eslintignore .",
     "lint:fix": "eslint --fix --max-warnings 0 --config ../../../../../.eslintrc --ignore-path ../../../../../.eslintignore ."
@@ -25,8 +25,7 @@
     "eslint": "^6.8.0",
     "eslint-plugin-jest": "^23.8.2",
     "eslint-plugin-react": "^7.34.1",
-    "eslint-plugin-sonarjs": "^0.5.0",
-    "rimraf": "^3.0.2"
+    "eslint-plugin-sonarjs": "^0.5.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/packages/templates/clients/websocket/javascript/package.json
+++ b/packages/templates/clients/websocket/javascript/package.json
@@ -25,8 +25,7 @@
     "eslint": "^6.8.0",
     "eslint-plugin-jest": "^23.8.2",
     "eslint-plugin-react": "^7.34.1",
-    "eslint-plugin-sonarjs": "^0.5.0",
-    "rimraf": "^3.0.2"
+    "eslint-plugin-sonarjs": "^0.5.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/packages/templates/clients/websocket/python/package.json
+++ b/packages/templates/clients/websocket/python/package.json
@@ -25,8 +25,7 @@
     "eslint": "^6.8.0",
     "eslint-plugin-jest": "^23.8.2",
     "eslint-plugin-react": "^7.34.1",
-    "eslint-plugin-sonarjs": "^0.5.0",
-    "rimraf": "^3.0.2"
+    "eslint-plugin-sonarjs": "^0.5.0"
   },
   "jest": {
     "moduleFileExtensions": [


### PR DESCRIPTION
**Description**
Cleanup unused devDependencies rimraf from all websocket client template.

**Related issue(s)**
Fixes #1636 