### PR TITLE
refactor: remove redundant object spread in conditionalGeneration

### DIFF
--- a/apps/generator/lib/conditionalGeneration.js
+++ b/apps/generator/lib/conditionalGeneration.js
@@ -111,10 +111,9 @@ async function conditionalSubjectGeneration (
   const server = templateParams.server && asyncapiDocument.servers().get(templateParams.server);
   const source = jmespath.search({
     ...asyncapiDocument.json(),
-    ...{
-      server: server ? server.json() : undefined,
-    },
+    server: server ? server.json() : undefined,
   }, subject);
+
 
   if (!source) {
     log.debug(logMessage.relativeSourceFileNotGenerated(matchedConditionPath, subject));


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Simplified the object literal passed to jmespath.search by removing a redundant nested spread.
- Improved readability while preserving the existing behavior of the server property.
- Avoided unnecessary creation of an intermediate object.

**Related issue(s)**
Resolves #1911 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Minor internal code optimization with no impact to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->