### PR TITLE
test: improve unit test coverage for parser and utils modules

### DIFF
--- a/apps/generator/test/parser.test.js
+++ b/apps/generator/test/parser.test.js
@@ -3,7 +3,57 @@ const path = require('path');
 const { sanitizeTemplateApiVersion, usesNewAPI, parse, convertOldOptionsToNew } = require('../lib/parser');
 const dummyV2Document = fs.readFileSync(path.resolve(__dirname, './docs/dummy.yml'), 'utf8');
 const dummyV3Document = fs.readFileSync(path.resolve(__dirname, './docs/dummyV3.yml'), 'utf8');
+const ASYNCAPI_V2_VERSION = '2.3.0';
+const ASYNCAPI_V3_VERSION = '3.0.0';
+const TEST_DOCS_PATH = './test/docs/';
+describe('resolver canRead variations', () => {
+  const uri = {
+    valueOf: () => 'http://example.com/test.yaml',
+    suffix: () => 'yaml'
+  };
 
+  it('supports boolean canRead', () => {
+    const resolver = {
+      http: {
+        canRead: true,
+        read: jest.fn()
+      }
+    };
+
+    const options = convertOldOptionsToNew({ resolve: resolver }, {});
+    const r = options.__unstable.resolver.resolvers[0];
+
+    expect(r.canRead(uri)).toBe(true);
+  });
+
+  it('supports string canRead', () => {
+    const resolver = {
+      http: {
+        canRead: 'http://example.com/test.yaml',
+        read: jest.fn()
+      }
+    };
+
+    const options = convertOldOptionsToNew({ resolve: resolver }, {});
+    const r = options.__unstable.resolver.resolvers[0];
+
+    expect(r.canRead(uri)).toBe(true);
+  });
+
+  it('supports regex canRead', () => {
+    const resolver = {
+      http: {
+        canRead: /example/,
+        read: jest.fn()
+      }
+    };
+
+    const options = convertOldOptionsToNew({ resolve: resolver }, {});
+    const r = options.__unstable.resolver.resolvers[0];
+
+    expect(r.canRead(uri)).toBe(true);
+  });
+});
 describe('Parser', () => {
   describe('sanitizeTemplateApiVersion', () => {
     it('should return version number when given `v99` syntax', () => {
@@ -26,6 +76,11 @@ describe('Parser', () => {
       const sanitizedVersion = sanitizeTemplateApiVersion(rawVersion);
 
       expect(sanitizedVersion).toStrictEqual(expectedVersion);
+    });
+    it('should return undefined if apiVersion not provided', () => {
+      const result = sanitizeTemplateApiVersion(undefined);
+
+      expect(result).toBeUndefined();
     });
   });
   describe('usesNewAPI', () => {
@@ -65,19 +120,19 @@ describe('Parser', () => {
       const parsedDocument = await parse(dummyV2Document, {}, {templateConfig: {apiVersion: 'v1'}});
 
       expect(parsedDocument).toBeDefined();
-      expect(parsedDocument.document.version()).toEqual('2.3.0');
+      expect(parsedDocument.document.version()).toEqual(ASYNCAPI_V2_VERSION);
     });
     it('should be able to parse AsyncAPI v2 document for parser API v2', async () => {
       const parsedDocument = await parse(dummyV2Document, {}, {templateConfig: {apiVersion: 'v2'}});
 
       expect(parsedDocument).toBeDefined();
-      expect(parsedDocument.document.version()).toEqual('2.3.0');
+      expect(parsedDocument.document.version()).toEqual(ASYNCAPI_V2_VERSION);
     });
     it('should be able to parse AsyncAPI v2 document for parser API v3', async () => {
       const parsedDocument = await parse(dummyV2Document, {}, {templateConfig: {apiVersion: 'v3'}});
 
       expect(parsedDocument).toBeDefined();
-      expect(parsedDocument.document.version()).toEqual('2.3.0');
+      expect(parsedDocument.document.version()).toEqual(ASYNCAPI_V2_VERSION);
     });
     it('should not be able to parse AsyncAPI v3 document for parser API v1', async () => {
       const parsedDocument = await parse(dummyV3Document, {}, {templateConfig: {apiVersion: 'v1'}});
@@ -95,12 +150,12 @@ describe('Parser', () => {
       const parsedDocument = await parse(dummyV3Document, {}, {templateConfig: {apiVersion: 'v2'}});
 
       expect(parsedDocument).toBeDefined();
-      expect(parsedDocument.document.version()).toEqual('3.0.0');
+      expect(parsedDocument.document.version()).toEqual(ASYNCAPI_V3_VERSION);
     });
     it('should be able to parse AsyncAPI v3 document for parser API v3', async () => {
       const parsedDocument = await parse(dummyV3Document, {}, {templateConfig: {apiVersion: 'v3'}});
       expect(parsedDocument).toBeDefined();
-      expect(parsedDocument.document.version()).toEqual('3.0.0');
+      expect(parsedDocument.document.version()).toEqual(ASYNCAPI_V3_VERSION);
     });
   });
   
@@ -121,7 +176,7 @@ describe('Parser', () => {
 
       expect(properDocument).toBeDefined();
       expect(properDocument.document._json).toBeDefined();
-      expect(properDocument.document._json.asyncapi).toEqual('2.3.0');
+      expect(properDocument.document._json.asyncapi).toEqual(ASYNCAPI_V2_VERSION);
       expect(properDocument.diagnostics).toBeDefined();
       expect(properDocument.diagnostics.length).toBeGreaterThan(0);
 
@@ -146,7 +201,7 @@ describe('Parser', () => {
       expect(properDocument).toBeDefined();
 
       // Validate that the document is converted to the specified API version
-      expect(properDocument.document._json.asyncapi).toEqual('2.3.0');
+      expect(properDocument.document._json.asyncapi).toEqual(ASYNCAPI_V2_VERSION);
       expect(properDocument.diagnostics).toBeDefined();
       expect(properDocument.diagnostics.length).toBeGreaterThan(0);
       
@@ -171,7 +226,7 @@ describe('Parser', () => {
   describe('convertOldOptionsToNew', () => {
     it('should convert old options to new options', () => {
       const oldOptions = {
-        path: './test/docs/',
+        path: TEST_DOCS_PATH,
         applyTraits: true,
         resolve: {
           http: {
@@ -184,7 +239,7 @@ describe('Parser', () => {
       const generator = {
         mapBaseUrlToFolder: {
           url: 'https://schema.example.com/crm/',
-          folder: './test/docs/'
+          folder: 'TEST_DOCS_PATH'
         }
       };
       const newOptions = convertOldOptionsToNew(oldOptions, generator);
@@ -200,6 +255,80 @@ describe('Parser', () => {
       const newOptions = convertOldOptionsToNew(undefined, {});
 
       expect(newOptions).toBeUndefined();
+    });
+    it('should handle empty resolve object', () => {
+      const oldOptions = { resolve: {} };
+      const generator = {};
+
+      const newOptions = convertOldOptionsToNew(oldOptions, generator);
+
+      expect(newOptions).toEqual({});
+    });
+    it('should work without generator.mapBaseUrlToFolder', () => {
+      const oldOptions = {
+        path: './docs',
+        applyTraits: false
+      };
+
+      const newOptions = convertOldOptionsToNew(oldOptions, {});
+
+      expect(newOptions.source).toEqual('./docs');
+      expect(newOptions.applyTraits).toBe(false);
+    });
+    it('should return empty array when resolvers empty', () => {
+      const result = convertOldOptionsToNew(
+        { resolve: {} },
+        {}
+      );
+
+      expect(result).toEqual({});
+    });
+    it('should read file using mapBaseUrlToFolder resolver', async () => {
+      const generator = {
+        mapBaseUrlToFolder: {
+          url: 'https://schema.example.com/',
+          folder: 'TEST_DOCS_PATH'
+        }
+      };
+
+      const oldOptions = {};
+
+      const newOptions = convertOldOptionsToNew(oldOptions, generator);
+
+      expect(newOptions.__unstable.resolver.resolvers.length).toBeGreaterThan(0);
+    });
+  });
+  describe('canReadFn branches', () => {
+    const uri = {
+      valueOf: () => 'http://example.com/file.yaml',
+      suffix: () => 'yaml'
+    };
+
+    it('handles array canRead', () => {
+      const resolver = {
+        http: {
+          canRead: ['http://example.com/file.yaml'],
+          read: jest.fn()
+        }
+      };
+
+      const options = convertOldOptionsToNew({ resolve: resolver }, {});
+      const r = options.__unstable.resolver.resolvers[0];
+
+      expect(r.canRead(uri)).toBe(true);
+    });
+    it('handles function canRead', () => {
+      const resolver = {
+        http: {
+          canRead: () => true,
+          read: jest.fn()
+        }
+      };
+
+      const options = convertOldOptionsToNew({ resolve: resolver }, {});
+      const r = options.__unstable.resolver.resolvers[0];
+
+      expect(r.canRead(uri)).toBe(true);
     });
   });
 });

--- a/apps/generator/test/parser.test.js
+++ b/apps/generator/test/parser.test.js
@@ -239,7 +239,7 @@ describe('Parser', () => {
       const generator = {
         mapBaseUrlToFolder: {
           url: 'https://schema.example.com/crm/',
-          folder: 'TEST_DOCS_PATH'
+          folder: TEST_DOCS_PATH
         }
       };
       const newOptions = convertOldOptionsToNew(oldOptions, generator);
@@ -287,7 +287,7 @@ describe('Parser', () => {
       const generator = {
         mapBaseUrlToFolder: {
           url: 'https://schema.example.com/',
-          folder: 'TEST_DOCS_PATH'
+          folder: TEST_DOCS_PATH
         }
       };
 
@@ -295,7 +295,15 @@ describe('Parser', () => {
 
       const newOptions = convertOldOptionsToNew(oldOptions, generator);
 
-      expect(newOptions.__unstable.resolver.resolvers.length).toBeGreaterThan(0);
+      const resolver = newOptions.__unstable.resolver.resolvers[0];
+
+      expect(resolver).toBeDefined();
+      expect(typeof resolver.read).toBe('function');
+
+      const content = await resolver.read('https://schema.example.com/dummy.yml');
+
+      expect(typeof content).toBe('string');
+      expect(content.length).toBeGreaterThan(0);
     });
   });
   describe('canReadFn branches', () => {

--- a/apps/generator/test/utils.test.js
+++ b/apps/generator/test/utils.test.js
@@ -128,38 +128,6 @@ describe('Utils', () => {
     });
   });
   describe('#isFileSystemPath', () => {
-
-  it('detects absolute path', () => {
-    const result = utils.isFileSystemPath(__dirname);
-    expect(result).toBe(true);
-  });
-
-  it('detects relative path', () => {
-    const result = utils.isFileSystemPath(`.${path.sep}test`);
-    expect(result).toBe(true);
-  });
-
-  it('detects parent relative path', () => {
-    const result = utils.isFileSystemPath(`..${path.sep}test`);
-    expect(result).toBe(true);
-  });
-
-  it('detects home path', () => {
-    const result = utils.isFileSystemPath('~/folder');
-    expect(result).toBe(true);
-  });
-
-  it('returns false for package name', () => {
-    const result = utils.isFileSystemPath('express');
-    expect(result).toBe(false);
-  });
-
-});
-
-    afterEach(() => {
-      jest.restoreAllMocks();
-    });
-
     it('detects absolute path', () => {
       const result = utils.isFileSystemPath(__dirname);
       expect(result).toBe(true);
@@ -273,7 +241,7 @@ describe('Utils', () => {
         expect(() => utils.registerTypeScript('file.ts')).not.toThrow();
       } finally {
         if (previousTsNodeDev === undefined) {
-           delete process.env.TS_NODE_DEV;
+          delete process.env.TS_NODE_DEV;
         } else {
           process.env.TS_NODE_DEV = previousTsNodeDev;
         }
@@ -287,4 +255,4 @@ describe('Utils', () => {
       expect(result).toEqual({});
     });
   });
-
+});

--- a/apps/generator/test/utils.test.js
+++ b/apps/generator/test/utils.test.js
@@ -128,16 +128,33 @@ describe('Utils', () => {
     });
   });
   describe('#isFileSystemPath', () => {
-    beforeEach(() => {
-      jest.spyOn(utils, 'isFileSystemPath').mockImplementation((p) => {
-        return (
-          require('path').isAbsolute(p) ||
-          p.startsWith(`.${require('path').sep}`) ||
-          p.startsWith(`..${require('path').sep}`) ||
-          p.startsWith('~')
-        );
-      });
-    });
+
+  it('detects absolute path', () => {
+    const result = utils.isFileSystemPath(__dirname);
+    expect(result).toBe(true);
+  });
+
+  it('detects relative path', () => {
+    const result = utils.isFileSystemPath(`.${path.sep}test`);
+    expect(result).toBe(true);
+  });
+
+  it('detects parent relative path', () => {
+    const result = utils.isFileSystemPath(`..${path.sep}test`);
+    expect(result).toBe(true);
+  });
+
+  it('detects home path', () => {
+    const result = utils.isFileSystemPath('~/folder');
+    expect(result).toBe(true);
+  });
+
+  it('returns false for package name', () => {
+    const result = utils.isFileSystemPath('express');
+    expect(result).toBe(false);
+  });
+
+});
 
     afterEach(() => {
       jest.restoreAllMocks();
@@ -248,11 +265,19 @@ describe('Utils', () => {
     });
 
     it('skips when ts-node already registered', () => {
+      const previousTsNodeDev = process.env.TS_NODE_DEV;
+
       process.env.TS_NODE_DEV = 'true';
 
-      expect(() => utils.registerTypeScript('file.ts')).not.toThrow();
-
-      delete process.env.TS_NODE_DEV;
+      try {
+        expect(() => utils.registerTypeScript('file.ts')).not.toThrow();
+      } finally {
+        if (previousTsNodeDev === undefined) {
+           delete process.env.TS_NODE_DEV;
+        } else {
+          process.env.TS_NODE_DEV = previousTsNodeDev;
+        }
+      }
     });
   });
   describe('#convertCollectionToObject edge', () => {
@@ -262,4 +287,4 @@ describe('Utils', () => {
       expect(result).toEqual({});
     });
   });
-});
+

--- a/apps/generator/test/utils.test.js
+++ b/apps/generator/test/utils.test.js
@@ -1,14 +1,18 @@
 /* eslint-disable sonarjs/no-duplicate-string */
+jest.mock('node-fetch');
 const fs = require('fs');
 const path = require('path');
 const Generator = require('../lib/generator');
 const log = require('loglevel');
-const utils = jest.requireActual('../lib/utils');
+const utils = require('../lib/utils');
 
 const logMessage = require('./../lib/logMessages.js');
 
 describe('Utils', () => {
   describe('#getTemplateDetails', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
     let resolvePkg, resolveFrom;
     const templateNpmName = 'nameOfTestTemplate';
 
@@ -21,7 +25,7 @@ describe('Utils', () => {
 
     it('works with a file system path', () => {
       log.debug = jest.fn();
-      utils.isFileSystemPath = jest.fn(() => true);
+      jest.spyOn(utils, 'isFileSystemPath').mockReturnValue(true);
       const templatePath = './testTemplate';
       const result = utils.getTemplateDetails(templatePath, 'package.json');
       expect(log.debug).toHaveBeenCalledWith(logMessage.NODE_MODULES_INSTALL);
@@ -33,7 +37,7 @@ describe('Utils', () => {
 
     it('works with an npm package', () => {
       log.debug = jest.fn();
-      utils.isFileSystemPath = jest.fn(() => false);
+      jest.spyOn(utils, 'isFileSystemPath').mockReturnValue(false);
       const packagePath = path.join(Generator.DEFAULT_TEMPLATES_DIR, templateNpmName);
       resolvePkg.__resolvePkgValue = packagePath;
       const result = utils.getTemplateDetails(templateNpmName, 'package.json');
@@ -47,7 +51,7 @@ describe('Utils', () => {
 
     it('works with global npm package', () => {
       log.debug = jest.fn();
-      utils.isFileSystemPath = jest.fn(() => false);
+      jest.spyOn(utils, 'isFileSystemPath').mockReturnValue(false);
       resolvePkg.__resolvePkgValue = undefined;
       resolveFrom.__resolveFromValue = path.join(Generator.DEFAULT_TEMPLATES_DIR, templateNpmName, 'package.json');
       utils.getTemplateDetails(templateNpmName, 'package.json');
@@ -121,6 +125,141 @@ describe('Utils', () => {
     it('should return false if it is not a JS file', () => {
       const isJsFile = utils.isJsFile('./invalid-file');
       expect(isJsFile).toBeFalsy();
+    });
+  });
+  describe('#isFileSystemPath', () => {
+    beforeEach(() => {
+      jest.spyOn(utils, 'isFileSystemPath').mockImplementation((p) => {
+        return (
+          require('path').isAbsolute(p) ||
+          p.startsWith(`.${require('path').sep}`) ||
+          p.startsWith(`..${require('path').sep}`) ||
+          p.startsWith('~')
+        );
+      });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('detects absolute path', () => {
+      const result = utils.isFileSystemPath(__dirname);
+      expect(result).toBe(true);
+    });
+
+    it('detects relative path', () => {
+      const result = utils.isFileSystemPath(`.${path.sep}test`);
+      expect(result).toBe(true);
+    });
+
+    it('detects parent relative path', () => {
+      const result = utils.isFileSystemPath(`..${path.sep}test`);
+      expect(result).toBe(true);
+    });
+
+    it('detects home path', () => {
+      const result = utils.isFileSystemPath('~/folder');
+      expect(result).toBe(true);
+    });
+
+    it('returns false for package name', () => {
+      const result = utils.isFileSystemPath('express');
+      expect(result).toBe(false);
+    });
+  });
+  describe('#convertMapToObject', () => {
+    it('converts map to object', () => {
+      const map = new Map();
+      map.set('a', 1);
+      map.set('b', 2);
+      const result = utils.convertMapToObject(map);
+
+      expect(result).toEqual({ a: 1, b: 2 });
+    });
+  });
+  describe('#isFilePath', () => {
+    it('returns true for file path', () => {
+      expect(utils.isFilePath('./test.yaml')).toBe(true);
+    });
+
+    it('returns false for url', () => {
+      expect(utils.isFilePath('https://example.com')).toBe(false);
+    });
+  });
+  describe('#getGeneratorVersion', () => {
+    it('returns generator version', () => {
+      const version = utils.getGeneratorVersion();
+      expect(version).toBeDefined();
+    });
+  });
+  describe('#isAsyncFunction', () => {
+    it('detects async function', () => {
+      async function test() {}
+
+      expect(utils.isAsyncFunction(test)).toBe(true);
+    });
+
+    it('detects non async function', () => {
+      function test() {}
+
+      expect(utils.isAsyncFunction(test)).toBe(false);
+    });
+  });
+  describe('#convertCollectionToObject', () => {
+    it('converts collection to object', () => {
+      const collection = [
+        { id: () => 'a' },
+        { id: () => 'b' }
+      ];
+
+      const result = utils.convertCollectionToObject(collection, 'id');
+
+      expect(result.a).toBeDefined();
+      expect(result.b).toBeDefined();
+    });
+  });
+  describe('#fetchSpec', () => {
+    it('fetches spec content', async () => {
+      const fetch = require('node-fetch');
+
+      fetch.mockResolvedValue({
+        text: () => Promise.resolve('spec content')
+      });
+
+      const result = await utils.fetchSpec('http://test.com');
+
+      expect(result).toEqual('spec content');
+    });
+  });
+  describe('#fetchSpec error', () => {
+    it('rejects when fetch fails', async () => {
+      const fetch = require('node-fetch');
+
+      fetch.mockRejectedValue(new Error('network error'));
+
+      await expect(utils.fetchSpec('http://test.com'))
+        .rejects.toThrow('network error');
+    });
+  });
+  describe('#registerTypeScript', () => {
+    it('skips when file is not ts', () => {
+      expect(() => utils.registerTypeScript('file.js')).not.toThrow();
+    });
+
+    it('skips when ts-node already registered', () => {
+      process.env.TS_NODE_DEV = 'true';
+
+      expect(() => utils.registerTypeScript('file.ts')).not.toThrow();
+
+      delete process.env.TS_NODE_DEV;
+    });
+  });
+  describe('#convertCollectionToObject edge', () => {
+    it('handles empty collection', () => {
+      const result = utils.convertCollectionToObject([], 'id');
+
+      expect(result).toEqual({});
     });
   });
 });


### PR DESCRIPTION
## Summary
This PR improves unit test coverage for the `parser` and `utils` modules.

## Changes
- Added tests for resolver `canRead` variations (boolean, string, regex, array, function)
- Added tests covering parser API version handling
- Added tests validating old vs new API document behavior
- Added additional utility tests including error branches

## Coverage Improvement
parser.js
- Statements: ~85%
- Branch: ~88%

utils.js
- Statements: ~96%
- Branch: ~90%

The tests focus on meaningful edge cases and error paths rather than artificially targeting 100% coverage.

## Summary
This PR improves unit test coverage for the `parser` and `utils` modules.

## Changes
- Added tests for resolver `canRead` variations (boolean, string, regex, array, function)
- Added tests covering parser API version handling
- Added tests validating old vs new API document behavior
- Added additional utility tests including error branches

## Coverage Improvement
parser.js
- Statements: ~85%
- Branch: ~88%

utils.js
- Statements: ~96%
- Branch: ~70%

The tests focus on meaningful edge cases and error paths rather than artificially targeting 100% coverage.

<img width="1023" height="463" alt="Screenshot 2026-03-05 142051" src="https://github.com/user-attachments/assets/8bfb5011-d5e7-41f7-a51a-1260c79add16" />
Resolves #1981

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded parser tests: added version constants, new "resolver canRead variations" suite (boolean/string/regex), sanitizeTemplateApiVersion undefined case, and broader convertOldOptionsToNew coverage (path substitutions, empty resolves, resolver behaviors, canRead function branches).
  * Overhauled utility tests: switched to spy-based mocks, added node-fetch mocking with success/failure cases, added extensive cases for path detection, collection/map conversion, fetchSpec, generator version, async detection, and TypeScript registration; added afterEach mock cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->