### PR TITLE
test: acceptance tests using microcks for java/quarkus template

### DIFF
--- a/.github/workflows/pr-testing-with-test-project.yml
+++ b/.github/workflows/pr-testing-with-test-project.yml
@@ -106,3 +106,7 @@ jobs:
         name: Run PY acceptance tests
         run: docker compose -f ./microcks-setup/microcks-podman.yml --profile test-py up  --abort-on-container-exit --force-recreate
         working-directory: ./packages/templates/clients/websocket/test
+      - if: needs.changes.outputs.should_test == 'true'
+        name: Run JAVA acceptance tests
+        run: docker compose -f ./microcks-setup/microcks-podman.yml --profile test-java up  --abort-on-container-exit --force-recreate
+        working-directory: ./packages/templates/clients/websocket/test

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ coverage
 /.idea
 temp
 __pycache__
+**/target/
 
 microcks-data
 packages/templates/clients/websocket/test/__fixtures__/bundled.yml

--- a/packages/components/src/components/DependencyProvider.js
+++ b/packages/components/src/components/DependencyProvider.js
@@ -27,7 +27,7 @@ const dependenciesConfig = {
           'import io.quarkus.websockets.next.WebSocketClientConnection;','import io.quarkus.websockets.next.OnOpen;',
           'import io.quarkus.websockets.next.OnClose;','import io.quarkus.websockets.next.OnError;',
           'import io.quarkus.websockets.next.OnTextMessage;','import io.quarkus.websockets.next.CloseReason;',
-          'import jakarta.inject.Inject;','import io.quarkus.logging.Log;']
+          'import jakarta.inject.Inject;','import org.jboss.logging.Logger;']
       },
       connector: {
         dependencies: ['package com.asyncapi;\n','import io.quarkus.websockets.next.WebSocketConnector;',

--- a/packages/components/test/components/__snapshots__/DependencyProvider.test.js.snap
+++ b/packages/components/test/components/__snapshots__/DependencyProvider.test.js.snap
@@ -16,7 +16,7 @@ import io.quarkus.websockets.next.OnError;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.CloseReason;
 import jakarta.inject.Inject;
-import io.quarkus.logging.Log;
+import org.jboss.logging.Logger;
 import java.util.concurrent.CompletableFuture;
 import java.time.Duration;"
 `;
@@ -32,7 +32,7 @@ import io.quarkus.websockets.next.OnError;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.CloseReason;
 import jakarta.inject.Inject;
-import io.quarkus.logging.Log;"
+import org.jboss.logging.Logger;"
 `;
 
 exports[`Testing of DependencyProvider function render java quarkus connector websockets file dependencies correctly 1`] = `

--- a/packages/templates/clients/websocket/java/quarkus/components/ClientFields.js
+++ b/packages/templates/clients/websocket/java/quarkus/components/ClientFields.js
@@ -1,7 +1,7 @@
 import { toCamelCase } from '@asyncapi/generator-helpers';
 import { Text } from '@asyncapi/generator-react-sdk';
 
-export function ClientFields({ queryParams }) {
+export function ClientFields({ queryParams, clientName }) {
   let queryParamsVariables = '';
   const queryParamsArray = queryParams && Array.from(queryParams.entries());
   
@@ -16,7 +16,10 @@ export function ClientFields({ queryParams }) {
   return (
     <Text indent={2} newLines={2}>
       {`@Inject
-WebSocketClientConnection connection;
+public WebSocketClientConnection connection;
+
+private static final Logger LOG = Logger.getLogger(${clientName}.class);
+
 ${queryParamsVariables}`}
     </Text>
   );

--- a/packages/templates/clients/websocket/java/quarkus/components/EchoWebSocket.js
+++ b/packages/templates/clients/websocket/java/quarkus/components/EchoWebSocket.js
@@ -19,7 +19,7 @@ export function EchoWebSocket({ clientName, pathName, title, queryParams, operat
 @WebSocketClient(path = "${pathName}")  
 public class ${clientName}{`}
       </Text>
-      <ClientFields queryParams={queryParams} />
+      <ClientFields queryParams={queryParams} clientName={clientName}/>
       <Constructor clientName={clientName} query={queryParams} />
       <OnOpen title={title}/>
       <OnTextMessageHandler sendOperations={sendOperations}/>

--- a/packages/templates/clients/websocket/java/quarkus/components/HandleError.js
+++ b/packages/templates/clients/websocket/java/quarkus/components/HandleError.js
@@ -5,7 +5,7 @@ export default function HandleError() {
     <Text indent={2}>
       {`@OnError
 public void onError(Throwable throwable) {
-    Log.error("Websocket connection error: " + throwable.getMessage());
+    LOG.error("Websocket connection error: " + throwable.getMessage());
 }
 `}
     </Text>

--- a/packages/templates/clients/websocket/java/quarkus/components/OnClose.js
+++ b/packages/templates/clients/websocket/java/quarkus/components/OnClose.js
@@ -6,7 +6,7 @@ export default function OnClose({ title }) {
       {`@OnClose
    public void onClose(CloseReason reason, WebSocketClientConnection connection) {
       int code = reason.getCode();
-      Log.info("Websocket disconnected from ${title} with Close code: " + code);
+      LOG.info("Websocket disconnected from ${title} with Close code: " + code);
   }
 }
 `}

--- a/packages/templates/clients/websocket/java/quarkus/components/OnOpen.js
+++ b/packages/templates/clients/websocket/java/quarkus/components/OnOpen.js
@@ -6,8 +6,8 @@ export default function OnOpen({ title }) {
       {`@OnOpen
 public void onOpen() {
     String broadcastMessage = "Echo called from ${title} server";
-    Log.info("Connected to ${title} server");
-    Log.info(broadcastMessage);
+    LOG.info("Connected to ${title} server");
+    LOG.info(broadcastMessage);
 }
 `}
     </Text>

--- a/packages/templates/clients/websocket/java/quarkus/components/OnTextMessageHandler.js
+++ b/packages/templates/clients/websocket/java/quarkus/components/OnTextMessageHandler.js
@@ -11,7 +11,7 @@ export default function OnTextMessage({ sendOperations }) {
               <Text newLines={2} indent={2}>
                 {`@OnTextMessage
 public void ${methodName}(String message, WebSocketClientConnection connection) {
-    Log.info("Received text message: " + message);
+    LOG.info("Received text message: " + message);
 }`}
               </Text>
             );
@@ -19,11 +19,12 @@ public void ${methodName}(String message, WebSocketClientConnection connection) 
         )}
 
       {
+        // need a default handler
         (!sendOperations || sendOperations.length === 0) && (
           <Text newLines={2} indent={2}>
             {`@OnTextMessage
 public void processTextMessage(String message, WebSocketClientConnection connection) {
-    Log.info("Received text message: " + message);
+    LOG.info("Received text message: " + message);
 }`}
           </Text>
 

--- a/packages/templates/clients/websocket/test/README.md
+++ b/packages/templates/clients/websocket/test/README.md
@@ -24,7 +24,7 @@ To run tests:
 
     > You need to remember about `--profile infra` to run whole setup with tests. This way you ensure that the `asyncapi-bundler` service produces `__fixtures__/bundled.yml`, which the importer container will import into Microcks.
 
-1. Run tests for given client, for example `podman compose -f microcks-podman.yml --profile test-js up --abort-on-container-exit` to run JS client tests. Use `test-py` profile for Python client tests.
+1. Run tests for given client, for example `podman compose -f microcks-podman.yml --profile test-js up --abort-on-container-exit` to run JS client tests. Use `test-py` profile for Python client tests and `test-java` for Java client tests.
 
 ## Testing Clients with Microcks
 

--- a/packages/templates/clients/websocket/test/integration-test/__snapshots__/integration.test.js.snap
+++ b/packages/templates/clients/websocket/test/integration-test/__snapshots__/integration.test.js.snap
@@ -1531,14 +1531,17 @@ import io.quarkus.websockets.next.OnError;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.CloseReason;
 import jakarta.inject.Inject;
-import io.quarkus.logging.Log;
+import org.jboss.logging.Logger;
 import java.util.HashMap;
 
 @WebSocketClient(path = \\"/link\\")  
 public class SlackWebsocketAPIClient{
 
   @Inject
-  WebSocketClientConnection connection;
+  public WebSocketClientConnection connection;
+
+  private static final Logger LOG = Logger.getLogger(SlackWebsocketAPIClient.class);
+
 
   private HashMap<String, String> params;
   private String ticket;
@@ -1563,24 +1566,24 @@ public class SlackWebsocketAPIClient{
   @OnOpen
   public void onOpen() {
       String broadcastMessage = \\"Echo called from Slack Websocket API Client server\\";
-      Log.info(\\"Connected to Slack Websocket API Client server\\");
-      Log.info(broadcastMessage);
+      LOG.info(\\"Connected to Slack Websocket API Client server\\");
+      LOG.info(broadcastMessage);
   }
 
   @OnTextMessage
   public void processTextMessage(String message, WebSocketClientConnection connection) {
-      Log.info(\\"Received text message: \\" + message);
+      LOG.info(\\"Received text message: \\" + message);
   }
 
   @OnError
   public void onError(Throwable throwable) {
-      Log.error(\\"Websocket connection error: \\" + throwable.getMessage());
+      LOG.error(\\"Websocket connection error: \\" + throwable.getMessage());
   }
 
   @OnClose
      public void onClose(CloseReason reason, WebSocketClientConnection connection) {
         int code = reason.getCode();
-        Log.info(\\"Websocket disconnected from Slack Websocket API Client with Close code: \\" + code);
+        LOG.info(\\"Websocket disconnected from Slack Websocket API Client with Close code: \\" + code);
     }
   }
 
@@ -2552,36 +2555,39 @@ import io.quarkus.websockets.next.OnError;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.CloseReason;
 import jakarta.inject.Inject;
-import io.quarkus.logging.Log;
+import org.jboss.logging.Logger;
 
 @WebSocketClient(path = \\"/\\")  
 public class HoppscotchClient{
 
   @Inject
-  WebSocketClientConnection connection;
+  public WebSocketClientConnection connection;
+
+  private static final Logger LOG = Logger.getLogger(HoppscotchClient.class);
+
 
 
   @OnOpen
   public void onOpen() {
       String broadcastMessage = \\"Echo called from Hoppscotch Echo WebSocket Client server\\";
-      Log.info(\\"Connected to Hoppscotch Echo WebSocket Client server\\");
-      Log.info(broadcastMessage);
+      LOG.info(\\"Connected to Hoppscotch Echo WebSocket Client server\\");
+      LOG.info(broadcastMessage);
   }
 
   @OnTextMessage
   public void sendEchoMessage(String message, WebSocketClientConnection connection) {
-      Log.info(\\"Received text message: \\" + message);
+      LOG.info(\\"Received text message: \\" + message);
   }
 
   @OnError
   public void onError(Throwable throwable) {
-      Log.error(\\"Websocket connection error: \\" + throwable.getMessage());
+      LOG.error(\\"Websocket connection error: \\" + throwable.getMessage());
   }
 
   @OnClose
      public void onClose(CloseReason reason, WebSocketClientConnection connection) {
         int code = reason.getCode();
-        Log.info(\\"Websocket disconnected from Hoppscotch Echo WebSocket Client with Close code: \\" + code);
+        LOG.info(\\"Websocket disconnected from Hoppscotch Echo WebSocket Client with Close code: \\" + code);
     }
   }
 
@@ -3702,36 +3708,39 @@ import io.quarkus.websockets.next.OnError;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.CloseReason;
 import jakarta.inject.Inject;
-import io.quarkus.logging.Log;
+import org.jboss.logging.Logger;
 
 @WebSocketClient(path = \\"/\\")  
 public class HoppscotchEchoWebSocketClient{
 
   @Inject
-  WebSocketClientConnection connection;
+  public WebSocketClientConnection connection;
+
+  private static final Logger LOG = Logger.getLogger(HoppscotchEchoWebSocketClient.class);
+
 
 
   @OnOpen
   public void onOpen() {
       String broadcastMessage = \\"Echo called from Hoppscotch Echo WebSocket Client server\\";
-      Log.info(\\"Connected to Hoppscotch Echo WebSocket Client server\\");
-      Log.info(broadcastMessage);
+      LOG.info(\\"Connected to Hoppscotch Echo WebSocket Client server\\");
+      LOG.info(broadcastMessage);
   }
 
   @OnTextMessage
   public void sendEchoMessage(String message, WebSocketClientConnection connection) {
-      Log.info(\\"Received text message: \\" + message);
+      LOG.info(\\"Received text message: \\" + message);
   }
 
   @OnError
   public void onError(Throwable throwable) {
-      Log.error(\\"Websocket connection error: \\" + throwable.getMessage());
+      LOG.error(\\"Websocket connection error: \\" + throwable.getMessage());
   }
 
   @OnClose
      public void onClose(CloseReason reason, WebSocketClientConnection connection) {
         int code = reason.getCode();
-        Log.info(\\"Websocket disconnected from Hoppscotch Echo WebSocket Client with Close code: \\" + code);
+        LOG.info(\\"Websocket disconnected from Hoppscotch Echo WebSocket Client with Close code: \\" + code);
     }
   }
 
@@ -4950,36 +4959,39 @@ import io.quarkus.websockets.next.OnError;
 import io.quarkus.websockets.next.OnTextMessage;
 import io.quarkus.websockets.next.CloseReason;
 import jakarta.inject.Inject;
-import io.quarkus.logging.Log;
+import org.jboss.logging.Logger;
 
 @WebSocketClient(path = \\"/raw\\")  
 public class PostmanEchoWebSocketClientClient{
 
   @Inject
-  WebSocketClientConnection connection;
+  public WebSocketClientConnection connection;
+
+  private static final Logger LOG = Logger.getLogger(PostmanEchoWebSocketClientClient.class);
+
 
 
   @OnOpen
   public void onOpen() {
       String broadcastMessage = \\"Echo called from Postman Echo WebSocket Client server\\";
-      Log.info(\\"Connected to Postman Echo WebSocket Client server\\");
-      Log.info(broadcastMessage);
+      LOG.info(\\"Connected to Postman Echo WebSocket Client server\\");
+      LOG.info(broadcastMessage);
   }
 
   @OnTextMessage
   public void sendEchoMessage(String message, WebSocketClientConnection connection) {
-      Log.info(\\"Received text message: \\" + message);
+      LOG.info(\\"Received text message: \\" + message);
   }
 
   @OnError
   public void onError(Throwable throwable) {
-      Log.error(\\"Websocket connection error: \\" + throwable.getMessage());
+      LOG.error(\\"Websocket connection error: \\" + throwable.getMessage());
   }
 
   @OnClose
      public void onClose(CloseReason reason, WebSocketClientConnection connection) {
         int code = reason.getCode();
-        Log.info(\\"Websocket disconnected from Postman Echo WebSocket Client with Close code: \\" + code);
+        LOG.info(\\"Websocket disconnected from Postman Echo WebSocket Client with Close code: \\" + code);
     }
   }
 

--- a/packages/templates/clients/websocket/test/java/quarkus/pom.xml
+++ b/packages/templates/clients/websocket/test/java/quarkus/pom.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.asyncapi</groupId>
+    <artifactId>websocket-acceptance-tests</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <properties>
+        <compiler-plugin.version>3.14.0</compiler-plugin.version>
+        <maven.compiler.release>21</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.version>3.23.0</quarkus.platform.version>
+        <skipITs>true</skipITs>
+        <surefire-plugin.version>3.5.2</surefire-plugin.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <!-- Local Hoppscotch Client WebSocket -->
+        <dependency>
+            <groupId>com.asyncapi</groupId>
+            <artifactId>quarkus-websocket</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/../../../java/quarkus/test/temp/snapshotTestResult/client_hoppscotch/target/quarkus-websocket-1.0.0-SNAPSHOT.jar</systemPath>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-websockets-next</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-websockets</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-jackson</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-rest-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus.platform</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${compiler-plugin.version}</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <maven.home>${maven.home}</maven.home>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/packages/templates/clients/websocket/test/java/quarkus/src/main/java/com/asyncapi/HoppscotchReceiveWrapper.java
+++ b/packages/templates/clients/websocket/test/java/quarkus/src/main/java/com/asyncapi/HoppscotchReceiveWrapper.java
@@ -1,0 +1,30 @@
+package com.asyncapi;
+
+import io.quarkus.websockets.next.WebSocketClient;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+import jakarta.enterprise.context.ApplicationScoped;
+import com.asyncapi.HoppscotchEchoWebSocketClient;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@WebSocketClient(path = "/api/ws/Hoppscotch+Echo+WebSocket+Server/1.0.0/sendTimeStampMessage")
+@ApplicationScoped 
+public class HoppscotchReceiveWrapper extends HoppscotchEchoWebSocketClient {
+
+    // To store received messages
+    private static List<String> receivedMessages = Collections.synchronizedList(new ArrayList<>());
+
+    @Override
+    public void sendEchoMessage(String message, WebSocketClientConnection connection) {
+        System.out.println("From wrapper received message: " + message);
+        receivedMessages.add(message);
+        super.sendEchoMessage(message, connection);
+    }
+
+    public static List<String> getReceivedMessages() {
+        return receivedMessages;
+    }
+
+}

--- a/packages/templates/clients/websocket/test/java/quarkus/src/main/java/com/asyncapi/HoppscotchSendWrapper.java
+++ b/packages/templates/clients/websocket/test/java/quarkus/src/main/java/com/asyncapi/HoppscotchSendWrapper.java
@@ -1,0 +1,12 @@
+package com.asyncapi;
+
+import io.quarkus.websockets.next.WebSocketClient;
+import jakarta.enterprise.context.ApplicationScoped;
+import com.asyncapi.HoppscotchEchoWebSocketClient;
+
+
+@WebSocketClient(path = "/")
+@ApplicationScoped
+public class HoppscotchSendWrapper extends HoppscotchEchoWebSocketClient {
+
+}

--- a/packages/templates/clients/websocket/test/java/quarkus/src/test/java/com/asyncapi/AcceptanceTest.java
+++ b/packages/templates/clients/websocket/test/java/quarkus/src/test/java/com/asyncapi/AcceptanceTest.java
@@ -41,7 +41,6 @@ public class AcceptanceTest {
     public void testHoppscotchClientReceivesMessage() throws Exception {
         String expectedMessage = "GMT+0000 (Coordinated Universal Time)";
 
-        
         // Connect to the Microcks mock server
         WebSocketClientConnection connection = receiveConnector
             .baseUri(URI.create("ws://microcks-async-minion:8081"))

--- a/packages/templates/clients/websocket/test/java/quarkus/src/test/java/com/asyncapi/AcceptanceTest.java
+++ b/packages/templates/clients/websocket/test/java/quarkus/src/test/java/com/asyncapi/AcceptanceTest.java
@@ -1,0 +1,161 @@
+package test.java.com.asyncapi;
+
+import java.net.URI;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.websockets.next.WebSocketConnector;
+import io.quarkus.websockets.next.WebSocketClientConnection;
+import jakarta.inject.Inject;
+import jakarta.websocket.*;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import com.asyncapi.HoppscotchReceiveWrapper;
+import com.asyncapi.HoppscotchSendWrapper;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+@ApplicationScoped
+public class AcceptanceTest {
+
+    private static final String MICROCKS_TEST_ENDPOINT = "http://microcks:8080/api/tests";
+    private static final int SERVER_PORT = 8084;
+
+    @Inject
+    WebSocketConnector<HoppscotchReceiveWrapper> receiveConnector;
+
+    @Inject
+    WebSocketConnector<HoppscotchSendWrapper> sendConnector;
+
+    @Test
+    public void testHoppscotchClientReceivesMessage() throws Exception {
+        String expectedMessage = "GMT+0000 (Coordinated Universal Time)";
+
+        
+        // Connect to the Microcks mock server
+        WebSocketClientConnection connection = receiveConnector
+            .baseUri(URI.create("ws://microcks-async-minion:8081"))
+            .connectAndAwait();
+        
+        connection.sendTextAndAwait("Hello from Quarkus Test!Shuaib");
+        
+        // Wait for message to be received (up to 10 seconds)
+        int timeout = 10;
+        long startTime = System.currentTimeMillis(); 
+        while (HoppscotchReceiveWrapper.getReceivedMessages().isEmpty() && (System.currentTimeMillis() - startTime) < timeout * 1000) {
+            Thread.sleep(100);
+        }
+
+        List<String> receivedMessages = HoppscotchReceiveWrapper.getReceivedMessages();
+        
+        assertTrue(!receivedMessages.isEmpty(), "Expected message was not received within timeout");
+        connection.closeAndAwait();
+
+        // Verify the message content
+        boolean foundExpectedMessage = receivedMessages.stream().anyMatch(msg -> msg.contains(expectedMessage));
+        
+
+        assertTrue(foundExpectedMessage, 
+            String.format("Expected message containing '%s' but got messages: %s", expectedMessage, receivedMessages));
+    }
+
+    @Test
+    public void testHoppscotchClientSendsMessage() throws Exception {
+        String expectedOutgoingMessage = "Sending acceptance test message to Microcks.";
+        
+        System.out.println("Starting WebSocket server on port " + SERVER_PORT);
+        
+        // Connect to our test server endpoint
+        WebSocketClientConnection connection = sendConnector
+            .baseUri("ws://localhost:" + SERVER_PORT + "/ws")
+            .connectAndAwait();
+        
+        
+        // Send the test message using our wrapper's send functionality
+        connection.sendTextAndAwait(expectedOutgoingMessage);
+        
+        // Give a moment for the message to be processed
+        Thread.sleep(1000);
+        
+        // Now trigger the Microcks test
+        String payload = String.format("""
+            {
+                "serviceId": "Hoppscotch Echo WebSocket Server:1.0.0",
+                "testEndpoint": "ws://websocket-acceptance-tester-java:%d/ws",
+                "runnerType": "ASYNC_API_SCHEMA",
+                "timeout": 30000,
+                "filteredOperations": ["RECEIVE handleEchoMessage"]
+            }""", SERVER_PORT);
+        
+        // Start test in Microcks using REST client
+        Client restClient = ClientBuilder.newClient();
+        Response response = restClient.target(MICROCKS_TEST_ENDPOINT)
+            .request(MediaType.APPLICATION_JSON)
+            .post(Entity.json(payload));
+
+        assertEquals(201, response.getStatus(), "Failed to start Microcks test");
+        
+        String responseBody = response.readEntity(String.class);
+        String testId = extractTestIdFromResponse(responseBody);
+        System.out.println("Started Microcks test with ID: " + testId);
+
+        // Poll for test results (up to 30 attempts, 2 seconds apart = 1 minute max)
+        boolean microcksSuccess = false;
+        for (int i = 0; i < 30; i++) {
+            Response resultResponse = restClient.target(MICROCKS_TEST_ENDPOINT + "/" + testId)
+                .request(MediaType.APPLICATION_JSON)
+                .get();
+            
+            String resultBody = resultResponse.readEntity(String.class);
+            System.out.println("Polling Microcks (attempt " + (i + 1) + "): " + resultBody);
+            
+            // Parse JSON to check success
+            if (isTestSuccessful(resultBody)) {
+                microcksSuccess = true;
+                break;
+            }
+            
+            Thread.sleep(2000);
+        }
+
+        restClient.close();
+        connection.closeAndAwait();
+        
+        assertTrue(microcksSuccess, "Microcks test " + testId + " did not succeed");        
+    }
+
+    // Helper method to extract test ID from JSON response
+    private String extractTestIdFromResponse(String jsonResponse) {
+        String idField = "\"id\":\"";
+        int startIndex = jsonResponse.indexOf(idField);
+        if (startIndex == -1) {
+            throw new RuntimeException("Could not find test ID in response: " + jsonResponse);
+        }
+        startIndex += idField.length();
+        int endIndex = jsonResponse.indexOf("\"", startIndex);
+        return jsonResponse.substring(startIndex, endIndex);
+    }
+
+    // Helper method to determine if the test was successful from JSON response
+    private boolean isTestSuccessful(String jsonResponse) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode jsonNode = mapper.readTree(jsonResponse);
+            JsonNode successNode = jsonNode.get("success");
+            return successNode != null && successNode.asBoolean();
+        } catch (Exception e) {
+            // Fallback to string parsing
+            return jsonResponse.contains("\"success\":true");
+        }
+    }
+}

--- a/packages/templates/clients/websocket/test/java/quarkus/src/test/java/com/asyncapi/TestWebSocketServer.java
+++ b/packages/templates/clients/websocket/test/java/quarkus/src/test/java/com/asyncapi/TestWebSocketServer.java
@@ -1,0 +1,45 @@
+package test.java.com.asyncapi;
+
+import io.quarkus.websockets.next.OnClose;
+import io.quarkus.websockets.next.OnOpen;
+import io.quarkus.websockets.next.OnTextMessage;
+import io.quarkus.websockets.next.OnError;
+import io.quarkus.websockets.next.WebSocket;
+import io.quarkus.logging.Log;
+import io.quarkus.websockets.next.WebSocketConnection;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@WebSocket(path = "/ws")
+@ApplicationScoped
+public class TestWebSocketServer{
+
+    @OnOpen
+    public void onOpen(WebSocketConnection connection) {
+        Log.info("Server: Connection opened");
+        connection.sendTextAndAwait("Welcome to the Test WebSocket Server!");
+    }
+
+    @OnTextMessage
+    public void onMessage(String message, WebSocketConnection connection) {
+        Log.info("Server received message: " + message);
+        try {
+            Log.info("Server echoing message back: " + message);
+            connection.sendTextAndAwait(message);
+        } catch (Exception e) {
+            Log.error("Error sending echo", e);
+        }
+    }
+
+    @OnClose
+    public void onClose() {
+        Log.info("Server: Connection closed");
+    }
+
+    @OnError
+    public void onError(Throwable throwable) {
+        Log.error("Server: Error occurred - " + throwable.getMessage(), throwable);
+    }
+}

--- a/packages/templates/clients/websocket/test/java/quarkus/src/test/resources/application.properties
+++ b/packages/templates/clients/websocket/test/java/quarkus/src/test/resources/application.properties
@@ -1,0 +1,13 @@
+# application.properties 
+
+# HTTP configuration
+quarkus.http.port=8084
+quarkus.http.host=0.0.0.0
+
+# Test port configuration
+%test.quarkus.http.port=8084
+%test.quarkus.http.host=0.0.0.0
+
+# Optional: separate test port
+quarkus.http.test-port=8084
+quarkus.websocket.url=ws://0.0.0.0:8084/ws

--- a/packages/templates/clients/websocket/test/microcks-setup/microcks-podman.yml
+++ b/packages/templates/clients/websocket/test/microcks-setup/microcks-podman.yml
@@ -173,6 +173,18 @@ services:
       - ../../../../../../:/usr/src/app
     command: ["sh", "-c", "cd packages/templates/clients/websocket/python/test/temp/snapshotTestResult/client_hoppscotch && pip install -r requirements.txt && cd ../../../../../test/python && pip install -r requirements.txt && pytest"]
 
+  tester-java:
+    profiles:
+      - test-java
+    image: maven:3.9-eclipse-temurin-21
+    container_name: websocket-acceptance-tester-java
+    ports:
+      - "8084:8084"
+    working_dir: /usr/src/app
+    volumes:
+      - ../../../../../../:/usr/src/app
+    command: ["sh", "-c", "cd packages/templates/clients/websocket/java/quarkus/test/temp/snapshotTestResult/client_hoppscotch && mvn clean install && cd ../../../../../../test/java/quarkus && mvn clean test"]
+    
   # Below for debugging purposes. 
   # Just uncomment below and after starting environment you can enter the constainer with "podman exec -it net-debug sh" and use websocat to test the websocket connection
 


### PR DESCRIPTION
**Description**
- added acceptance tests for java quarkus template
- Adding test on pr-testing

**Related issue(s)**
Fixes #1705 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enhanced Java (Quarkus) WebSocket client templates with standardized logging and added generated client fields.
  - Added a sample WebSocket test server for local validation.

- Tests
  - Introduced Java-based WebSocket acceptance tests with supporting test project and test-server configuration.
  - CI now runs Java acceptance tests alongside Python, with both steps using a consistent test working directory.

- Documentation
  - Updated test instructions to include running Java client tests.

- Chores
  - Ignored all build output “target” directories across the repo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->