### PR TITLE
fix: replace Object.prototype.hasOwnProperty.call with Object.hasOwn

### DIFF
--- a/apps/generator/lib/templates/config/loader.js
+++ b/apps/generator/lib/templates/config/loader.js
@@ -48,7 +48,7 @@ function loadDefaultValues(templateConfig, templateParams) {
     const parameters = templateConfig.parameters;
     const defaultValues = Object.keys(parameters || {}).filter(key =>  Object.hasOwn(parameters[key], "default"));
 
-    defaultValues.filter(dv => !Object.prototype.hasOwnProperty.call(templateParams, dv)).forEach(dv =>
+    defaultValues.filter(dv => !Object.hasOwn(templateParams, dv)).forEach(dv =>
         Object.defineProperty(templateParams, dv, {
             enumerable: true,
             get() {


### PR DESCRIPTION
**Description**

- Replaced `Object.prototype.hasOwnProperty.call(templateParams, dv)` with `Object.hasOwn(templateParams, dv)` in `apps/generator/lib/templates/config/loader.js` (line 51).
- `Object.hasOwn()` is the modern ES2022 equivalent and is already used on line 49 of the same file. This removes the last remaining `Object.prototype.hasOwnProperty.call` usage in the file and resolves the SonarCloud S5742 code smell.

**Related issue(s)**

Fixes #1912

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration loader to use modern property detection methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->