### PR TITLE
feat: add support for `reply` in python websocket client

### DIFF
--- a/packages/templates/clients/websocket/test/__fixtures__/asyncapi-slack-client.yml
+++ b/packages/templates/clients/websocket/test/__fixtures__/asyncapi-slack-client.yml
@@ -108,6 +108,8 @@ components:
   messages:
     event:
       summary: Event message representing different event types
+      correlationId:
+        location: $message.payload#/envelope_id
       payload:
         $ref: '#/components/schemas/event'
       examples:
@@ -249,6 +251,8 @@ components:
               app_id: A08NKKBFGBD
     acknowledge:
       summary: Acknowledgement response sent to Server
+      correlationId:
+        location: $message.payload#/envelope_id
       payload:
         $ref: '#/components/schemas/acknowledge'
       examples:

--- a/packages/templates/clients/websocket/test/__fixtures__/reply/asyncapi-postman-both-correlation.yml
+++ b/packages/templates/clients/websocket/test/__fixtures__/reply/asyncapi-postman-both-correlation.yml
@@ -1,0 +1,66 @@
+asyncapi: 3.0.0
+
+info:
+  title: Postman Echo WebSocket Client with Reply (Both Correlation IDs)
+  version: 1.0.0
+  description: >
+    Test fixture for reply handling with correlation IDs on both incoming and reply messages.
+    Template should extract correlation ID from incoming, pass to handler, and auto-inject into reply.
+
+servers:
+  echoServer:
+    host: ws.postman-echo.com
+    pathname: /raw
+    protocol: wss
+
+channels:
+  echo:
+    description: The main channel where messages are sent and echoed back by the Postman Echo WebSocket server.
+    address: /
+    messages:
+      echoMessage:
+        $ref: '#/components/messages/echoMessage'
+
+operations:
+  sendEchoMessage:
+    summary: Send a message to the Postman Echo server and receive a reply.
+    action: send
+    channel: 
+      $ref: '#/channels/echo'
+    messages:
+      - $ref: '#/channels/echo/messages/echoMessage'
+    reply:
+      channel: 
+        $ref: '#/channels/echo'
+      messages:
+        - $ref: '#/channels/echo/messages/echoMessage'
+
+components:
+  messages:
+    echoMessage:
+      summary: A message exchanged with the echo server with correlation ID on both request and reply.
+      correlationId:
+        location: $message.payload#/requestId
+      payload:
+        type: object
+        properties:
+          requestId:
+            type: string
+            description: Request identifier (auto-injected into reply)
+          message:
+            type: string
+            description: Message to echo back
+          timestamp:
+            type: string
+            description: Request/reply timestamp
+      examples:
+        - name: stringWithId
+          payload:
+            requestId: req-12345
+            message: test
+            timestamp: '2025-12-23T10:00:00Z'
+        - name: objectWithId
+          payload:
+            requestId: req-67890
+            message: test text
+            timestamp: '2025-12-23T10:00:00Z'

--- a/packages/templates/clients/websocket/test/__fixtures__/reply/asyncapi-postman-incoming-correlation.yml
+++ b/packages/templates/clients/websocket/test/__fixtures__/reply/asyncapi-postman-incoming-correlation.yml
@@ -1,0 +1,66 @@
+asyncapi: 3.0.0
+
+info:
+  title: Postman Echo WebSocket Client with Reply (Incoming Correlation Only)
+  version: 1.0.0
+  description: >
+    Test fixture for reply handling with correlation ID only on incoming message.
+    Template should extract correlation ID and pass to handler, but not auto-inject into reply.
+
+servers:
+  echoServer:
+    host: ws.postman-echo.com
+    pathname: /raw
+    protocol: wss
+
+channels:
+  echo:
+    description: The main channel where messages are sent and echoed back by the Postman Echo WebSocket server.
+    address: /
+    messages:
+      echoMessage:
+        $ref: '#/components/messages/echoMessage'
+
+operations:
+  sendEchoMessage:
+    summary: Send a message to the Postman Echo server and receive a reply.
+    action: send
+    channel: 
+      $ref: '#/channels/echo'
+    messages:
+      - $ref: '#/channels/echo/messages/echoMessage'
+    reply:
+      channel: 
+        $ref: '#/channels/echo'
+      messages:
+        - $ref: '#/channels/echo/messages/echoMessage'
+
+components:
+  messages:
+    echoMessage:
+      summary: A message exchanged with the echo server with correlation ID.
+      correlationId:
+        location: $message.payload#/requestId
+      payload:
+        type: object
+        properties:
+          requestId:
+            type: string
+            description: Unique request identifier
+          message:
+            type: string
+            description: Message to echo back
+          timestamp:
+            type: string
+            description: Request timestamp
+      examples:
+        - name: stringWithId
+          payload:
+            requestId: req-12345
+            message: test
+            timestamp: '2025-12-23T10:00:00Z'
+        - name: objectWithId
+          payload:
+            requestId: req-67890
+            message: test text
+            timestamp: '2025-12-23T10:00:00Z'

