### PR TITLE
fix: prefer String#replaceAll() over String#replace() (fixes #1914)

### DIFF
--- a/apps/react-sdk/src/transpiler/transpiler.ts
+++ b/apps/react-sdk/src/transpiler/transpiler.ts
@@ -52,7 +52,7 @@ export async function transpileFiles(directory: string, outputDir: string, optio
             dir: outputDir,
             exports: "auto",
             paths: {
-              'react/jsx-runtime': require.resolve('react/cjs/react-jsx-runtime.production.min').replace(/\\/g, '/'),
+              'react/jsx-runtime': require.resolve('react/cjs/react-jsx-runtime.production.min').replaceAll(/\\/g, '/'),
             },
             sanitizeFileName: false,
         })

--- a/packages/helpers/src/utils.js
+++ b/packages/helpers/src/utils.js
@@ -55,7 +55,7 @@ const getClientName = (asyncapi, appendClientSuffix, customClientName) => {
     return customClientName;
   }
   const title = getTitle(asyncapi);
-  const baseName = `${title.replace(/\s+/g, '') // Remove all spaces
+  const baseName = `${title.replaceAll(/\s+/g, '') // Remove all spaces
     .replace(/^./, char => char.toUpperCase())}`; // Make the first letter uppercase
   return appendClientSuffix ? `${baseName}Client` : baseName;
 };
@@ -69,7 +69,7 @@ const getClientName = (asyncapi, appendClientSuffix, customClientName) => {
  */
 const toSnakeCase = (inputStr) => {
   return inputStr
-    .replace(/\W+/g, ' ')
+    .replaceAll(/\W+/g, ' ')
     .split(/ |\B(?=[A-Z])/)
     .map((word) => word.toLowerCase())
     .join('_');


### PR DESCRIPTION
## Description

Closes #1914

Addresses **SonarQube rule S4145**: Use `String#replaceAll()` instead of `String#replace()` when the regex has the global (`/g`) flag, as the intent is to replace all occurrences.

### Changes

| File | Line | Change |
|------|------|--------|
| `packages/helpers/src/utils.js` | 58 | `replace` -> `replaceAll` for whitespace removal |
| `packages/helpers/src/utils.js` | 72 | `replace` -> `replaceAll` for non-word char replacement |
| `apps/react-sdk/src/transpiler/transpiler.ts` | 55 | `replace` -> `replaceAll` for path backslash normalization |

### SonarQube Impact

Resolves all 3 S4145 issues for this rule in the codebase.

### Testing

- Changes are semantically equivalent (same behavior with `/g` regex)
- No test updates needed (pure refactoring)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal string normalization logic to use more efficient string replacement methods across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->