### PR TITLE
docs: migrate generator template tutorial to AsyncAPI v3 syntax and p…

### DIFF
--- a/apps/generator/docs/generator-template.md
+++ b/apps/generator/docs/generator-template.md
@@ -105,7 +105,7 @@ python-mqtt-client-template
 │ └── fixtures
 │ └── asyncapi.yml
 └── package.json
-
+```
 
 Lets break it down:
 


### PR DESCRIPTION
This PR resolves #1503 by completely migrating the Python Generator Template Tutorial from AsyncAPI v2.6.0 to v3.0.0 compatibility.

**Key changes implemented:**

1.  **Specification Upgrade**: Rewrote all example YAML documents (initial and final multi-channel) to adhere to AsyncAPI v3.0.0 standards (using `host` instead of `url`, `operations` separate from `channels`, and `action: send` instead of `publish`).
2.  **Parser API (JavaScript):** Updated the template logic in `index.js` and `TopicFunction.js` to use the v3 Parser API, specifically switching from `asyncapi.channels().filterByReceive()` to **`asyncapi.operations().filterByAction('send')`** for correct operation fetching.
3.  **Template Logic:** Updated `TopicFunction.js` to correctly extract channel addresses and operation IDs from the new v3 operation objects.

## Related Issue(s)

Resolves  #1503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Overhauled template docs and examples to an operations-centric model; AsyncAPI samples, examples, and outputs updated to match new terminology.
* **New Features**
  * Examples and generated clients now demonstrate operation-based topic usage and server address handling.
* **Refactor**
  * Public-facing template APIs and wiring converted from channel-centric to operations-first interfaces.
* **Bug Fixes**
  * Fixed terminology inconsistencies and adjusted formatting across docs and sample code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->