### PR TITLE
refactor: update fs/promises imports to use node: prefix

### DIFF
--- a/apps/generator/scripts/build-templates.js
+++ b/apps/generator/scripts/build-templates.js
@@ -1,7 +1,7 @@
 // This script traverse packages/templates and as a result updates template's .ageneratorrc with metadata and their package.json with proper name, then generate lib/templates/BakedInTemplatesList.json
 // Run with: `npm run build` always as pretest script
 
-const { readdir, readFile, writeFile, cp } = require('fs/promises');
+const { readdir, readFile, writeFile, cp } = require('node:fs/promises');
 const path = require('path');
 const yaml = require('js-yaml');
 const { transpileFiles } = require('@asyncapi/generator-react-sdk');

--- a/packages/helpers/src/testing.js
+++ b/packages/helpers/src/testing.js
@@ -1,4 +1,4 @@
-const { readFile, rm, readdir} = require('fs/promises');
+const { readFile, rm, readdir} = require('node:fs/promises');
 const path = require('path');
 
 /**

--- a/packages/helpers/test/testing.test.js
+++ b/packages/helpers/test/testing.test.js
@@ -1,8 +1,8 @@
 const { listFiles, buildParams, hasNestedConfig, cleanTestResultPaths, getDirElementsRecursive } = require('@asyncapi/generator-helpers');
 const path = require('path');
-const { rm, readdir } = require('fs/promises');
+const { rm, readdir } = require('node:fs/promises');
 
-jest.mock('fs/promises', () => ({
+jest.mock('node:fs/promises', () => ({
   rm: jest.fn(),
   readdir: jest.fn(),
 }));


### PR DESCRIPTION
This PR standardizes the usage of the Node core modules by adding the node: prefix to fs/promises imports across the codebase.

The Problem:
Older imports like require('fs/promises') trigger warnings in SonarCloud and can cause resolution issues in stricter, modern Node environments (like Node 24). This addresses the issue recently raised by @Varshitha in the #generator Slack channel regarding SonarCloud flagging these imports.

The Fix:

Updated apps/generator/scripts/build-templates.js

Updated packages/helpers/src/testing.js

Updated packages/helpers/test/testing.test.js (including Jest mocks).

Verification:

npm run test passes successfully in packages/helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js module import conventions across the codebase for improved compatibility and consistency. No functional changes or user impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->