### PR TITLE
chore: change links in package.json of helpers and components

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -19,7 +19,8 @@
   "main": "lib/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/asyncapi/generator/packages/components"
+    "url": "https://github.com/asyncapi/generator.git",
+    "directory": "packages/components"
   },
   "author": "Lukasz Gornicki",
   "license": "Apache-2.0",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -10,7 +10,8 @@
   "main": "src/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/asyncapi/generator/packages/helpers"
+    "url": "https://github.com/asyncapi/generator.git",
+    "directory": "packages/helpers"
   },
   "author": "Lukasz Gornicki",
   "license": "Apache-2.0",


### PR DESCRIPTION
**Description**
Fix the broken links in `package.json` of helpers and components inside `/package` directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository metadata to align with a monorepo structure, pointing package links to the repository root and declaring each package’s directory.
  * Applied to the Components and Helpers packages to improve package discoverability and source links in package managers.
  * No functional changes; behavior and APIs remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->