### PR TITLE
docs: add note about baked-in templates in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ There is a large number of templates that are ready to use and are officially su
 
 You can find above templates and the ones provided by the community in **[this list](https://github.com/search?q=topic%3Aasyncapi+topic%3Agenerator+topic%3Atemplate)**
 
+> [!NOTE]
+
+AsyncAPI Generator also comes with **baked-in templates** - official templates shipped directly inside the Generator (`@asyncapi/generator`). These provide visibility into ongoing experimental work and offer a streamlined way to generate clients, documentation, and other artifacts.
+
+⚠️ This feature is experimental and not recommended for production use.
+
+For those who want to try them out or learn more, see the [Baked-in templates documentation](https://www.asyncapi.com/docs/tools/generator/baked-in-templates).
+
 ## Filters
 
  `apps/nunjucks-filters` library contains generator filters that can be reused across multiple templates, helping to avoid redundant work. These filters are designed specifically for Nunjucks templates and are included by default with the generator, so there's no need to add them to dependencies separately.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ There is a large number of templates that are ready to use and are officially su
 
 You can find above templates and the ones provided by the community in **[this list](https://github.com/search?q=topic%3Aasyncapi+topic%3Agenerator+topic%3Atemplate)**
 
-> [!NOTE]
+> [!IMPORTANT]
 
 AsyncAPI Generator also comes with **baked-in templates** - official templates shipped directly inside the Generator (`@asyncapi/generator`). These provide visibility into ongoing experimental work and offer a streamlined way to generate clients, documentation, and other artifacts.
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ There is a large number of templates that are ready to use and are officially su
 You can find above templates and the ones provided by the community in **[this list](https://github.com/search?q=topic%3Aasyncapi+topic%3Agenerator+topic%3Atemplate)**
 
 > [!IMPORTANT]
-
-AsyncAPI Generator also comes with **baked-in templates** - official templates shipped directly inside the Generator (`@asyncapi/generator`). These provide visibility into ongoing experimental work and offer a streamlined way to generate clients, documentation, and other artifacts.
+>AsyncAPI Generator also comes with **baked-in templates** - official templates shipped directly inside the Generator (`@asyncapi/generator`).They cover code, docs, configs, and SDKs, and are maintained under [`/packages/templates`](packages/templates) with a consistent, opinionated structure for reliability and ease of maintenance. These provide visibility into ongoing experimental work and offer a streamlined way to generate clients, documentation, and other artifacts.
 
 ⚠️ This feature is experimental and not recommended for production use.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ There is a large number of templates that are ready to use and are officially su
 
 You can find above templates and the ones provided by the community in **[this list](https://github.com/search?q=topic%3Aasyncapi+topic%3Agenerator+topic%3Atemplate)**
 
-> [!IMPORTANT]
+> [!NOTE]
 >AsyncAPI Generator also comes with **baked-in templates** - official templates shipped directly inside the Generator (`@asyncapi/generator`). They cover code, docs, configs, and SDKs, and are maintained under [`/packages/templates`](packages/templates) with a consistent, opinionated structure for reliability and ease of maintenance. These provide visibility into ongoing experimental work and offer a streamlined way to generate clients, documentation, and other artifacts.
 
 ⚠️ This feature is experimental and not recommended for production use.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ There is a large number of templates that are ready to use and are officially su
 You can find above templates and the ones provided by the community in **[this list](https://github.com/search?q=topic%3Aasyncapi+topic%3Agenerator+topic%3Atemplate)**
 
 > [!IMPORTANT]
->AsyncAPI Generator also comes with **baked-in templates** - official templates shipped directly inside the Generator (`@asyncapi/generator`).They cover code, docs, configs, and SDKs, and are maintained under [`/packages/templates`](packages/templates) with a consistent, opinionated structure for reliability and ease of maintenance. These provide visibility into ongoing experimental work and offer a streamlined way to generate clients, documentation, and other artifacts.
+>AsyncAPI Generator also comes with **baked-in templates** - official templates shipped directly inside the Generator (`@asyncapi/generator`). They cover code, docs, configs, and SDKs, and are maintained under [`/packages/templates`](packages/templates) with a consistent, opinionated structure for reliability and ease of maintenance. These provide visibility into ongoing experimental work and offer a streamlined way to generate clients, documentation, and other artifacts.
 
 ⚠️ This feature is experimental and not recommended for production use.
 

--- a/apps/generator/README.md
+++ b/apps/generator/README.md
@@ -28,8 +28,7 @@ There is a large number of templates that are ready to use and are officially su
 You can find above templates and the ones provided by the community in **[this list](https://github.com/search?q=topic%3Aasyncapi+topic%3Agenerator+topic%3Atemplate)**
 
 > [!IMPORTANT]
-
-AsyncAPI Generator also comes with **baked-in templates** - official templates shipped directly inside the Generator (`@asyncapi/generator`). These provide visibility into ongoing experimental work and offer a streamlined way to generate clients, documentation, and other artifacts.
+>AsyncAPI Generator also comes with **baked-in templates** - official templates shipped directly inside the Generator (`@asyncapi/generator`).They cover code, docs, configs, and SDKs, and are maintained under [`/packages/templates`](packages/templates) with a consistent, opinionated structure for reliability and ease of maintenance. These provide visibility into ongoing experimental work and offer a streamlined way to generate clients, documentation, and other artifacts.
 
 ⚠️ This feature is experimental and not recommended for production use.
 

--- a/apps/generator/README.md
+++ b/apps/generator/README.md
@@ -27,7 +27,7 @@ There is a large number of templates that are ready to use and are officially su
 
 You can find above templates and the ones provided by the community in **[this list](https://github.com/search?q=topic%3Aasyncapi+topic%3Agenerator+topic%3Atemplate)**
 
-> [!NOTE]
+> [!IMPORTANT]
 
 AsyncAPI Generator also comes with **baked-in templates** - official templates shipped directly inside the Generator (`@asyncapi/generator`). These provide visibility into ongoing experimental work and offer a streamlined way to generate clients, documentation, and other artifacts.
 

--- a/apps/generator/README.md
+++ b/apps/generator/README.md
@@ -28,7 +28,7 @@ There is a large number of templates that are ready to use and are officially su
 You can find above templates and the ones provided by the community in **[this list](https://github.com/search?q=topic%3Aasyncapi+topic%3Agenerator+topic%3Atemplate)**
 
 > [!IMPORTANT]
->AsyncAPI Generator also comes with **baked-in templates** - official templates shipped directly inside the Generator (`@asyncapi/generator`).They cover code, docs, configs, and SDKs, and are maintained under [`/packages/templates`](packages/templates) with a consistent, opinionated structure for reliability and ease of maintenance. These provide visibility into ongoing experimental work and offer a streamlined way to generate clients, documentation, and other artifacts.
+>AsyncAPI Generator also comes with **baked-in templates** - official templates shipped directly inside the Generator (`@asyncapi/generator`). They cover code, docs, configs, and SDKs, and are maintained under [`/packages/templates`](packages/templates) with a consistent, opinionated structure for reliability and ease of maintenance. These provide visibility into ongoing experimental work and offer a streamlined way to generate clients, documentation, and other artifacts.
 
 ⚠️ This feature is experimental and not recommended for production use.
 

--- a/apps/generator/README.md
+++ b/apps/generator/README.md
@@ -27,7 +27,7 @@ There is a large number of templates that are ready to use and are officially su
 
 You can find above templates and the ones provided by the community in **[this list](https://github.com/search?q=topic%3Aasyncapi+topic%3Agenerator+topic%3Atemplate)**
 
-> [!IMPORTANT]
+> [!NOTE]
 >AsyncAPI Generator also comes with **baked-in templates** - official templates shipped directly inside the Generator (`@asyncapi/generator`). They cover code, docs, configs, and SDKs, and are maintained under [`/packages/templates`](packages/templates) with a consistent, opinionated structure for reliability and ease of maintenance. These provide visibility into ongoing experimental work and offer a streamlined way to generate clients, documentation, and other artifacts.
 
 ⚠️ This feature is experimental and not recommended for production use.

--- a/apps/generator/README.md
+++ b/apps/generator/README.md
@@ -26,3 +26,11 @@ There is a large number of templates that are ready to use and are officially su
 <!-- TEMPLATES-LIST:END -->
 
 You can find above templates and the ones provided by the community in **[this list](https://github.com/search?q=topic%3Aasyncapi+topic%3Agenerator+topic%3Atemplate)**
+
+> [!NOTE]
+
+AsyncAPI Generator also comes with **baked-in templates** - official templates shipped directly inside the Generator (`@asyncapi/generator`). These provide visibility into ongoing experimental work and offer a streamlined way to generate clients, documentation, and other artifacts.
+
+⚠️ This feature is experimental and not recommended for production use.
+
+For those who want to try them out or learn more, see the [Baked-in templates documentation](https://www.asyncapi.com/docs/tools/generator/baked-in-templates).


### PR DESCRIPTION
## Description

### Summary
This PR adds a note about **baked-in templates (experimental)** to the main `README.md`, under the _List of official generator templates_ section.

### Why
- The README is the most frequently visited entry point for users and contributors.
- Adding this note helps readers understand what baked-in templates are and where to find them.
- It increases visibility into ongoing experimental work.

### Changes
- Added an `[!NOTE]` note with a link to the baked-in templates documentation.

### Related issue(s)
Resolves [#1718](https://github.com/asyncapi/generator/issues/1718)
