### PR TITLE
fix: ensure baked-in templates are published to npm

### DIFF
--- a/.changeset/sad-dogs-tickle.md
+++ b/.changeset/sad-dogs-tickle.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/generator": patch
+---
+
+Ensure transpiled baked-in templates are published to npm.

--- a/apps/generator/docs/api.md
+++ b/apps/generator/docs/api.md
@@ -16,8 +16,7 @@ Reference API documentation for AsyncAPI Generator library.
 <dl>
 <dt><a href="#listBakedInTemplates">listBakedInTemplates</a> ⇒ <code>Array.&lt;Object&gt;</code></dt>
 <dd><p>List core templates, optionally filter by type, stack, protocol, or target.
-Use name of returned templates as input for the <code>generate</code> method for template generation. Such core templates code is part of the @asyncapi/generator package.</p>
-</dd>
+Use name of returned templates as input for the <code>generate</code> method for template generation. Such core templates code is part of the @asyncapi/generator package.</p></dd>
 </dl>
 
 

--- a/apps/generator/package.json
+++ b/apps/generator/package.json
@@ -27,7 +27,7 @@
     "bump:version": "npm --no-git-tag-version --allow-same-version version $VERSION",
     "build": "node scripts/build-templates.js",
     "pretest": "npm run build",
-    "prepublish": "npm run build"
+    "prepare": "npm run build"
   },
   "preferGlobal": true,
   "bugs": {

--- a/apps/generator/package.json
+++ b/apps/generator/package.json
@@ -27,7 +27,7 @@
     "bump:version": "npm --no-git-tag-version --allow-same-version version $VERSION",
     "build": "node scripts/build-templates.js",
     "pretest": "npm run build",
-    "prepare": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "preferGlobal": true,
   "bugs": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Minor formatting cleanup in API docs; no content changes.

- Chores
  - Added a changeset declaring a patch release for the generator and noting that transpiled baked-in templates should be published.
  - Updated package preparation to run the build during the npm prepublish lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->