### PR TITLE
docs: align node/npm versions in development guide

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -195,7 +195,7 @@ For the PR titles you can refer to [this guide](CONTRIBUTING.md?plain=1#L60)
 
 If you encounter any issues during development or testing, please check the following:
 
-1. Ensure you're using the correct Node.js version (18.20.8 or higher) and npm version (10.8.2 or higher).
+1. Ensure you're using the correct Node.js version (24.11 or higher) and npm version (11.5.1 or higher), matching the engines field in package.json.
 2. Clear the `node_modules` directory and reinstall dependencies if you encounter unexpected behavior.
 3. For Docker-related issues, make sure Docker is running and you have sufficient permissions.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/generator": {
       "name": "@asyncapi/generator",
-      "version": "3.0.0",
+      "version": "3.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/generator-components": "*",
@@ -642,7 +642,6 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -917,7 +916,6 @@
       "version": "26.6.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^26.6.3",
         "import-local": "^3.0.2",
@@ -2184,7 +2182,6 @@
     "node_modules/@babel/core": {
       "version": "7.28.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -5570,7 +5567,6 @@
       "version": "7.20.5",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -5762,7 +5758,6 @@
       "version": "14.1.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -5927,7 +5922,6 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6004,7 +5998,6 @@
     "node_modules/ajv": {
       "version": "8.17.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6738,7 +6731,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -8025,6 +8017,7 @@
       "version": "2.1.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -8254,7 +8247,6 @@
       "version": "6.8.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -12146,7 +12138,6 @@
     "node_modules/jsep": {
       "version": "1.4.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -12386,6 +12377,7 @@
       "version": "3.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "uc.micro": "^1.0.1"
       }
@@ -12618,6 +12610,7 @@
       "version": "12.3.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "~2.1.0",
@@ -12641,7 +12634,8 @@
     "node_modules/markdown-it/node_modules/argparse": {
       "version": "2.0.1",
       "dev": true,
-      "license": "Python-2.0"
+      "license": "Python-2.0",
+      "peer": true
     },
     "node_modules/markdown-link": {
       "version": "0.1.1",
@@ -12702,7 +12696,8 @@
     "node_modules/mdurl": {
       "version": "1.0.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -13531,8 +13526,7 @@
     },
     "node_modules/openapi-types": {
       "version": "12.1.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.8.3",
@@ -14886,7 +14880,6 @@
     "node_modules/rollup": {
       "version": "2.79.2",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -16873,7 +16866,8 @@
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
@@ -17774,7 +17768,7 @@
     },
     "packages/components": {
       "name": "@asyncapi/generator-components",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/generator-helpers": "*",
@@ -17792,7 +17786,7 @@
     },
     "packages/helpers": {
       "name": "@asyncapi/generator-helpers",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "jest": "^27.3.1"
@@ -17802,7 +17796,7 @@
       "name": "core-template-client-kafka-java-quarkus",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-helpers": "1.0.0",
+        "@asyncapi/generator-helpers": "1.1.0",
         "@asyncapi/generator-react-sdk": "^1.1.2"
       },
       "devDependencies": {
@@ -17841,8 +17835,8 @@
       "name": "core-template-client-websocket-dart",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-components": "0.4.0",
-        "@asyncapi/generator-helpers": "1.0.0",
+        "@asyncapi/generator-components": "0.5.0",
+        "@asyncapi/generator-helpers": "1.1.0",
         "@asyncapi/generator-react-sdk": "*"
       },
       "devDependencies": {
@@ -17862,8 +17856,8 @@
       "name": "core-template-client-websocket-java-quarkus",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-components": "0.4.0",
-        "@asyncapi/generator-helpers": "1.0.0",
+        "@asyncapi/generator-components": "0.5.0",
+        "@asyncapi/generator-helpers": "1.1.0",
         "@asyncapi/generator-react-sdk": "^1.1.2"
       },
       "devDependencies": {
@@ -17885,8 +17879,8 @@
       "name": "core-template-client-websocket-javascript",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-components": "0.4.0",
-        "@asyncapi/generator-helpers": "1.0.0",
+        "@asyncapi/generator-components": "0.5.0",
+        "@asyncapi/generator-helpers": "1.1.0",
         "@asyncapi/generator-react-sdk": "*",
         "@asyncapi/keeper": "0.5.0"
       },
@@ -17907,8 +17901,8 @@
       "name": "core-template-client-websocket-python",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-components": "0.4.0",
-        "@asyncapi/generator-helpers": "1.0.0",
+        "@asyncapi/generator-components": "0.5.0",
+        "@asyncapi/generator-helpers": "1.1.0",
         "@asyncapi/generator-react-sdk": "*"
       },
       "devDependencies": {
@@ -17928,7 +17922,7 @@
       "name": "@asyncapi/template-integration-test",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-helpers": "1.0.0"
+        "@asyncapi/generator-helpers": "1.1.0"
       },
       "devDependencies": {
         "@asyncapi/generator": "*",


### PR DESCRIPTION
## Summary
> - Updated the Troubleshooting section in Development.md to match the node and npm versions specified in the engines field of package.json.
>
## Why
> - The previous values (Node 18.20.8 / npm 10.8.2) conflicted with the actual requirement (node >= 24.11, npm >= 11.5.1), which can confuse new contributors and cause EBADENGINE errors.
>
## Testing
> - npm run generator:test
> - <img width="511" height="160" alt="image" src="https://github.com/user-attachments/assets/c1021d3e-ca64-4068-9c0b-5ee6e5fed45e" />

>


<img width="319" height="157" alt="image" src="https://github.com/user-attachments/assets/193d470d-54c4-4d65-bc74-66068387ea1c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development environment version requirements to Node.js 24.11+ and npm 11.5.1+ in the troubleshooting guide.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->