### PR TITLE
fix: remove generator requirements from baked-in templates

### DIFF
--- a/packages/templates/clients/kafka/java/quarkus/.ageneratorrc
+++ b/packages/templates/clients/kafka/java/quarkus/.ageneratorrc
@@ -1,5 +1,4 @@
 apiVersion: v3
-generator: '>=1.3.0 <3.0.0'
 parameters:
   server:
     description: The name of the server described in AsyncAPI document

--- a/packages/templates/clients/websocket/java/quarkus/.ageneratorrc
+++ b/packages/templates/clients/websocket/java/quarkus/.ageneratorrc
@@ -1,5 +1,4 @@
 apiVersion: v3
-generator: '>=1.3.0 <3.0.0'
 parameters:
   server:
     description: The name of the server described in AsyncAPI document


### PR DESCRIPTION
this is causing tests and release fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed generator version constraints from Kafka Java Quarkus template configuration.
  * Removed generator version constraints from WebSocket Java Quarkus template configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->