### PR TITLE
fix: remove async from Promise executor in hooksRegistry (SonarQube S4146)

### DIFF
--- a/apps/generator/lib/hooksRegistry.js
+++ b/apps/generator/lib/hooksRegistry.js
@@ -25,19 +25,19 @@ async function registerHooks (hooks, templateConfig, templateDir, hooksDir) {
  * @param {String} hooksDir Directory where local hooks are located.
  */
 async function registerLocalHooks(hooks, templateDir, hooksDir) {
-  return new Promise(async (resolve, reject) => {
-    const localHooks = path.resolve(templateDir, hooksDir);
+  const localHooks = path.resolve(templateDir, hooksDir);
 
-    if (!await exists(localHooks)) return resolve(hooks);
+  if (!await exists(localHooks)) return hooks;
 
+  return new Promise((resolve, reject) => {
     const walker = xfs.walk(localHooks, {
       followLinks: false
     });
-    
-    walker.on('file', async (root, stats, next) => {
+
+    walker.on('file', (root, stats, next) => {
       try {
         const filePath = path.resolve(templateDir, path.resolve(root, stats.name));
-        
+
         registerTypeScript(filePath);
 
         delete require.cache[require.resolve(filePath)];
@@ -55,7 +55,7 @@ async function registerLocalHooks(hooks, templateDir, hooksDir) {
       reject(nodeStatsArray);
     });
 
-    walker.on('end', async () => {
+    walker.on('end', () => {
       resolve(hooks);
     });
   });


### PR DESCRIPTION
## Description

Fixes **SonarQube Bug S4146**: "Promise executor functions should not be async."

### Problem

`registerLocalHooks()` in `hooksRegistry.js` used `new Promise(async (resolve, reject) => {...})`. This is an anti-pattern because:

1. If the async executor throws synchronously before any `await`, the error becomes a rejected promise instead of being thrown
2. Errors in async code within the executor can be silently swallowed
3. It adds unnecessary complexity

### Fix

Removed `async` keyword from:
- The Promise executor function itself
- The walker `"file"` event handler (no await needed)
- The walker `"end"` event handler (no await needed)

### Behavior

**Identical** before and after. No functional change.

### SonarQube Impact

Resolves: https://sonarcloud.io/project/issues?id=asyncapi_generator&resolved=false&types=BUG&rules=javascript%3AS4146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Internal optimization of hook registration logic with improved code efficiency. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->