### PR TITLE
feat: first release of generator helpers and components

### DIFF
--- a/.changeset/yellow-elephants-crash.md
+++ b/.changeset/yellow-elephants-crash.md
@@ -1,7 +1,6 @@
 ---
 "@asyncapi/generator-components": minor
 "@asyncapi/generator-helpers": minor
-"@asyncapi/generator": patch
 ---
 
-Initial release of `@asyncapi/generator-components` and `@asyncapi/generator-helpers` to make them available for @asyncapi/generator
+Initial release of `@asyncapi/generator-components` and `@asyncapi/generator-helpers` to make them available for `@asyncapi/generator`

--- a/.changeset/yellow-elephants-crash.md
+++ b/.changeset/yellow-elephants-crash.md
@@ -1,0 +1,7 @@
+---
+"@asyncapi/generator-components": minor
+"@asyncapi/generator-helpers": minor
+"@asyncapi/generator": patch
+---
+
+Initial release of `@asyncapi/generator-components` and `@asyncapi/generator-helpers` to make them available for @asyncapi/generator

--- a/apps/generator/lib/templates/BakedInTemplatesList.json
+++ b/apps/generator/lib/templates/BakedInTemplatesList.json
@@ -6,6 +6,13 @@
     "target": "dart"
   },
   {
+    "name": "core-template-client-websocket-java-quarkus",
+    "type": "client",
+    "protocol": "websocket",
+    "target": "java",
+    "stack": "quarkus"
+  },
+  {
     "name": "core-template-client-websocket-javascript",
     "type": "client",
     "protocol": "websocket",

--- a/apps/generator/package.json
+++ b/apps/generator/package.json
@@ -52,6 +52,8 @@
   "license": "Apache-2.0",
   "homepage": "https://github.com/asyncapi/generator",
   "dependencies": {
+    "@asyncapi/generator-components": "*",
+    "@asyncapi/generator-helpers": "*",
     "@asyncapi/generator-hooks": "*",
     "@asyncapi/generator-react-sdk": "*",
     "@asyncapi/multi-parser": "^2.1.1",

--- a/apps/generator/package.json
+++ b/apps/generator/package.json
@@ -52,8 +52,6 @@
   "license": "Apache-2.0",
   "homepage": "https://github.com/asyncapi/generator",
   "dependencies": {
-    "@asyncapi/generator-components": "*",
-    "@asyncapi/generator-helpers": "*",
     "@asyncapi/generator-hooks": "*",
     "@asyncapi/generator-react-sdk": "*",
     "@asyncapi/multi-parser": "^2.1.1",

--- a/apps/generator/test/test-templates/react-template/package-lock.json
+++ b/apps/generator/test/test-templates/react-template/package-lock.json
@@ -8,7 +8,7 @@
             "name": "react-template",
             "version": "0.0.1",
             "dependencies": {
-                "@asyncapi/generator-components": "1.0.0",
+                "@asyncapi/generator-components": "0.1.0",
                 "@asyncapi/generator-react-sdk": "*"
             }
         },

--- a/apps/generator/test/test-templates/react-template/package.json
+++ b/apps/generator/test/test-templates/react-template/package.json
@@ -7,7 +7,7 @@
     },
     "dependencies": {
         "@asyncapi/generator-react-sdk": "*",
-        "@asyncapi/generator-components": "1.0.0"
+        "@asyncapi/generator-components": "0.1.0"
     }
 }
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,6 @@
       "version": "2.8.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-components": "*",
-        "@asyncapi/generator-helpers": "*",
         "@asyncapi/generator-hooks": "*",
         "@asyncapi/generator-react-sdk": "*",
         "@asyncapi/multi-parser": "^2.1.1",
@@ -19750,7 +19748,7 @@
     },
     "packages/components": {
       "name": "@asyncapi/generator-components",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/generator-react-sdk": "*",
@@ -19767,7 +19765,7 @@
     },
     "packages/helpers": {
       "name": "@asyncapi/generator-helpers",
-      "version": "1.0.0",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "jest": "^27.3.1"
@@ -19793,6 +19791,12 @@
         "jest-esm-transformer": "^1.0.0"
       }
     },
+    "packages/templates/clients/websocket/dart/node_modules/@asyncapi/generator-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/generator-helpers/-/generator-helpers-1.0.0.tgz",
+      "integrity": "sha512-uw6g+x7Pvzoj9OL+vzSuvIX0sQySWT63CJJb+zsvAwGimrCNoEyLe1ThinnLioEc4rl6UBF3qaJb8aK6YHktfw==",
+      "license": "Apache-2.0"
+    },
     "packages/templates/clients/websocket/java/quarkus": {
       "name": "core-template-client-websocket-java-quarkus",
       "version": "0.0.1",
@@ -19816,6 +19820,12 @@
         "jest-esm-transformer": "^1.0.0"
       }
     },
