### PR TITLE
ci: add workflow to check generated docs are in sync on PRs

### DIFF
--- a/.github/workflows/check-generated-docs-sync.yml
+++ b/.github/workflows/check-generated-docs-sync.yml
@@ -7,6 +7,9 @@ on:
     types: [opened, reopened, synchronize]
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   check-docs:
     name: 'Check generated docs sync'
@@ -30,6 +33,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Determine what node version to use
         uses: asyncapi/.github/.github/actions/get-node-version-from-package-lock@master

--- a/.github/workflows/check-generated-docs-sync.yml
+++ b/.github/workflows/check-generated-docs-sync.yml
@@ -1,0 +1,64 @@
+# This workflow verifies that generated documentation files are in sync with source code.
+# If a PR modifies JSDoc comments or source files without regenerating docs, this check will fail.
+name: 'Check generated docs are up to date'
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches: [master]
+
+jobs:
+  check-docs:
+    name: 'Check generated docs sync'
+    runs-on: ubuntu-latest
+    # Skip for bot-generated PRs (docs updates, releases, CI sync)
+    if: >
+      !github.event.pull_request.draft && !(
+        (github.actor == 'asyncapi-bot' && (
+          startsWith(github.event.pull_request.title, 'ci: update of files from global .github repo') ||
+           startsWith(github.event.pull_request.title, 'chore(release):') ||
+           github.event.pull_request.title == 'chore: update generated docs'
+        )) ||
+        (github.actor == 'asyncapi-bot-eve' && (
+          startsWith(github.event.pull_request.title, 'ci: update of files from global .github repo') ||
+          startsWith(github.event.pull_request.title, 'chore(release):')
+        )) ||
+        (github.actor == 'allcontributors[bot]' &&
+          startsWith(github.event.pull_request.title, 'docs: add')
+        )
+      )
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Determine what node version to use
+        uses: asyncapi/.github/.github/actions/get-node-version-from-package-lock@master
+        with:
+          node-version: ${{ vars.NODE_VERSION }}
+        id: lockversion
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "${{ steps.lockversion.outputs.version }}"
+          cache: 'npm'
+          cache-dependency-path: '**/package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Regenerate documentation assets
+        run: npm run generate:assets
+
+      - name: Check for doc differences
+        run: |
+          if git diff --exit-code --quiet -- '*.md'; then
+            echo "✅ All generated documentation is up to date"
+          else
+            echo "::error::Generated documentation is out of sync with source code."
+            echo "Please run 'npm run generate:assets' locally and commit the updated docs."
+            echo ""
+            echo "Changed files:"
+            git diff --name-only -- '*.md'
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Fixes #2038

## Problem

Contributors can update JSDoc comments and forget to run `npm run generate:assets`, causing generated docs (`api_components.md`, `api.md`, README TOC, etc.) to silently go out of sync with no CI check to catch them.

We already had this problem with #1922 where docs changes were unexpectedly auto-merged.

## Solution

Add a PR workflow () that:

1. **Triggers** on all PRs against `master` (opened, reopened, synchronize)
2. **Installs** dependencies via `npm ci`
3. **Regenerates** all documentation assets via `npm run generate:assets` (runs `turbo run generate:assets` across all packages + README TOC update)
4. **Checks** if any generated `.md` files have diffs
5. **Fails** with a clear error message pointing contributors to run `npm run generate:assets` locally

### Design decisions

- **Skips bot PRs**: Docs update PRs, release PRs, CI sync PRs, and allcontributors bot PRs are excluded (they are expected to change generated files)
- **Skips draft PRs**: No need to check until the PR is ready for review
- **Uses existing patterns**: Follows the same node version detection, setup, and bot-exclusion logic as `pr-testing-with-test-project.yml`
- **Checks all `*.md` diffs**: Catches not just `api_components.md` but any generated documentation that may be added in the future

## Notes

- This makes the existing `update-docs-on-docs-commits.yml` workflow partially redundant for catching stale docs on PRs (that workflow still serves the purpose of auto-creating docs update PRs on `docs:` commits to master)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated check on pull requests that validates generated documentation is up to date. It runs for active PRs (skipping drafts and known bot PRs) and will flag/fail the PR if documentation artifacts diverge, prompting authors to regenerate docs before merge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->