### PR TITLE
fix: log warning when local hook file fails to load

### DIFF
--- a/apps/generator/lib/hooksRegistry.js
+++ b/apps/generator/lib/hooksRegistry.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const xfs = require('fs.extra');
+const log = require('loglevel');
 const { exists, registerTypeScript } = require('./utils');
 
 /**
@@ -47,6 +48,8 @@ async function registerLocalHooks(hooks, templateDir, hooksDir) {
 
         next();
       } catch (e) {
+        const filePath = path.resolve(root, stats.name);
+        log.warn(`Failed to load hook file ${filePath}: ${e.message}`);
         reject(e);
       }
     });

--- a/apps/generator/lib/hooksRegistry.js
+++ b/apps/generator/lib/hooksRegistry.js
@@ -24,6 +24,8 @@ async function registerHooks (hooks, templateConfig, templateDir, hooksDir) {
  * @param {Object} hooks Object that stores information about all available hook functions grouped by the type of the hook.
  * @param {String} templateDir Directory where template is located.
  * @param {String} hooksDir Directory where local hooks are located.
+ * @returns {Promise<Object>} Resolves to the hooks object after local hooks are loaded.
+ * @throws {Error} Rejects when a hook file cannot be loaded or transformed.
  */
 async function registerLocalHooks(hooks, templateDir, hooksDir) {
   return new Promise(async (resolve, reject) => {
@@ -49,7 +51,9 @@ async function registerLocalHooks(hooks, templateDir, hooksDir) {
         next();
       } catch (e) {
         const filePath = path.resolve(root, stats.name);
-        log.warn(`Failed to load hook file ${filePath}: ${e.message}`);
+        const errorMessage = e && e.message ? e.message : String(e);
+        const errorDetails = e && e.stack ? e.stack : errorMessage;
+        log.warn(`Failed to load hook file ${filePath}: ${errorDetails}`);
         reject(e);
       }
     });

--- a/apps/generator/test/__mocks__/fs.extra.js
+++ b/apps/generator/test/__mocks__/fs.extra.js
@@ -1,3 +1,3 @@
-const xfs = jest.genMockFromModule('fs.extra');
+const xfs = jest.createMockFromModule('fs.extra');
 
 module.exports = xfs;

--- a/apps/generator/test/__mocks__/loglevel.js
+++ b/apps/generator/test/__mocks__/loglevel.js
@@ -1,3 +1,3 @@
-const log = jest.genMockFromModule('loglevel');
+const log = jest.createMockFromModule('loglevel');
 
 module.exports = log;

--- a/apps/generator/test/hooksRegistry.test.js
+++ b/apps/generator/test/hooksRegistry.test.js
@@ -3,10 +3,12 @@
  */
 const fs = require('fs');
 const path = require('path');
+const log = require('loglevel');
 const { addHook, registerLocalHooks, registerConfigHooks, registerHooks } = require('../lib/hooksRegistry');
 
 jest.mock('fs');
 jest.mock('path');
+jest.mock('loglevel');
 
 describe('hooksRegistry', () => {
   let hooks;
@@ -71,15 +73,45 @@ describe('hooksRegistry', () => {
     it('handles errors during hook loading', async () => {
       fs.existsSync.mockReturnValue(true);
       fs.readdirSync.mockReturnValue(['errorHook.js']);
-      
+
       jest.mock('fixtures/template/hooks/errorHook.js', () => {
         throw new Error('Mock import error');
       }, { virtual: true });
-      
+
       await expect(registerLocalHooks(hooks, 'fixtures/template', 'hooks'))
         .resolves.not.toThrow();
-        
+
       expect(hooks).toEqual({});
+    });
+
+    it('logs a warning when a hook file fails to load', async () => {
+      const EventEmitter = require('events');
+      const fakeWalker = new EventEmitter();
+      let localRegisterLocalHooks;
+      let localLog;
+
+      jest.isolateModules(() => {
+        const xfs = require('fs.extra');
+        xfs.walk = jest.fn().mockReturnValue(fakeWalker);
+
+        fs.promises = { stat: jest.fn().mockResolvedValue({}) };
+
+        localLog = require('loglevel');
+        localLog.warn = jest.fn();
+
+        localRegisterLocalHooks = require('../lib/hooksRegistry').registerLocalHooks;
+      });
+
+      const promise = localRegisterLocalHooks(hooks, '/some/template', 'hooks');
+
+      // Emit a file event - require(undefined) throws due to mocked path.resolve
+      fakeWalker.emit('file', '/some/template/hooks', { name: 'badHook.js' }, () => {});
+      fakeWalker.emit('end');
+
+      await expect(promise).rejects.toThrow();
+      expect(localLog.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to load hook file')
+      );
     });
   });
 

--- a/apps/generator/test/hooksRegistry.test.js
+++ b/apps/generator/test/hooksRegistry.test.js
@@ -3,7 +3,6 @@
  */
 const fs = require('fs');
 const path = require('path');
-const log = require('loglevel');
 const { addHook, registerLocalHooks, registerConfigHooks, registerHooks } = require('../lib/hooksRegistry');
 
 jest.mock('fs');
@@ -86,32 +85,50 @@ describe('hooksRegistry', () => {
 
     it('logs a warning when a hook file fails to load', async () => {
       const EventEmitter = require('events');
+      const realFs = jest.requireActual('fs');
+      const realPath = jest.requireActual('path');
+      const mockImportError = 'Mock import error';
       const fakeWalker = new EventEmitter();
       let localRegisterLocalHooks;
       let localLog;
+      const tempRoot = realFs.mkdtempSync(realPath.join('/tmp', 'hooks-registry-'));
+      const templateDir = realPath.join(tempRoot, 'template');
+      const hooksDir = realPath.join(templateDir, 'hooks');
+      const badHookPath = realPath.join(hooksDir, 'badHook.js');
 
-      jest.isolateModules(() => {
-        const xfs = require('fs.extra');
-        xfs.walk = jest.fn().mockReturnValue(fakeWalker);
+      realFs.mkdirSync(hooksDir, { recursive: true });
+      realFs.writeFileSync(badHookPath, `throw new Error(${JSON.stringify(mockImportError)});\n`);
 
-        fs.promises = { stat: jest.fn().mockResolvedValue({}) };
+      try {
+        jest.isolateModules(() => {
+          const localPath = require('path');
+          const localFs = require('fs');
+          const xfs = require('fs.extra');
+          localLog = require('loglevel');
 
-        localLog = require('loglevel');
-        localLog.warn = jest.fn();
+          localPath.resolve.mockImplementation((...parts) => realPath.resolve(...parts.filter(Boolean)));
+          localFs.promises = { stat: jest.fn().mockResolvedValue({}) };
+          xfs.walk = jest.fn().mockReturnValue(fakeWalker);
+          localLog.warn = jest.fn();
 
-        localRegisterLocalHooks = require('../lib/hooksRegistry').registerLocalHooks;
-      });
+          localRegisterLocalHooks = require('../lib/hooksRegistry').registerLocalHooks;
+        });
 
-      const promise = localRegisterLocalHooks(hooks, '/some/template', 'hooks');
+        const promise = localRegisterLocalHooks(hooks, templateDir, 'hooks');
+        await new Promise(resolve => setImmediate(resolve));
 
-      // Emit a file event - require(undefined) throws due to mocked path.resolve
-      fakeWalker.emit('file', '/some/template/hooks', { name: 'badHook.js' }, () => {});
-      fakeWalker.emit('end');
+        fakeWalker.emit('file', hooksDir, { name: 'badHook.js' }, () => {});
+        fakeWalker.emit('end');
 
-      await expect(promise).rejects.toThrow();
-      expect(localLog.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to load hook file')
-      );
+        await expect(promise).rejects.toThrow(mockImportError);
+        expect(localLog.warn).toHaveBeenCalledWith(
+          expect.stringContaining(`Failed to load hook file ${badHookPath}`)
+        );
+        expect(localLog.warn.mock.calls[0][0]).toContain(mockImportError);
+      } finally {
+        jest.restoreAllMocks();
+        realFs.rmSync(tempRoot, { recursive: true, force: true });
+      }
     });
   });
 


### PR DESCRIPTION
**Description**

- When a hook file throws during `require()` (e.g. syntax error, bad import), the error was previously propagated via `reject(e)` with no logging. Template authors had no way to know which hook file caused the failure.
- Added `log.warn(\`Failed to load hook file ${filePath}: ${e.message}\`)` before `reject(e)` in the `walker.on('file', ...)` catch block of `registerLocalHooks` in `apps/generator/lib/hooksRegistry.js`. The generator still fails fast on hook load errors, but the failure is now immediately visible as a warning log.
- Updated `apps/generator/test/hooksRegistry.test.js` to add a test that verifies `log.warn` is called with a message containing `'Failed to load hook file'` when a hook file throws.
- Also updated `apps/generator/test/__mocks__/fs.extra.js` and `apps/generator/test/__mocks__/loglevel.js` to replace the removed `jest.genMockFromModule` with `jest.createMockFromModule`.

**Related issue(s)**

Fixes #1880

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced error logging when hook files fail to load, providing clearer diagnostic messages and ensuring the original error is propagated.

* **Tests**
  * Added coverage for hook file loading failures and assertions on warning log output.
  * Updated test mocks to use the current Jest mock API.

* **Documentation**
  * Clarified JSDoc for hook registration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->