+    "packages/templates/clients/websocket/java/quarkus/node_modules/@asyncapi/generator-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/generator-helpers/-/generator-helpers-1.0.0.tgz",
+      "integrity": "sha512-uw6g+x7Pvzoj9OL+vzSuvIX0sQySWT63CJJb+zsvAwGimrCNoEyLe1ThinnLioEc4rl6UBF3qaJb8aK6YHktfw==",
+      "license": "Apache-2.0"
+    },
     "packages/templates/clients/websocket/javascript": {
       "name": "core-template-client-websocket-javascript",
       "license": "Apache-2.0",
@@ -19835,6 +19845,12 @@
         "eslint-plugin-sonarjs": "^0.5.0",
         "jest-esm-transformer": "^1.0.0"
       }
+    },
+    "packages/templates/clients/websocket/javascript/node_modules/@asyncapi/generator-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/generator-helpers/-/generator-helpers-1.0.0.tgz",
+      "integrity": "sha512-uw6g+x7Pvzoj9OL+vzSuvIX0sQySWT63CJJb+zsvAwGimrCNoEyLe1ThinnLioEc4rl6UBF3qaJb8aK6YHktfw==",
+      "license": "Apache-2.0"
     },
     "packages/templates/clients/websocket/python": {
       "name": "core-template-client-websocket-python",
@@ -19856,6 +19872,12 @@
         "jest-esm-transformer": "^1.0.0"
       }
     },
+    "packages/templates/clients/websocket/python/node_modules/@asyncapi/generator-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/generator-helpers/-/generator-helpers-1.0.0.tgz",
+      "integrity": "sha512-uw6g+x7Pvzoj9OL+vzSuvIX0sQySWT63CJJb+zsvAwGimrCNoEyLe1ThinnLioEc4rl6UBF3qaJb8aK6YHktfw==",
+      "license": "Apache-2.0"
+    },
     "packages/templates/clients/websocket/test/integration-test": {
       "name": "@asyncapi/template-integration-test",
       "version": "0.0.1",
@@ -19875,6 +19897,12 @@
         "eslint-plugin-sonarjs": "^0.5.0",
         "jest-esm-transformer": "^1.0.0"
       }
+    },
+    "packages/templates/clients/websocket/test/integration-test/node_modules/@asyncapi/generator-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@asyncapi/generator-helpers/-/generator-helpers-1.0.0.tgz",
+      "integrity": "sha512-uw6g+x7Pvzoj9OL+vzSuvIX0sQySWT63CJJb+zsvAwGimrCNoEyLe1ThinnLioEc4rl6UBF3qaJb8aK6YHktfw==",
+      "license": "Apache-2.0"
     },
     "packages/templates/clients/websocket/test/javascript": {
       "name": "@asyncapi/template-acceptance-test-js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,11 @@
     },
     "apps/generator": {
       "name": "@asyncapi/generator",
-      "version": "2.7.1",
+      "version": "2.8.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@asyncapi/generator-components": "*",
+        "@asyncapi/generator-helpers": "*",
         "@asyncapi/generator-hooks": "*",
         "@asyncapi/generator-react-sdk": "*",
         "@asyncapi/multi-parser": "^2.1.1",
@@ -2633,10 +2635,6 @@
     },
     "node_modules/@asyncapi/template-integration-test": {
       "resolved": "packages/templates/clients/websocket/test/integration-test",
-      "link": true
-    },
-    "node_modules/@asyncapi/template-java-websocket-quarkus": {
-      "resolved": "packages/templates/clients/websocket/java/quarkus",
       "link": true
     },
     "node_modules/@babel/cli": {
@@ -8684,6 +8682,10 @@
     },
     "node_modules/core-template-client-websocket-dart": {
       "resolved": "packages/templates/clients/websocket/dart",
+      "link": true
+    },
+    "node_modules/core-template-client-websocket-java-quarkus": {
+      "resolved": "packages/templates/clients/websocket/java/quarkus",
       "link": true
     },
     "node_modules/core-template-client-websocket-javascript": {
@@ -19792,7 +19794,7 @@
       }
     },
     "packages/templates/clients/websocket/java/quarkus": {
-      "name": "@asyncapi/template-java-websocket-quarkus",
+      "name": "core-template-client-websocket-java-quarkus",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19775,7 +19775,8 @@
       "name": "core-template-client-websocket-dart",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-helpers": "1.0.0",
+        "@asyncapi/generator-components": "0.1.0",
+        "@asyncapi/generator-helpers": "0.1.0",
         "@asyncapi/generator-react-sdk": "*"
       },
       "devDependencies": {
@@ -19791,18 +19792,13 @@
         "jest-esm-transformer": "^1.0.0"
       }
     },
