### PR TITLE
fix: handle HTTP error status codes in fetchSpec

### DIFF
--- a/apps/generator/lib/utils.js
+++ b/apps/generator/lib/utils.js
@@ -64,6 +64,7 @@ utils.convertMapToObject = (map) => {
  *
  * @param {String} link URL where the AsyncAPI document is located.
  * @returns {Promise<String>} Content of fetched file.
+ * @throws {Error} When fetch fails or the HTTP response is not 2xx, including the status and statusText.
  */
 utils.fetchSpec = async (link) => {
   const res = await fetch(link);

--- a/apps/generator/lib/utils.js
+++ b/apps/generator/lib/utils.js
@@ -65,12 +65,12 @@ utils.convertMapToObject = (map) => {
  * @param {String} link URL where the AsyncAPI document is located.
  * @returns {Promise<String>} Content of fetched file.
  */
-utils.fetchSpec = (link) => {
-  return new Promise((resolve, reject) => {
-    fetch(link)
-      .then(res => resolve(res.text()))
-      .catch(reject);
-  });
+utils.fetchSpec = async (link) => {
+  const res = await fetch(link);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch AsyncAPI document from ${link}: HTTP ${res.status} ${res.statusText}`);
+  }
+  return res.text();
 };
 
 /**

--- a/apps/generator/test/utils.test.js
+++ b/apps/generator/test/utils.test.js
@@ -123,4 +123,68 @@ describe('Utils', () => {
       expect(isJsFile).toBeFalsy();
     });
   });
+
+  describe('#fetchSpec', () => {
+    let mockFetch;
+
+    beforeEach(() => {
+      mockFetch = jest.fn();
+      jest.mock('node-fetch', () => mockFetch);
+    });
+
+    afterEach(() => {
+      jest.resetModules();
+      jest.restoreAllMocks();
+    });
+
+    it('should return the body text for a successful 200 response', async () => {
+      jest.resetModules();
+      jest.mock('node-fetch', () => jest.fn().mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve('spec content'),
+      }));
+      const freshUtils = require('../lib/utils');
+
+      const result = await freshUtils.fetchSpec('http://example.com/asyncapi.yaml');
+      expect(result).toBe('spec content');
+    });
+
+    it('should throw an error with URL and status for a 404 response', async () => {
+      jest.resetModules();
+      jest.mock('node-fetch', () => jest.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      }));
+      const freshUtils = require('../lib/utils');
+
+      await expect(freshUtils.fetchSpec('http://example.com/missing.yaml'))
+        .rejects
+        .toThrow('Failed to fetch AsyncAPI document from http://example.com/missing.yaml: HTTP 404 Not Found');
+    });
+
+    it('should throw an error with URL and status for a 500 response', async () => {
+      jest.resetModules();
+      jest.mock('node-fetch', () => jest.fn().mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      }));
+      const freshUtils = require('../lib/utils');
+
+      await expect(freshUtils.fetchSpec('http://example.com/asyncapi.yaml'))
+        .rejects
+        .toThrow('Failed to fetch AsyncAPI document from http://example.com/asyncapi.yaml: HTTP 500 Internal Server Error');
+    });
+
+    it('should propagate network errors when fetch itself rejects', async () => {
+      jest.resetModules();
+      jest.mock('node-fetch', () => jest.fn().mockRejectedValueOnce(new Error('Network failure')));
+      const freshUtils = require('../lib/utils');
+
+      await expect(freshUtils.fetchSpec('http://example.com/asyncapi.yaml'))
+        .rejects
+        .toThrow('Network failure');
+    });
+  });
 });


### PR DESCRIPTION
**Description**

- `fetchSpec` in `apps/generator/lib/utils.js` previously resolved successfully even when the server returned a 4xx or 5xx HTTP status code. The error body was silently passed to the AsyncAPI parser, which then produced a confusing diagnostic like _"Unexpected token < in JSON at position 0"_ instead of a clear HTTP error message.
- Replaced the Promise constructor antipattern with an `async` function that checks `res.ok` immediately after the fetch. Non-2xx responses now throw a descriptive `Error` that includes the URL, HTTP status code, and status text (e.g. _"Failed to fetch AsyncAPI document from https://example.com/nonexistent.yaml: HTTP 404 Not Found"_).
- Added four unit tests covering: successful response, 404, 500, and network-level rejection.

**Related issue(s)**

Fixes #1807

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fetch behavior: successful responses return the response body; non-2xx responses now fail with a descriptive error including the request URL and HTTP status/statusText; network errors are propagated.

* **Tests**
  * Added tests validating successful fetches, non-2xx response errors, and network failure propagation, with isolated mock setup/teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->