### PR TITLE
chore: add @Adi-204 to `CODEOWNERS` as templates champion that joins maintainers list

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,13 @@
 
 # The default owners are automatically added as reviewers when you open a pull request unless different owners are specified in the file.
 
+# Core Maintainers
 * @derberg @magicmatatjahu @jonaslagoni @asyncapi-bot-eve
 
+# Packages directory
+# @Adi-204 is Templates Champion
+packages/ @Adi-204
+
 # All .md files
+# @Florence-Njeri is Docs Champion
 *.md @Florence-Njeri @derberg @asyncapi-bot-eve


### PR DESCRIPTION
@Adi-204 proved over the last couple of months that he deserves the trust to join the project and share its responsibility. He's the main driver of the change that takes place in the repo, related to templates development and is alrady in the position to accept and merge related PRs. He acted as triager of issues and PRs over the last few months like a pro!