--- a/packages/templates/clients/websocket/test/__fixtures__/reply/asyncapi-postman-no-correlation.yml
+++ b/packages/templates/clients/websocket/test/__fixtures__/reply/asyncapi-postman-no-correlation.yml
@@ -1,0 +1,59 @@
+asyncapi: 3.0.0
+
+info:
+  title: Postman Echo WebSocket Client with Reply (No Correlation)
+  version: 1.0.0
+  description: >
+    Test fixture for reply handling without correlation IDs.
+    Postman Echo server replies to incoming messages without any correlation tracking.
+
+servers:
+  echoServer:
+    host: ws.postman-echo.com
+    pathname: /raw
+    protocol: wss
+
+channels:
+  echo:
+    description: The main channel where messages are sent and echoed back by the Postman Echo WebSocket server.
+    address: /
+    messages:
+      echoMessage:
+        $ref: '#/components/messages/echoMessage'
+
+operations:
+  sendEchoMessage:
+    summary: Send a message to the Postman Echo server and receive a reply.
+    action: send
+    channel: 
+      $ref: '#/channels/echo'
+    messages:
+      - $ref: '#/channels/echo/messages/echoMessage'
+    reply:
+      channel: 
+        $ref: '#/channels/echo'
+      messages:
+        - $ref: '#/channels/echo/messages/echoMessage'
+
+components:
+  messages:
+    echoMessage:
+      summary: A message exchanged with the echo server.
+      payload:
+        type: object
+        properties:
+          message:
+            type: string
+            description: Message to echo back
+          timestamp:
+            type: string
+            description: Request timestamp
+      examples:
+        - name: string
+          payload:
+            message: test
+            timestamp: '2025-12-23T10:00:00Z'
+        - name: object
+          payload:
+            message: test text
+            timestamp: '2025-12-23T10:00:00Z'

--- a/packages/templates/clients/websocket/test/__fixtures__/reply/asyncapi-postman-outgoing-correlation.yml
+++ b/packages/templates/clients/websocket/test/__fixtures__/reply/asyncapi-postman-outgoing-correlation.yml
@@ -1,0 +1,80 @@
+asyncapi: 3.0.0
+
+info:
+  title: Postman Echo WebSocket Client with Reply (Outgoing Correlation Only)
+  version: 1.0.0
+  description: >
+    Test fixture for reply handling with correlation ID only on reply message.
+    Template should log a warning that correlation cannot be populated from incoming message.
+
+servers:
+  echoServer:
+    host: ws.postman-echo.com
+    pathname: /raw
+    protocol: wss
+
+channels:
+  echo:
+    description: The main channel where messages are sent and echoed back by the Postman Echo WebSocket server.
+    address: /
+    messages:
+      echoRequest:
+        $ref: '#/components/messages/echoRequest'
+      echoReply:
+        $ref: '#/components/messages/echoReply'
+
+operations:
+  sendEchoMessage:
+    summary: Send a message to the Postman Echo server and receive a reply.
+    action: send
+    channel: 
+      $ref: '#/channels/echo'
+    messages:
+      - $ref: '#/channels/echo/messages/echoRequest'
+    reply:
+      channel: 
+        $ref: '#/channels/echo'
+      messages:
+        - $ref: '#/channels/echo/messages/echoReply'
+
+components:
+  messages:
+    echoRequest:
+      summary: Echo request message without correlation ID.
+      payload:
+        type: object
+        properties:
+          message:
+            type: string
+            description: Message to echo back
+          timestamp:
+            type: string
+            description: Request timestamp
+      examples:
+        - name: string
+          payload:
+            message: test
+            timestamp: '2025-12-23T10:00:00Z'
+
+    echoReply:
+      summary: Echo reply message with correlation ID.
+      correlationId:
+        location: $message.payload#/responseId
+      payload:
+        type: object
+        properties:
+          responseId:
+            type: string
+            description: Response identifier (cannot be auto-populated)
+          echo:
+            type: string
+            description: Echoed message
+          processedAt:
+            type: string
+            description: Server processing timestamp
+      examples:
+        - name: replyWithId
+          payload:
+            responseId: resp-67890
+            echo: test
+            processedAt: '2025-12-23T10:00:01Z'


