### PR TITLE
fix(validator): treat falsy values as valid template params (#2008)

### DIFF
--- a/apps/generator/lib/templates/config/validator.js
+++ b/apps/generator/lib/templates/config/validator.js
@@ -75,7 +75,7 @@ function isTemplateCompatible(generator, apiVersion) {
  */
 function isRequiredParamProvided(configParams, templateParams) {
   const missingParams = Object.keys(configParams || {})
-    .filter(key => configParams[key].required && !templateParams[key]);
+    .filter(key => configParams[key].required && templateParams[key] === undefined);
 
   if (missingParams.length) {
     throw new Error(`This template requires the following missing params: ${missingParams}.`);


### PR DESCRIPTION
## Problem

**Fixes #2008**

In `validator.js`, required template parameters are validated with:

```js
.filter(key => configParams[key].required && !templateParams[key]);
```

The `!templateParams[key]` check uses **truthiness**, which incorrectly treats these **valid** values as **missing**:

| Value | `!value` | Should be missing? |
|---|---|---|
| `undefined` | `true` | ✅ Yes |
| `null` | `true` | ✅ Yes (arguably) |
| `false` | `true` | ❌ No! |
| `0` | `true` | ❌ No! |
| `''` (empty string) | `true` | ❌ No! |

## Fix

**1 line change**: `!templateParams[key]` → `templateParams[key] === undefined`

Only truly undefined values are treated as missing required params.

## Impact

- Generators used programmatically can now pass `false`, `0`, or `''` as template param values
- Template validation behavior matches developer intent
- No breaking change — only makes the validator less strict (more correct)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parameter validation to properly recognize explicitly provided falsy values (such as `false`, `0`, empty strings, and `null`) as valid for required parameters, preventing unnecessary validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->