### PR TITLE
fix: release generator helpers and components lib to have latest changes

### DIFF
--- a/.changeset/maniek.md
+++ b/.changeset/maniek.md
@@ -1,0 +1,7 @@
+---
+"@asyncapi/generator": patch
+"@asyncapi/generator-helpers": patch
+"@asyncapi/generator-components": patch
+---
+
+Enforce new helpers and components release to use latest versions in generator. Required because of the recent misconfiguration of releases and Trusted Publishing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/generator": {
       "name": "@asyncapi/generator",
-      "version": "2.11.0",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/generator-components": "*",
@@ -2132,10 +2132,6 @@
     },
     "node_modules/@asyncapi/template-integration-test": {
       "resolved": "packages/templates/clients/websocket/test/integration-test",
-      "link": true
-    },
-    "node_modules/@asyncapi/template-kafka-integration-test": {
-      "resolved": "packages/templates/clients/kafka/test/integration-test",
       "link": true
     },
     "node_modules/@babel/cli": {
@@ -10070,6 +10066,10 @@
         "node": ">=8"
       }
     },
+    "node_modules/integration-test": {
+      "resolved": "packages/templates/clients/kafka/test/integration-test",
+      "link": true
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "license": "MIT",
@@ -17774,7 +17774,7 @@
     },
     "packages/components": {
       "name": "@asyncapi/generator-components",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/generator-helpers": "*",
@@ -17792,7 +17792,7 @@
     },
     "packages/helpers": {
       "name": "@asyncapi/generator-helpers",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "jest": "^27.3.1"
@@ -17802,7 +17802,7 @@
       "name": "core-template-client-kafka-java-quarkus",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-helpers": "0.2.0",
+        "@asyncapi/generator-helpers": "1.0.0",
         "@asyncapi/generator-react-sdk": "^1.1.2"
       },
       "devDependencies": {
@@ -17821,11 +17821,9 @@
       }
     },
     "packages/templates/clients/kafka/test/integration-test": {
-      "name": "@asyncapi/template-kafka-integration-test",
-      "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-helpers": "0.2.0"
+        "@asyncapi/generator-helpers": "1.0.0"
       },
       "devDependencies": {
         "@asyncapi/generator": "*",
@@ -17844,8 +17842,8 @@
       "name": "core-template-client-websocket-dart",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-components": "0.3.1",
-        "@asyncapi/generator-helpers": "0.2.0",
+        "@asyncapi/generator-components": "0.4.0",
+        "@asyncapi/generator-helpers": "1.0.0",
         "@asyncapi/generator-react-sdk": "*"
       },
       "devDependencies": {
@@ -17865,8 +17863,8 @@
       "name": "core-template-client-websocket-java-quarkus",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-components": "0.3.1",
-        "@asyncapi/generator-helpers": "0.2.0",
+        "@asyncapi/generator-components": "0.4.0",
+        "@asyncapi/generator-helpers": "1.0.0",
         "@asyncapi/generator-react-sdk": "^1.1.2"
       },
       "devDependencies": {
@@ -17888,8 +17886,8 @@
       "name": "core-template-client-websocket-javascript",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-components": "0.3.1",
-        "@asyncapi/generator-helpers": "0.2.0",
+        "@asyncapi/generator-components": "0.4.0",
+        "@asyncapi/generator-helpers": "1.0.0",
         "@asyncapi/generator-react-sdk": "*",
         "@asyncapi/keeper": "0.5.0"
       },
@@ -17910,8 +17908,8 @@
       "name": "core-template-client-websocket-python",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-components": "0.3.1",
-        "@asyncapi/generator-helpers": "0.2.0",
+        "@asyncapi/generator-components": "0.4.0",
+        "@asyncapi/generator-helpers": "1.0.0",
         "@asyncapi/generator-react-sdk": "*"
       },
       "devDependencies": {
@@ -17931,7 +17929,7 @@
       "name": "@asyncapi/template-integration-test",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-helpers": "0.2.0"
+        "@asyncapi/generator-helpers": "1.0.0"
       },
       "devDependencies": {
         "@asyncapi/generator": "*",

--- a/packages/templates/clients/kafka/test/integration-test/package.json
+++ b/packages/templates/clients/kafka/test/integration-test/package.json
@@ -1,6 +1,4 @@
 {
-    "name": "@asyncapi/template-kafka-integration-test",
-    "version": "0.0.2",
     "private": true,
     "description": "This is a integration tests for all the kafka clients",
     "scripts": {


### PR DESCRIPTION
unable to use generator v3 in cli at the moment as helpers and components libraries were not released

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Prepared patch releases for @asyncapi/generator, @asyncapi/generator-helpers, and @asyncapi/generator-components packages.
  * Updated configuration to ensure helpers and components releases use the latest generator versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->