### PR DESCRIPTION
resolved https://github.com/asyncapi/generator/issues/1547 that depends on https://github.com/asyncapi/generator/issues/1548

### Reply is possible in cool way with `correlationId`

This PR contains at the moment only changes in fixtures. Slack example nicely shows that it is recommended that for handling `reply` it is critical to specify `correlationId` so it is not only from the docs perspective but also from code generation perspective useful to know how incomming message is correlated with the reply message, with what properties.

With `correlationId` in place, you can generate code that is aware of a specific correlationId property and enable access to it through dedicated arguments.

### Current Limitation

Why dependency?

Current problem is that for clients we generate a generic message handler for a given address. Looking at this from perspective of [Slack client](https://github.com/asyncapi/generator/blob/master/packages/templates/clients/websocket/test/__fixtures__/asyncapi-slack-client.yml), it means we have one handler for all incomming messages, `onHelloMessage`, `onEvent`, `onDisconnectMessage`. The user of the generated client on their own needs to write code that can help understand what type of message was received by the handler.

So if `onEvent` is the only message that requires `reply`, developer needs to write a code inside message handler that understands that `onEvent` message was received, and then reply.

At the moment there is nothing useful that could be generated. 

I could enable user to do `client.register_reply_handler('onEvent', reply_handler_with_correlation)` but what is the value really? 

message handler could use some new function like:
```
self.send_reply('onEvent', reply_message)
```

But we are stuck with generic solutions again, generic message handler and generic reply handler - I don't like it at all. 

### Reply as standalone operation

Current slack example has:
```yaml
operations:
  onEvent:
    action: receive
    channel:
      $ref: '#/channels/root'
    messages:
      - $ref: '#/channels/root/messages/event'
    reply:
      messages:
        - $ref: '#/channels/root/messages/acknowledge'
      channel:
        $ref: '#/channels/root'
```

We could do this to at least enable generation of standalone method to send reply"
```yaml
operations:
  onEvent:
    action: receive
    channel:
      $ref: '#/channels/root'
    messages:
      - $ref: '#/channels/root/messages/event'
    reply:
      messages:
        - $ref: '#/channels/root/messages/acknowledge'
      channel:
        $ref: '#/channels/root'
  sendEventAcknowledge:  # NEW: Explicit reply send operation
    action: send
    messages:
      - $ref: '#/channels/root/messages/acknowledge'
```

But this is controversial and enables errors, for example I can have different channel in reply and a different channel specified in `sendEventAcknowledge`. So to be honest best would be to enable `reply` object to simply have `operationId` or I would just have to generate `onEvent` + `Reply` as standalone function.

Some discussion under: https://github.com/asyncapi/spec/issues/981

---

So again, we should first solve https://github.com/asyncapi/generator/issues/1548 and then we can handle reply topic, because the best user experience would be if I get access to handler like `client.register_onevent_reply_handler(my_reply_method)` that allows me to pass `my_reply_method` that would have access to incoming message and correlationId and it's goal would be to return object that would be sent to the server/broker