### PR TITLE
docs: update AsyncAPI example to v3 syntax in Python tutorial

### DIFF
--- a/apps/generator/docs/generator-template.md
+++ b/apps/generator/docs/generator-template.md
@@ -44,7 +44,7 @@ Before you create the template, you'll need to have an [AsyncAPI document](https
 
 ``` yml
 
-asyncapi: 2.6.0
+asyncapi: 3.0.0
 
 info:
   title: Temperature Service
@@ -53,22 +53,27 @@ info:
 
 servers:
   dev:
-    url: test.mosquitto.org #in case you're using local mosquitto instance, change this value to localhost.
+    host: test.mosquitto.org #in case you're using local mosquitto instance, change this value to localhost.
     protocol: mqtt
 
 channels:
-  temperature/changed:
+  temperatureChangedChannel:
+    address: temperature/changed
     description: Updates the bedroom temperature in the database when the temperatures drops or goes up.
-    publish:
-      operationId: temperatureChange
-      message:
+    messages:
+      temperatureMessage:
         description: Message that is being sent when the temperature in the bedroom changes.
         payload:
-          type: object
-          additionalProperties: false
-          properties:
-            temperatureId:
-              type: string
+          $ref: '#/components/schemas/temperatureId'
+
+operations:
+  temperatureChange:
+    action: receive
+    channel:
+      $ref: '#/channels/temperatureChangedChannel'
+    messages:
+      - $ref: '#/channels/temperatureChangedChannel/messages/temperatureMessage'        
+
 components:
   schemas:
     temperatureId:
@@ -357,7 +362,7 @@ You often have different runtime environments in programming, e.g., development 
 ```yml
 servers:
   dev:
-    url: test.mosquitto.org
+    host: test.mosquitto.org
     protocol: mqtt
 ```
 


### PR DESCRIPTION
I've updated the AsyncAPI example used in the Python MQTT tutorial to use version 3 syntax. Earlier it was using v2.6.0, so I migrated the structure to match v3  updated channels, operations, and message definitions accordingly.
I kept the changes minimal and only focused on the YAML file for now. No template or parser logic was touched.
Also validated the file locally using asyncapi validate and it checks out.
This is just the first small step toward fully updating the tutorial to v3. Let me know if anything needs tweaking!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sample AsyncAPI template from version 2.6.0 to 3.0.0
  * Restructured channel and message definitions to align with AsyncAPI 3.x specifications
  * Updated server addressing configuration syntax for improved compatibility
  * Enhanced component schema definitions with new structural references

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->