### PR TITLE
docs: add note about baked-in templates in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,16 @@ There is a large number of templates that are ready to use and are officially su
 You can find above templates and the ones provided by the community in **[this list](https://github.com/search?q=topic%3Aasyncapi+topic%3Agenerator+topic%3Atemplate)**
 
 [!IMPORTANT]  
-**Baked-in Templates (Experimental):** Some templates are now available as baked-in templates.  
-These ship directly inside the Generator (see the `/packages` folder).  
-Learn more in the [baked-in templates documentation](https://www.asyncapi.com/docs/tools/generator/baked-in-templates).
+**Note on Baked-in Templates**  
+  
+AsyncAPI Generator also comes with **baked-in templates** - official templates shipped directly inside the Generator (`@asyncapi/generator`).  
+They include code, documentation, config, and SDK templates, all maintained under the [`/packages/templates`](./packages/templates) folder with a strict, opinionated structure.  
+  
+⚠️ This feature is experimental and not recommended for production use.  
+Instead, we encourage you to try them out and share feedback or contribute with your use cases.  
+  
+Learn more : [Baked-in templates documentation](https://www.asyncapi.com/docs/tools/generator/baked-in-templates)
+
 
 ## Filters
 

--- a/apps/generator/README.md
+++ b/apps/generator/README.md
@@ -26,3 +26,14 @@ There is a large number of templates that are ready to use and are officially su
 <!-- TEMPLATES-LIST:END -->
 
 You can find above templates and the ones provided by the community in **[this list](https://github.com/search?q=topic%3Aasyncapi+topic%3Agenerator+topic%3Atemplate)**
+
+
+**Note on Baked-in Templates**  
+  
+AsyncAPI Generator also comes with **baked-in templates** - official templates shipped directly inside the Generator (`@asyncapi/generator`).  
+They include code, documentation, config, and SDK templates, all maintained under the [`/packages/templates`](./packages/templates) folder with a strict, opinionated structure.  
+  
+⚠️ This feature is experimental and not recommended for production use.  
+Instead, we encourage you to try them out and share feedback or contribute with your use cases.  
+  
+Learn more : [Baked-in templates documentation](https://www.asyncapi.com/docs/tools/generator/baked-in-templates)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**
### Summary
This PR adds a note about **baked-in templates (experimental)** in the main `README.md` under the *List of official generator templates* section.

### Why
- The README is the most frequently visited entry point for users and contributors.
- Adding this note helps people understand what baked-in templates are and where to find them.
- Provides visibility into ongoing experimental work.

### Changes
- Added an [!IMPORTANT] note with a link to the baked-in templates documentation.


**Related issue(s)**
Resolves #1718