### PR TITLE
docs: fixing non-exisiting path test/tempalates and other in Development.md

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -76,7 +76,7 @@ You can also opt in to run the lint checks after the tests, by setting an enviro
 
 ### Manually testing with test templates
 
-To test template features manually we have `react-template` and `nunjucks-template` in `apps/generator/test/templates`, you can use this templates to manually test your changes like this:
+To test template features manually we have `react-template` and `nunjucks-template` in `apps/generator/test/test-templates`, you can use this templates to manually test your changes like this:
 
 1. Navigate to the generator directory:
 
@@ -88,7 +88,7 @@ cd apps/generator
 3. Run the generator with the react-template:
 
 ```bash
-node ./cli  ./test/docs/dummy.yml ./test/test-templates/react-template -o ./test/output --force-write
+node ./cli ./test/docs/dummy.yml ./test/test-templates/react-template -o ./test/output --force-write
 ```
 
 4. Check the output in the `./test/output` directory to verify the output that you desired.


### PR DESCRIPTION
**Description**
There is mentioned path for templates in manual testing `test/templates` but it doesn't exists this pr fixes this path to 
`test/test-templates`  and fixing Extra whitespaces and mentioning  The precise use of the command works only in CMD.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The 3rd option will not automatically close the issue after the merge. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Windows lint command wording to indicate CMD shell.
  * Expanded manual testing instructions to reference both React and Nunjucks test templates.
  * Updated example for invoking the CLI during tests and refined surrounding phrasing and navigation steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->