-    "packages/templates/clients/websocket/dart/node_modules/@asyncapi/generator-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/generator-helpers/-/generator-helpers-1.0.0.tgz",
-      "integrity": "sha512-uw6g+x7Pvzoj9OL+vzSuvIX0sQySWT63CJJb+zsvAwGimrCNoEyLe1ThinnLioEc4rl6UBF3qaJb8aK6YHktfw==",
-      "license": "Apache-2.0"
-    },
     "packages/templates/clients/websocket/java/quarkus": {
       "name": "core-template-client-websocket-java-quarkus",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-helpers": "1.0.0",
+        "@asyncapi/generator-components": "0.1.0",
+        "@asyncapi/generator-helpers": "0.1.0",
         "@asyncapi/generator-react-sdk": "^1.1.2"
       },
       "devDependencies": {
@@ -19820,17 +19816,12 @@
         "jest-esm-transformer": "^1.0.0"
       }
     },
-    "packages/templates/clients/websocket/java/quarkus/node_modules/@asyncapi/generator-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/generator-helpers/-/generator-helpers-1.0.0.tgz",
-      "integrity": "sha512-uw6g+x7Pvzoj9OL+vzSuvIX0sQySWT63CJJb+zsvAwGimrCNoEyLe1ThinnLioEc4rl6UBF3qaJb8aK6YHktfw==",
-      "license": "Apache-2.0"
-    },
     "packages/templates/clients/websocket/javascript": {
       "name": "core-template-client-websocket-javascript",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-helpers": "1.0.0",
+        "@asyncapi/generator-components": "0.1.0",
+        "@asyncapi/generator-helpers": "0.1.0",
         "@asyncapi/generator-react-sdk": "*"
       },
       "devDependencies": {
@@ -19845,18 +19836,13 @@
         "eslint-plugin-sonarjs": "^0.5.0",
         "jest-esm-transformer": "^1.0.0"
       }
-    },
-    "packages/templates/clients/websocket/javascript/node_modules/@asyncapi/generator-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/generator-helpers/-/generator-helpers-1.0.0.tgz",
-      "integrity": "sha512-uw6g+x7Pvzoj9OL+vzSuvIX0sQySWT63CJJb+zsvAwGimrCNoEyLe1ThinnLioEc4rl6UBF3qaJb8aK6YHktfw==",
-      "license": "Apache-2.0"
     },
     "packages/templates/clients/websocket/python": {
       "name": "core-template-client-websocket-python",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-helpers": "1.0.0",
+        "@asyncapi/generator-components": "0.1.0",
+        "@asyncapi/generator-helpers": "0.1.0",
         "@asyncapi/generator-react-sdk": "*"
       },
       "devDependencies": {
@@ -19871,19 +19857,13 @@
         "eslint-plugin-sonarjs": "^0.5.0",
         "jest-esm-transformer": "^1.0.0"
       }
-    },
-    "packages/templates/clients/websocket/python/node_modules/@asyncapi/generator-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/generator-helpers/-/generator-helpers-1.0.0.tgz",
-      "integrity": "sha512-uw6g+x7Pvzoj9OL+vzSuvIX0sQySWT63CJJb+zsvAwGimrCNoEyLe1ThinnLioEc4rl6UBF3qaJb8aK6YHktfw==",
-      "license": "Apache-2.0"
     },
     "packages/templates/clients/websocket/test/integration-test": {
       "name": "@asyncapi/template-integration-test",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-helpers": "1.0.0"
+        "@asyncapi/generator-helpers": "0.1.0"
       },
       "devDependencies": {
         "@asyncapi/generator": "*",
@@ -19897,12 +19877,6 @@
         "eslint-plugin-sonarjs": "^0.5.0",
         "jest-esm-transformer": "^1.0.0"
       }
-    },
-    "packages/templates/clients/websocket/test/integration-test/node_modules/@asyncapi/generator-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@asyncapi/generator-helpers/-/generator-helpers-1.0.0.tgz",
-      "integrity": "sha512-uw6g+x7Pvzoj9OL+vzSuvIX0sQySWT63CJJb+zsvAwGimrCNoEyLe1ThinnLioEc4rl6UBF3qaJb8aK6YHktfw==",
-      "license": "Apache-2.0"
     },
     "packages/templates/clients/websocket/test/javascript": {
       "name": "@asyncapi/template-acceptance-test-js",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/generator-components",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Package with reusable components for generation using React render engine",
   "scripts": {
     "test": "npm run build && jest --coverage",
@@ -11,6 +11,11 @@
     "lint:fix": "eslint --max-warnings 0 --config ../../.eslintrc --ignore-path ../../.eslintignore . --fix",
     "generate:assets": "npm run prepublishOnly"
   },
+  "files": [
+    "lib/**",
+    "README.md",
+    "LICENSE"
+  ],
   "main": "lib/index.js",
   "repository": {
     "type": "git",
@@ -18,6 +23,9 @@
   },
   "author": "Lukasz Gornicki",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@asyncapi/generator-react-sdk": "*",
     "@asyncapi/modelina": "^5.3.5"

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asyncapi/generator-helpers",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Package with reusable helpers that make it easier to work with AsyncAPI structures.",
   "scripts": {
     "test": "jest --coverage",
@@ -14,6 +14,9 @@
   },
   "author": "Lukasz Gornicki",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "jest": "^27.3.1"
   },

