### PR TITLE
fix(docs): correct broken' AsyncAPI' reference link

### DIFF
--- a/apps/generator/docs/model-generation.md
+++ b/apps/generator/docs/model-generation.md
@@ -5,7 +5,7 @@ weight: 200
 
 This guide will walk you through the process of enabling models/types generation in a template by using [Modelina](https://www.asyncapi.com/tools/modelina).
 
-Modelina is an AsyncAPI library designed for generating data models using inputs such as [AsyncAPI](generator/asyncapi-document), OpenAPI, or JSON schema inputs. Its functionality revolves around creating data models from the provided AsyncAPI document and the model template, which defines message payloads. It is better to use Modelina in your template to handle model generation rather than providing custom templates.
+Modelina is an AsyncAPI library designed for generating data models using inputs such as [AsyncAPI](/generator/apps/generator/docs/asyncapi-document), OpenAPI, or JSON schema inputs. Its functionality revolves around creating data models from the provided AsyncAPI document and the model template, which defines message payloads. It is better to use Modelina in your template to handle model generation rather than providing custom templates.
 
 You can integrate the work shown in this guide into a template by following the [tutorial about creating a template](https://www.asyncapi.com/docs/tools/generator/generator-template).
 


### PR DESCRIPTION
### What this PR does
Fixes a broken "AsyncAPI" documentation link that currently points to a non-existent path.

### Root cause
The link was resolving to:
`generator/asyncapi-document`
which results in a 404 due to duplicated path segments.

### Solution
Updated the link to the correct one:
`/generator/apps/generator/docs/asyncapi-document`


### Related issue  #1836



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation links and references for improved organization and accessibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->