### PR TITLE
fix: prevent empty <dd> tags in api.md from breaking website builds

### DIFF
--- a/apps/generator/docs/jsdoc2md-handlebars/docs.hbs
+++ b/apps/generator/docs/jsdoc2md-handlebars/docs.hbs
@@ -1,0 +1,5 @@
+{{>header~}}
+{{>body}}
+{{>member-index~}}
+{{>separator~}}
+{{>members~}}

--- a/apps/generator/docs/jsdoc2md-handlebars/global-index-dl.hbs
+++ b/apps/generator/docs/jsdoc2md-handlebars/global-index-dl.hbs
@@ -1,0 +1,11 @@
+{{#globals kind=kind ~}}
+{{#if @first~}}{{>heading-indent}}{{../title}}
+
+<dl>
+{{/if~}}
+<dt>{{>sig-link-html}}</dt>
+{{#if description}}<dd>{{{md (inlineLinks description)}}}</dd>{{/if}}
+{{#if @last~}}</dl>
+
+{{/if~}}
+{{/globals~}}

--- a/apps/generator/docs/jsdoc2md-handlebars/main-index-dl.hbs
+++ b/apps/generator/docs/jsdoc2md-handlebars/main-index-dl.hbs
@@ -1,0 +1,11 @@
+{{#modules~}}
+{{#if @first~}}{{>heading-indent}}Modules
+
+<dl>
+{{/if~}}
+<dt>{{>sig-link-html}}</dt>
+{{#if description}}<dd>{{{md (inlineLinks description)}}}</dd>{{/if}}
+{{#if @last~}}</dl>
+
+{{/if~}}
+{{/modules~}}

--- a/apps/generator/package.json
+++ b/apps/generator/package.json
@@ -18,7 +18,7 @@
     "test:integration": "npm run test:cleanup && jest --testPathPattern=integration --modulePathIgnorePatterns='./__mocks__(?!\\/loglevel\\.js$)'",
     "test:integration:update": "npm run test:integration -- -u",
     "test:cleanup": "rimraf \"test/temp\"",
-    "docs": "jsdoc2md --partial docs/jsdoc2md-handlebars/custom-sig-name.hbs docs/jsdoc2md-handlebars/main.hbs docs/jsdoc2md-handlebars/docs.hbs docs/jsdoc2md-handlebars/header.hbs docs/jsdoc2md-handlebars/defaultvalue.hbs docs/jsdoc2md-handlebars/link.hbs docs/jsdoc2md-handlebars/params-table.hbs --files lib/generator.js > docs/api.md",
+    "docs": "jsdoc2md --partial docs/jsdoc2md-handlebars/custom-sig-name.hbs docs/jsdoc2md-handlebars/main.hbs docs/jsdoc2md-handlebars/docs.hbs docs/jsdoc2md-handlebars/header.hbs docs/jsdoc2md-handlebars/defaultvalue.hbs docs/jsdoc2md-handlebars/link.hbs docs/jsdoc2md-handlebars/params-table.hbs docs/jsdoc2md-handlebars/main-index-dl.hbs docs/jsdoc2md-handlebars/global-index-dl.hbs --files lib/generator.js > docs/api.md",
     "docker:build": "docker build -t asyncapi/generator:latest .",
     "lint": "eslint --max-warnings 0 --config ../../.eslintrc --ignore-path ../../.eslintignore .",
     "lint:fix": "npm run lint -- --fix",


### PR DESCRIPTION
**Description**

- Fix empty `<dd></dd>` tags in generated api.md that break website builds
- Add missing docs.hbs template referenced in npm script
- Create custom main-index-dl.hbs and global-index-dl.hbs templates with conditional rendering
- Update docs generation script to include new template partials
- Regenerate api.md with fixed templates to eliminate empty description tags

**Related issue(s)**
Fixes #1734