### PR TITLE
fix: use String.raw to avoid escaping backslashes in ANSI escape codes

### DIFF
--- a/packages/components/src/components/HandleMessage.js
+++ b/packages/components/src/components/HandleMessage.js
@@ -11,11 +11,11 @@ import { MethodGenerator } from './MethodGenerator';
  */
 const websocketHandleMessageConfig = {
   python: {
-    methodLogic: `if len(self.message_handlers) == 0:
-  print("\\033[94mReceived raw message:\\033[0m", message)
+    methodLogic: String.raw`if len(self.message_handlers) == 0:
+  print("\033[94mReceived raw message:\033[0m", message)
 else:
     for handler in self.message_handlers:
-      handler(message)`
+      handler(message)`,
   },
   javascript: {
     methodDocs: '// Method to handle message with callback',

--- a/packages/templates/clients/websocket/python/components/HandleError.js
+++ b/packages/templates/clients/websocket/python/components/HandleError.js
@@ -4,10 +4,10 @@ export function HandleError() {
   return (
     <Text newLines={2} indent={2}>
       {
-        `def handle_error(self, error):
+        String.raw`def handle_error(self, error):
     """Pass the error to all registered error handlers. Generic log message is printed if no handlers are registered."""
     if len(self.error_handlers) == 0:
-      print("\\033[91mError occurred:\\033[0m", error)
+      print("\033[91mError occurred:\033[0m", error)
     else:
       # Call custom error handlers
       for handler in self.error_handlers:


### PR DESCRIPTION
**Description**

- Replaced double-escaped backslash sequences (`\\033`) with `String.raw` tagged template literals (`\033`) in two components:
  - `packages/components/src/components/HandleMessage.js` (Python `methodLogic` string)
  - `packages/templates/clients/websocket/python/components/HandleError.js`
- `String.raw` treats backslash characters literally, eliminating the need for double-escaping and making ANSI terminal escape sequences in the generated Python code easier to read and maintain.
- The runtime output is identical — both forms produce the string value `\033[...m` — so no snapshot updates are required.

**Related issue(s)**

Fixes #1913

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ANSI escape sequence handling in generated Python WebSocket client code to ensure terminal colors display correctly in output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->