### PR TITLE
fix: use new Array() instead of bare Array() (fixes #1915)

### DIFF
--- a/apps/react-sdk/src/utils/withIndendation.ts
+++ b/apps/react-sdk/src/utils/withIndendation.ts
@@ -43,5 +43,5 @@ export function withIndendation(content: string = '', size: number, type: Indent
  */
 function getIndentation(size: number = 0, type: IndentationTypes = IndentationTypes.SPACES): string {
   const whitespaceChar = type === IndentationTypes.SPACES ? ' ' : '\t';
-  return Array(size).fill(whitespaceChar).join("");
+  return new Array(size).fill(whitespaceChar).join("");
 }

--- a/apps/react-sdk/src/utils/withNewLines.ts
+++ b/apps/react-sdk/src/utils/withNewLines.ts
@@ -6,6 +6,6 @@
  * @returns {string}
  */
 export function withNewLines(content: string = '', number: number = 0): string {
-  const newLines = Array(number).fill('\n').join('');
+  const newLines = new Array(number).fill('\n').join('');
   return content + newLines;
 }


### PR DESCRIPTION
## Description

Fixes #1915

SonarCloud rule S3776: Use `new Array()` constructor for clarity and consistency.

### Changes
- **apps/react-sdk/src/utils/withNewLines.ts**: `Array(number)` → `new Array(number)`
- **apps/react-sdk/src/utils/withIndendation.ts**: `Array(size)` → `new Array(size)`

### Testing
- [x] No behavioral change — same output, clearer syntax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code quality improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->