### PR TITLE
fix(generator): remove duplicate generate:after hook in handleEntrypoint (#1993)

### DIFF
--- a/apps/generator/lib/generator.js
+++ b/apps/generator/lib/generator.js
@@ -347,7 +347,6 @@ class Generator {
       }
       if (this.output === 'fs') {
         await this.generateFile(this.asyncapi, path.basename(entrypointPath), path.dirname(entrypointPath));
-        await this.launchHook('generate:after');
       } else if (this.output === 'string') {
         return await this.renderFile(this.asyncapi, entrypointPath);
       }


### PR DESCRIPTION
## Problem

**Fixes #1993**

When using Generator API with `entrypoint` set and `output = 'fs'` (default), the `generate:after` hook fires **twice**:

```
generate() {
  await this.handleEntrypoint();     // ← calls generate:after (line 350)
  await this.executeAfterHook();    // ← calls generate:after (line 368) AGAIN
}
```

### Root Cause

`handleEntrypoint()` has an internal `launchHook('generate:after')` for the 'fs' output case, but `generate()` **always** calls `executeAfterHook()` afterward — which also launches the same hook.

### Impact

- All `generate:after` side effects run twice (file cleanup, notifications, etc.)
- Only affects `entrypoint + fs` usage; other combinations are unaffected

## Fix

**1 line removal**: Delete the `launchHook('generate:after')` call from inside `handleEntrypoint()`.

The canonical hook execution is in `executeAfterHook()`, called unconditionally by `generate()`.

### Lifecycle After Fix

```
generate:before
[generation logic]
generate:after    ← exactly once, always
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal generator hook invocation sequence to prevent duplicate execution while maintaining consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->