### PR TITLE
feat: update release worflow and trigger release

### DIFF
--- a/.changeset/yellow-foxes-shout.md
+++ b/.changeset/yellow-foxes-shout.md
@@ -1,0 +1,6 @@
+---
+"@asyncapi/generator": minor
+"@asyncapi/keeper": minor
+---
+
+Pushing of release https://github.com/asyncapi/generator/pull/1747 that failed due to pipeline issues.

--- a/.github/workflows/release-with-changesets.yml
+++ b/.github/workflows/release-with-changesets.yml
@@ -51,6 +51,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "${{ steps.lockversion.outputs.version }}"
+          registry-url: "https://registry.npmjs.org"
       - if: steps.lockversion.outputs.version == '18' && matrix.os == 'windows-latest'
         name: Install npm cli 8
         shell: bash


### PR DESCRIPTION
doing what folks in https://github.com/Effect-TS/effect/pull/5802 did should be enough.

I make this feat to release new minors as because of removal of recent versions on npm by npm due to security, next cannot be patch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Prepared package updates for release, including version bumps for generator and keeper packages.
  * Updated CI/CD workflow configuration to ensure proper registry connectivity during build processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->