### PR TITLE
fix: use `new Array()` instead of `Array()`

### DIFF
--- a/apps/react-sdk/src/utils/withIndendation.ts
+++ b/apps/react-sdk/src/utils/withIndendation.ts
@@ -43,5 +43,5 @@ export function withIndendation(content: string = '', size: number, type: Indent
  */
 function getIndentation(size: number = 0, type: IndentationTypes = IndentationTypes.SPACES): string {
   const whitespaceChar = type === IndentationTypes.SPACES ? ' ' : '\t';
-  return Array(size).fill(whitespaceChar).join("");
+  return new Array(size).fill(whitespaceChar).join("");
 }

--- a/apps/react-sdk/src/utils/withNewLines.ts
+++ b/apps/react-sdk/src/utils/withNewLines.ts
@@ -6,6 +6,6 @@
  * @returns {string}
  */
 export function withNewLines(content: string = '', number: number = 0): string {
-  const newLines = Array(number).fill('\n').join('');
+  const newLines = new Array(number).fill('\n').join('');
   return content + newLines;
 }


### PR DESCRIPTION
Fixes #1915

Changed 2 occurrences in react-sdk utils:
- `withNewLines.ts`: `Array(number)` → `new Array(number)`
- `withIndendation.ts`: `Array(size)` → `new Array(size)`

SonarQube S3776 compliance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal utility functions to use explicit array construction methods for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->