### PR TITLE
docs: fix generator CLI path in README

### DIFF
--- a/packages/templates/clients/kafka/java/quarkus/README.md
+++ b/packages/templates/clients/kafka/java/quarkus/README.md
@@ -26,7 +26,7 @@
 1. Navigate to `packages/templates/clients/kafka/java/quarkus`
 2. Install with `npm install`
 3. Navigate back to `./generator`
-4. Generate the template client with `node .\apps\generator\cli.js <path-to-custom-document> .\packages\templates\clients\kafka\java\quarkus\ -o outputClient --force-write --param server=<custom-server>`
+4. Generate the template client with `node .\apps\generator\test\cli.js <path-to-custom-document> .\packages\templates\clients\kafka\java\quarkus\ -o outputClient --force-write --param server=<custom-server>`
 5. Navigate to `outputClient` or any other name you gave the output folder
 6. Navigate to the docker folder with `cd src/main/docker` and find the `docker-compose.yaml` file. 
 7. Start the kafka broker by runnning `docker-compose up -d`. Make sure you have docker desktop up and running.

--- a/packages/templates/clients/websocket/java/quarkus/README.md
+++ b/packages/templates/clients/websocket/java/quarkus/README.md
@@ -75,7 +75,7 @@ You can use our AsyncAPI's credentials to access different set of events produce
 2. Navigate to `packages/templates/clients/websocket/java/quarkus`
 3. Install with `npm install`
 4. Navigate back to `./generator`
-5. Generate the template client with `node .\apps\generator\cli.js <path-to-custom-document> .\packages\templates\clients\websocket\java\quarkus\ -o outputClient --force-write --param server=<custom-server>`
+5. Generate the template client with `node .\apps\generator\test\cli.js <path-to-custom-document> .\packages\templates\clients\websocket\java\quarkus\ -o outputClient --force-write --param server=<custom-server>`
 6. Navigate to `outputClient` or any other name you gave the output folder
 7. Run `mvn quarkus:dev`
 8. See the output in the terminal


### PR DESCRIPTION
cli.js is moved from `.apps\generator\cli.js` to `.apps\generator\test\cli.js` but path is not updated in the dev guide.
This pr updates the path. 

NOTE: maintainer asked for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated generator CLI paths in Kafka and WebSocket template client documentation to reflect current configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->