--- a/packages/templates/clients/websocket/dart/package.json
+++ b/packages/templates/clients/websocket/dart/package.json
@@ -12,7 +12,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@asyncapi/generator-react-sdk": "*",
-    "@asyncapi/generator-helpers": "1.0.0"
+    "@asyncapi/generator-helpers": "0.1.0",
+    "@asyncapi/generator-components": "0.1.0"
   },
   "devDependencies": {
     "@asyncapi/parser": "^3.0.14",

--- a/packages/templates/clients/websocket/java/quarkus/.ageneratorrc
+++ b/packages/templates/clients/websocket/java/quarkus/.ageneratorrc
@@ -1,6 +1,6 @@
 renderer: react
 apiVersion: v3
-generator: ">=1.3.0 <3.0.0"
+generator: '>=1.3.0 <3.0.0'
 parameters:
   server:
     description: The name of the server described in AsyncAPI document
@@ -8,14 +8,18 @@ parameters:
   appendClientSuffix:
     description: Add 'Client' suffix at the end of the class name. This option has no effect if 'customClientName' is specified.
     required: false
-    default: false  
+    default: false
   customClientName:
     description: The custom name for the generated client class
     required: false
-
 nonRenderableFiles:
   - .dockerignore
   - .gitignore
   - .mvn/**
   - mvnw
   - mvnw.cmd
+metadata:
+  type: client
+  protocol: websocket
+  target: java
+  stack: quarkus

--- a/packages/templates/clients/websocket/java/quarkus/package.json
+++ b/packages/templates/clients/websocket/java/quarkus/package.json
@@ -18,7 +18,8 @@
     "lint:fix": "eslint --fix --max-warnings 0 --config ../../../../../../.eslintrc --ignore-path ../../../../../../.eslintignore ."
   },
   "dependencies": {
-    "@asyncapi/generator-helpers": "1.0.0",
+    "@asyncapi/generator-helpers": "0.1.0",
+    "@asyncapi/generator-components": "0.1.0",
     "@asyncapi/generator-react-sdk": "^1.1.2"
   },
   "devDependencies": {

--- a/packages/templates/clients/websocket/java/quarkus/package.json
+++ b/packages/templates/clients/websocket/java/quarkus/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@asyncapi/template-java-websocket-quarkus",
+  "name": "core-template-client-websocket-java-quarkus",
   "version": "0.0.1",
   "description": "This is a template generating a Java Quarkus websocket client",
   "keywords": [

--- a/packages/templates/clients/websocket/javascript/package.json
+++ b/packages/templates/clients/websocket/javascript/package.json
@@ -12,7 +12,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@asyncapi/generator-react-sdk": "*",
-    "@asyncapi/generator-helpers": "1.0.0"
+    "@asyncapi/generator-helpers": "0.1.0",
+    "@asyncapi/generator-components": "0.1.0"
   },
   "devDependencies": {
     "@asyncapi/parser": "^3.0.14",

--- a/packages/templates/clients/websocket/python/package.json
+++ b/packages/templates/clients/websocket/python/package.json
@@ -12,7 +12,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@asyncapi/generator-react-sdk": "*",
-    "@asyncapi/generator-helpers": "1.0.0"
+    "@asyncapi/generator-helpers": "0.1.0",
+    "@asyncapi/generator-components": "0.1.0"
   },
   "devDependencies": {
     "@asyncapi/parser": "^3.0.14",

--- a/packages/templates/clients/websocket/test/integration-test/package.json
+++ b/packages/templates/clients/websocket/test/integration-test/package.json
@@ -11,7 +11,7 @@
     "author": "Adi Boghawala <boghawalaadi@gmail.com>",
     "license": "Apache-2.0",
     "dependencies": {
-        "@asyncapi/generator-helpers": "1.0.0"
+        "@asyncapi/generator-helpers": "0.1.0"
     },
     "devDependencies": {
         "@babel/cli": "^7.25.9",


### PR DESCRIPTION
they are needed for new baked-in templates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a built-in Java (Quarkus) WebSocket client template, discoverable in the generator's template list with metadata (type, protocol, target, stack).

* **Chores**
  * Prepared initial public releases for generator components and helpers with publish configuration.
  * Standardized template package naming for the Java (Quarkus) WebSocket client.
  * Updated templates to depend on the new components/helpers versions.
  * Minor configuration formatting cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->