### PR TITLE
fix: make sure to use latest npm for release pipeline

### DIFF
--- a/.changeset/yellow-foxes-shout.md
+++ b/.changeset/yellow-foxes-shout.md
@@ -1,0 +1,6 @@
+---
+"@asyncapi/generator": minor
+"@asyncapi/keeper": minor
+---
+
+Pushing of release https://github.com/asyncapi/generator/pull/1747 that failed due to pipeline issues.

--- a/.github/workflows/release-with-changesets.yml
+++ b/.github/workflows/release-with-changesets.yml
@@ -95,7 +95,7 @@ jobs:
         shell: bash
       - if: steps.packagejson.outputs.exists == 'true'
         name: Check package-lock version
-        uses: asyncapi/.github/.github/actions/get-node-version-from-package-lock@master
+        uses: derberg/.github-asyncapi/.github/actions/get-node-version-from-package-lock@fixnodereelase
         id: lockversion
       - if: steps.packagejson.outputs.exists == 'true'
         name: Setup Node.js


### PR DESCRIPTION
making sure that new action for node that we want to roll out to who org works: https://github.com/asyncapi/.github/pull/369/files#diff-1144592a2dd44057577288b96058c5438be9e9d6e6d4c7a75a545ea2787d889f

I have below already in repo settings
<img width="790" height="163" alt="Screenshot 2025-12-03 at 20 37 35" src="https://github.com/user-attachments/assets/133b454f-fbe3-4648-aa53-a3ee73bf67c5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow pipeline configuration for enhanced deployment reliability.
  * Prepared minor version updates for package releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->