### PR TITLE
fix: add proper token requirements to release

### DIFF
--- a/.changeset/yellow-foxes-shout.md
+++ b/.changeset/yellow-foxes-shout.md
@@ -1,0 +1,6 @@
+---
+"@asyncapi/generator": minor
+"@asyncapi/keeper": minor
+---
+
+Pushing of release https://github.com/asyncapi/generator/pull/1747 that failed due to pipeline issues.

--- a/.github/workflows/release-with-changesets.yml
+++ b/.github/workflows/release-with-changesets.yml
@@ -78,6 +78,10 @@ jobs:
     needs: [test-nodejs]
     name: Publish to any of NPM, GitHub, or Docker Hub
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
     steps:
       - name: Set git to use LF # To once and for all finish the never-ending fight between Unix and Windows
         run: |


### PR DESCRIPTION
The `id-token: write` permission is absolutely mandatory because it explicitly tells GitHub to generate a JSON Web Token (JWT) that contains the necessary identity claims for the external service (in this case, npm).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation security permissions to support the release workflow.
  * Updated release documentation with package version information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->