### PR TITLE
fix(generator): handle HTTP error status codes when fetching AsyncAPI spec 

### DIFF
--- a/apps/generator/lib/utils.js
+++ b/apps/generator/lib/utils.js
@@ -65,13 +65,16 @@ utils.convertMapToObject = (map) => {
  * @param {String} link URL where the AsyncAPI document is located.
  * @returns {Promise<String>} Content of fetched file.
  */
-utils.fetchSpec = (link) => {
-  return new Promise((resolve, reject) => {
-    fetch(link)
-      .then(res => resolve(res.text()))
-      .catch(reject);
-  });
+utils.fetchSpec = async (link) => {
+  const res = await fetch(link);
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch AsyncAPI document from ${link}: HTTP ${res.status} ${res.statusText}`
+    );
+  }
+  return res.text();
 };
+
 
 /**
  * Checks if given string is URL and if not, we assume it is file path
@@ -120,11 +123,11 @@ utils.isAsyncFunction = (fn) => {
  */
 utils.registerTypeScript = (filePath) => {
   const isTypescriptFile = filePath.endsWith('.ts');
-  
+
   if (!isTypescriptFile) {
     return;
   }
-  
+
   const { REGISTER_INSTANCE, register } = require('ts-node');
   // if the ts-node has already been registered before, do not register it again.
   // Check the env. TS_NODE_ENV if ts-node started via ts-node-dev package


### PR DESCRIPTION
Fixes #1807 

### Summary
This change improves error handling when fetching an AsyncAPI document from a remote URL.

### What was happening
The generator previously treated HTTP error responses (e.g. 404, 500) as successful fetches and attempted to parse the response body as an AsyncAPI document. This resulted in confusing parser errors that did not indicate the real cause of the failure.

### What’s changed
The generator now checks the HTTP response status when fetching a remote AsyncAPI document. If the response is not successful (non-2xx), the generation process fails immediately with a clear and descriptive error message that includes the HTTP status code.

### Result
Users now receive fast, accurate feedback when a remote AsyncAPI document cannot be fetched, and parsing is no longer attempted on invalid responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling when fetching documents with clearer error messages for failed requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->