### PR TITLE
docs: mention generator-helper and generator-component in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This is a Monorepo managed using [Turborepo](https://turbo.build/) and contains 
 
 1. [React-sdk](apps/react-sdk): AsyncAPI React SDK is a set of components/functions to use React as render engine for the generator. This is the library that undestand components from Generator's templates that are configured to use `react` render engine. 
 
+1. [Generator-helper](apps/generator-helper): A utility library that provides helper functions and utilities to simplify template development for baked-in templates. It reduces boilerplate and speeds up template creation.
+
+1. [Generator-component](apps/generator-component): A library of reusable components that can be shared across different baked-in templates, helping to avoid duplication and accelerate template development.
+
 > [!IMPORTANT]
 > **Deprecation Notice:** The Nunjucks renderer engine is deprecated and will be removed in future releases. We strongly recommend using the React renderer engine instead. You can find how to migrate from Nunjucks to React in the [migration guide](apps/generator/docs/nunjucks-depreciate.md)
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This is a Monorepo managed using [Turborepo](https://turbo.build/) and contains 
 
 1. [React-sdk](apps/react-sdk): AsyncAPI React SDK is a set of components/functions to use React as render engine for the generator. This is the library that undestand components from Generator's templates that are configured to use `react` render engine. 
 
-1. [Generator-helper](apps/generator-helper): A utility library that provides helper functions and utilities to simplify template development for baked-in templates. It reduces boilerplate and speeds up template creation.
+1. [Generator-helper](packages/helpers): A utility library that provides helper functions and utilities to simplify template development for baked-in templates. It reduces boilerplate and speeds up template creation.
 
-1. [Generator-component](apps/generator-component): A library of reusable components that can be shared across different baked-in templates, helping to avoid duplication and accelerate template development.
+1. [Generator-component](packages/components): A library of reusable components that can be shared across different baked-in templates, helping to avoid duplication and accelerate template development.
 
 > [!IMPORTANT]
 > **Deprecation Notice:** The Nunjucks renderer engine is deprecated and will be removed in future releases. We strongly recommend using the React renderer engine instead. You can find how to migrate from Nunjucks to React in the [migration guide](apps/generator/docs/nunjucks-depreciate.md)

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ This is a Monorepo managed using [Turborepo](https://turbo.build/) and contains 
 
 1. [React-sdk](apps/react-sdk): AsyncAPI React SDK is a set of components/functions to use React as render engine for the generator. This is the library that undestand components from Generator's templates that are configured to use `react` render engine. 
 
-1. [Generator-helper](packages/helpers): A utility library that provides helper functions and utilities to simplify template development for baked-in templates. It reduces boilerplate and speeds up template creation.
+1. [Generator-helpers](packages/helpers): A utility library that provides helper functions and utilities to simplify template development. It reduces boilerplate and speeds up template creation.
 
-1. [Generator-component](packages/components): A library of reusable components that can be shared across different baked-in templates, helping to avoid duplication and accelerate template development.
+1. [Generator-components](packages/components): A library of reusable components that can be shared across different templates, helping to avoid duplication and accelerate template development.
 
 > [!IMPORTANT]
 > **Deprecation Notice:** The Nunjucks renderer engine is deprecated and will be removed in future releases. We strongly recommend using the React renderer engine instead. You can find how to migrate from Nunjucks to React in the [migration guide](apps/generator/docs/nunjucks-depreciate.md)


### PR DESCRIPTION
Closes #1719 
This PR updates the main README.md of the AsyncAPI Generator repository to include mentions of two newly published supporting packages:

@asyncapi/generator-helper – Provides helper functions and utilities to simplify template development for baked-in templates, reducing boilerplate and speeding up template creation.

@asyncapi/generator-component – Offers reusable components that can be shared across baked-in templates to avoid duplication and accelerate development.

These packages are primarily intended for contributors and template developers, similar to how we list Hooks, Nunjucks-filters, and React-sdk. No standalone READMEs or dedicated documentation pages are added at this point, in line with current scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README updated with two new top-level package entries: Generator-helpers and Generator-components.
  * Adds descriptions for available utility helpers and reusable components to improve discoverability and guidance for template authors.
  * Documentation-only change; no runtime or behavioral modifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->