### PR TITLE
docs: fix the long link issue in `BakedInTemplates`

### DIFF
--- a/apps/generator/docs/baked-in-templates.md
+++ b/apps/generator/docs/baked-in-templates.md
@@ -9,7 +9,7 @@ Baked-in templates are official AsyncAPI templates that are **developed, version
 
 AsyncAPI Generator supports a variety of baked-in template types for generating code, documentation, configs, and SDKs. All templates are managed under the `packages/templates` directory and follow a strict, opinionated directory structure for consistency and ease of maintenance.
 
-> List of baked-in templates: https://github.com/asyncapi/generator/blob/master/apps/generator/lib/templates/BakedInTemplatesList.json
+> Check out the [list of baked-in templates](https://github.com/asyncapi/generator/blob/master/apps/generator/lib/templates/BakedInTemplatesList.json)
 
 ## Supported template types
 


### PR DESCRIPTION
**Description**
On website rendering long link of BakedInTemplates is having issue with readability. So better is to hide link behind text.

<img width="1918" height="861" alt="image" src="https://github.com/user-attachments/assets/70b3c61f-bb20-427d-bd3a-f10d9494c8ac" />


**Related issue(s)**
Small fix hence direct PR without issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined the “baked-in templates” section to improve clarity and readability. Replaced a plain URL line with a blockquoted callout featuring descriptive link text to the same resource. No changes to destination or content; this update makes the reference more visible and user-friendly in the docs within the generator documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->