### PR TITLE
feat: add generateOnly option to filter which template files are generated

### DIFF
--- a/apps/generator/lib/generator.js
+++ b/apps/generator/lib/generator.js
@@ -42,7 +42,7 @@ const DEFAULT_TEMPLATES_DIR = path.resolve(ROOT_DIR, 'node_modules');
 
 const TRANSPILED_TEMPLATE_LOCATION = '__transpiled';
 const TEMPLATE_CONTENT_DIRNAME = 'template';
-const GENERATOR_OPTIONS = ['debug', 'disabledHooks', 'entrypoint', 'forceWrite', 'install', 'noOverwriteGlobs', 'output', 'templateParams', 'mapBaseUrlToFolder', 'url', 'auth', 'token', 'registry', 'compile'];
+const GENERATOR_OPTIONS = ['debug', 'disabledHooks', 'entrypoint', 'forceWrite', 'generateOnly', 'install', 'noOverwriteGlobs', 'output', 'templateParams', 'mapBaseUrlToFolder', 'url', 'auth', 'token', 'registry', 'compile'];
 const logMessage = require('./logMessages');
 
 const shouldIgnoreFile = filePath =>
@@ -74,6 +74,7 @@ class Generator {
    * @param {Object<string, string>} [options.templateParams]   Optional parameters to pass to the template. Each template define their own params.
    * @param {String} [options.entrypoint]       Name of the file to use as the entry point for the rendering process. Use in case you want to use only a specific template file. Note: this potentially avoids rendering every file in the template.
    * @param {String[]} [options.noOverwriteGlobs] List of globs to skip when regenerating the template.
+   * @param {String[]} [options.generateOnly] List of globs to specify which files to generate. When set, only files matching these patterns will be generated.
    * @param {Object<String, Boolean | String | String[]>} [options.disabledHooks] Object with hooks to disable. The key is a hook type. If key has "true" value, then the generator skips all hooks from the given type. If the value associated with a key is a string with the name of a single hook, then the generator skips only this single hook name. If the value associated with a key is an array of strings, then the generator skips only hooks from the array.
    * @param {String} [options.output='fs'] Type of output. Can be either 'fs' (default) or 'string'. Only available when entrypoint is set.
    * @param {Boolean} [options.forceWrite=false] Force writing of the generated files to given directory even if it is a git repo with unstaged files or not empty dir. Default is set to false.
@@ -87,7 +88,7 @@ class Generator {
    * @param {String} [options.registry.token]     Optional parameter to pass npm registry auth token that you can grab from .npmrc file
    */
 
-  constructor(templateName, targetDir, { templateParams = {}, entrypoint, noOverwriteGlobs, disabledHooks, output = 'fs', forceWrite = false, install = false, debug = false, mapBaseUrlToFolder = {}, registry = {}, compile = true } = {}) {
+  constructor(templateName, targetDir, { templateParams = {}, entrypoint, noOverwriteGlobs, generateOnly, disabledHooks, output = 'fs', forceWrite = false, install = false, debug = false, mapBaseUrlToFolder = {}, registry = {}, compile = true } = {}) {
     const options = arguments[arguments.length - 1];
     this.verifyoptions(options);
     if (!templateName) throw new Error('No template name has been specified.');
@@ -105,6 +106,8 @@ class Generator {
     this.entrypoint = entrypoint;
     /** @type {String[]} List of globs to skip when regenerating the template. */
     this.noOverwriteGlobs = noOverwriteGlobs || [];
+    /** @type {String[]} List of globs to specify which files to generate. When set, only matching files are generated. */
+    this.generateOnly = generateOnly || [];
     /** @type {Object<String, Boolean | String | String[]>} Object with hooks to disable. The key is a hook type. If key has "true" value, then the generator skips all hooks from the given type. If the value associated with a key is a string with the name of a single hook, then the generator skips only this single hook name. If the value associated with a key is an array of strings, then the generator skips only hooks from the array. */
     this.disabledHooks = disabledHooks || {};
     /** @type {String} Type of output. Can be either 'fs' (default) or 'string'. Only available when entrypoint is set. */
@@ -846,6 +849,7 @@ class Generator {
     const relativeTargetFile = path.relative(this.targetDir, targetFile);
     const shouldOverwriteFile = await this.shouldOverwriteFile(relativeTargetFile);
     if (!shouldOverwriteFile) return;
+    if (!this.shouldGenerateFile(relativeTargetFile)) return;
     //Ensure the same object are parsed to the renderFile method as before.
     const temp = {};
     const key = template === 'everySchema' || template === 'objectSchema' ? 'schema' : template;
@@ -890,7 +894,9 @@ class Generator {
     let shouldGenerate = true;
   
     if (shouldIgnoreFile(relativeSourceFile)) return;
-    
+
+    if (!this.shouldGenerateFile(relativeSourceFile)) return;
+
     if (!(await this.shouldOverwriteFile(relativeTargetFile))) return;
 
     // conditionalFiles becomes deprecated with this PR, and soon will be removed.
@@ -999,6 +1005,18 @@ class Generator {
     if (!fileExists) return true;
 
     return !this.noOverwriteGlobs.some(globExp => minimatch(filePath, globExp));
+  }
+
+  /**
+   * Checks if a given file should be generated based on the generateOnly filter.
+   *
+   * @private
+   * @param  {string} filePath Relative path of the file to check against generateOnly globs.
+   * @return {boolean}
+   */
+  shouldGenerateFile(filePath) {
+    if (!Array.isArray(this.generateOnly) || this.generateOnly.length === 0) return true;
+    return this.generateOnly.some(globExp => minimatch(filePath, globExp));
   }
 
   /**

--- a/apps/generator/test/generator.test.js
+++ b/apps/generator/test/generator.test.js
@@ -21,6 +21,7 @@ describe('Generator', () => {
       expect(gen.targetDir).toStrictEqual(__dirname);
       expect(gen.entrypoint).toStrictEqual(undefined);
       expect(gen.noOverwriteGlobs).toStrictEqual([]);
+      expect(gen.generateOnly).toStrictEqual([]);
       expect(gen.disabledHooks).toStrictEqual({});
       expect(gen.output).toStrictEqual('fs');
       expect(gen.forceWrite).toStrictEqual(false);
@@ -33,6 +34,7 @@ describe('Generator', () => {
       const gen = new Generator('testTemplate', __dirname, {
         entrypoint: 'test-entrypoint',
         noOverwriteGlobs: ['test-globs'],
+        generateOnly: ['**/*.js'],
         disabledHooks: { 'test-hooks': true, 'generate:after': ['foo', 'bar'], foo: 'bar' },
         output: 'string',
         forceWrite: true,
@@ -46,6 +48,7 @@ describe('Generator', () => {
       expect(gen.targetDir).toStrictEqual(__dirname);
       expect(gen.entrypoint).toStrictEqual('test-entrypoint');
       expect(gen.noOverwriteGlobs).toStrictEqual(['test-globs']);
+      expect(gen.generateOnly).toStrictEqual(['**/*.js']);
       expect(gen.disabledHooks).toStrictEqual({ 'test-hooks': true, 'generate:after': ['foo', 'bar'], foo: 'bar' });
       expect(gen.output).toStrictEqual('string');
       expect(gen.forceWrite).toStrictEqual(true);
@@ -531,6 +534,38 @@ describe('Generator', () => {
       gen.hooks = { 'test-hooks': [function fooBar() {}, function barFoo() {}], 'string-test-hooks': [function fooBar() {}] };
       expect(gen.isHookAvailable('test-hooks')).toStrictEqual(false);
       expect(gen.isHookAvailable('string-test-hooks')).toStrictEqual(false);
+    });
+  });
+
+  describe('#shouldGenerateFile', () => {
+    it('returns true when generateOnly is not set', () => {
+      const gen = new Generator('testTemplate', __dirname);
+      expect(gen.shouldGenerateFile('test.js')).toStrictEqual(true);
+    });
+
+    it('returns true when generateOnly is empty array', () => {
+      const gen = new Generator('testTemplate', __dirname, { generateOnly: [] });
+      expect(gen.shouldGenerateFile('test.js')).toStrictEqual(true);
+    });
+
+    it('returns true for matching file pattern', () => {
+      const gen = new Generator('testTemplate', __dirname, { generateOnly: ['**/*.js'] });
+      expect(gen.shouldGenerateFile('src/test.js')).toStrictEqual(true);
+    });
+
+    it('returns false for non-matching file pattern', () => {
+      const gen = new Generator('testTemplate', __dirname, { generateOnly: ['**/*.js'] });
+      expect(gen.shouldGenerateFile('src/test.md')).toStrictEqual(false);
+    });
+
+    it('returns true if any pattern matches', () => {
+      const gen = new Generator('testTemplate', __dirname, { generateOnly: ['**/*.js', '**/*.md'] });
+      expect(gen.shouldGenerateFile('README.md')).toStrictEqual(true);
+    });
+
+    it('returns false when file does not match any of multiple patterns', () => {
+      const gen = new Generator('testTemplate', __dirname, { generateOnly: ['**/*.js', '**/*.md'] });
+      expect(gen.shouldGenerateFile('style.css')).toStrictEqual(false);
     });
   });
 });

--- a/apps/generator/test/integration.test.js
+++ b/apps/generator/test/integration.test.js
@@ -188,4 +188,25 @@ describe('Integration testing generateFromFile() to make sure the result of the 
     const exists = await readFile(conditionalFilePath).then(() => true).catch(() => false);
     expect(exists).toBe(true);
   });
+
+  it('should generate only files matching generateOnly globs', async () => {
+    const outputDir = generateFolderName();
+    const cleanReactTemplate = await getCleanReactTemplate();
+    const generator = new Generator(cleanReactTemplate, outputDir, {
+      forceWrite: true,
+      generateOnly: ['**/*.md'],
+    });
+
+    await generator.generateFromFile(dummySpecPath);
+
+    // Check that .md files were generated
+    const mdFile = path.join(outputDir, 'test-file.md');
+    const mdExists = await readFile(mdFile).then(() => true).catch(() => false);
+    expect(mdExists).toBe(true);
+
+    // Check that non-.md files were NOT generated
+    const htmlFile = path.join(outputDir, 'index.html');
+    const htmlExists = await readFile(htmlFile).then(() => true).catch(() => false);
+    expect(htmlExists).toBe(false);
+  });
 });


### PR DESCRIPTION
Fixes #581

Adds a new `generateOnly` option (analogous to the existing `noOverwriteGlobs`) that allows users to specify which files should be generated during template rendering.

## What changed

- Added `generateOnly` to the Generator constructor options
- When set (e.g., `generateOnly: ['**/*.md']`), only files matching the glob patterns are generated
- All other files are silently skipped during directory structure generation
- The filter applies to both regular file generation and separated file generation (e.g., per-channel/message files)
- Empty/unset `generateOnly` means generate everything (backward compatible, no behavior change)

## How it works

The new `shouldGenerateFile(filePath)` method uses `minimatch` (same library as `noOverwriteGlobs`) to check if a file path matches any of the provided glob patterns. The check is performed early in `generateFile()` and `generateSeparateFile()`, before any rendering or I/O occurs.

## How to verify

**Unit tests:**
```bash
cd apps/generator && npm test -- --testPathPattern=generator.test.js
```
6 new test cases cover: unset/empty generateOnly, matching/non-matching patterns, multi-pattern support.

**Integration test:**
```bash
cd apps/generator && npm test -- --testPathPattern=integration.test.js
```
Verifies that with `generateOnly: ['**/*.md']`, only .md files are generated while .html and other files are skipped.

**Manual usage:**
```js
const generator = new Generator('@asyncapi/html-template', './output', {
  generateOnly: ['**/*.md', '**/*.json'],
  forceWrite: true,
});
await generator.generateFromFile('./asyncapi.yaml');
```

Closes #581

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `generateOnly` configuration option to control which template files are generated. Specify one or more glob patterns to selectively generate only matching files. Non-matching files are skipped. When unset or empty, all files are generated, maintaining full backward compatibility with existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->