### PR TITLE
fix: remove duplicate generate:after hook call in handleEntrypoint

### DIFF
--- a/apps/generator/lib/generator.js
+++ b/apps/generator/lib/generator.js
@@ -332,7 +332,6 @@ class Generator {
    * - Resolves the absolute path of the entrypoint file.
    * - Throws an error if the entrypoint file doesn't exist.
    * - Generates a file or renders content based on the output type.
-   * - Launches the 'generate:after' hook if the output is 'fs'.
    *
    * If no entrypoint is specified, generates the directory structure.
    *
@@ -347,7 +346,6 @@ class Generator {
       }
       if (this.output === 'fs') {
         await this.generateFile(this.asyncapi, path.basename(entrypointPath), path.dirname(entrypointPath));
-        await this.launchHook('generate:after');
       } else if (this.output === 'string') {
         return await this.renderFile(this.asyncapi, entrypointPath);
       }


### PR DESCRIPTION
Fixes #1993

When using entrypoint templates with `output = 'fs'`, the `generate:after` hook was executed twice:
1. Inside `handleEntrypoint()` (line ~350)
2. Again inside `executeAfterHook()` (called from `generate()`)

This change removes the redundant `launchHook('generate:after')` call from `handleEntrypoint()`, centralizing hook execution in `executeAfterHook()`. The after hook now runs exactly once per generation lifecycle, regardless of whether an entrypoint is used.

**How to verify:**
- Create a template with a `generate:after` hook that logs to console
- Run generation with an entrypoint and default fs output
- Confirm the hook executes exactly once instead of twice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal hook execution flow to improve code structure and maintainability. Hook execution now occurs at a centralized point in the generation process rather than across multiple code paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->