### PR TITLE
feat: add HandleError component for standardized error handling (dart-websocket))

### DIFF
--- a/packages/components/src/components/OnError.js
+++ b/packages/components/src/components/OnError.js
@@ -37,13 +37,7 @@ const websocketOnErrorMethod = {
   dart: () => {
     return {
       onErrorMethod: `onError: (error) {
-        if (_errorHandlers.isNotEmpty) {
-          for (var handler in _errorHandlers) {
-            handler(error);
-          }
-        } else {
-          print('WebSocket Error: $error');
-        }
+        _handleError(error);
       },`
     };
   }

--- a/packages/components/test/components/__snapshots__/Connect.test.js.snap
+++ b/packages/components/test/components/__snapshots__/Connect.test.js.snap
@@ -24,13 +24,7 @@ exports[`Testing of Connect function render dart Connect method 1`] = `
         },
 
           onError: (error) {
-          if (_errorHandlers.isNotEmpty) {
-            for (var handler in _errorHandlers) {
-              handler(error);
-            }
-          } else {
-            print('WebSocket Error: $error');
-          }
+          _handleError(error);
         },
 
           onDone: () {

--- a/packages/components/test/components/__snapshots__/OnError.test.js.snap
+++ b/packages/components/test/components/__snapshots__/OnError.test.js.snap
@@ -2,13 +2,7 @@
 
 exports[`Testing of OnError function render dart OnError method 1`] = `
 "onError: (error) {
-        if (_errorHandlers.isNotEmpty) {
-          for (var handler in _errorHandlers) {
-            handler(error);
-          }
-        } else {
-          print('WebSocket Error: $error');
-        }
+        _handleError(error);
       },"
 `;
 

--- a/packages/templates/clients/websocket/dart/components/ClientClass.js
+++ b/packages/templates/clients/websocket/dart/components/ClientClass.js
@@ -3,6 +3,7 @@ import { Constructor } from './Constructor';
 import { SendEchoMessage } from './SendEchoMessage';
 import { CloseConnection, RegisterMessageHandler, RegisterErrorHandler, Connect, HandleMessage } from '@asyncapi/generator-components';
 import { ClientFields } from './ClientFields';
+import { HandleError } from './HandleError';
 
 export function ClientClass({ clientName, serverUrl, title }) {
   return (
@@ -26,6 +27,7 @@ export function ClientClass({ clientName, serverUrl, title }) {
         methodName="_handleMessage"
         methodParams={['dynamic message', 'void Function(String) cb']}
       />
+      <HandleError />
       <SendEchoMessage />
       <CloseConnection language="dart" />
       <Text>

--- a/packages/templates/clients/websocket/dart/components/HandleError.js
+++ b/packages/templates/clients/websocket/dart/components/HandleError.js
@@ -1,0 +1,21 @@
+import { Text } from '@asyncapi/generator-react-sdk';
+
+export function HandleError() {
+  return (
+    <Text newLines={2} indent={2}>
+      {
+        `/// Pass the error to all registered error handlers.
+/// A generic log message is printed if no handlers are registered.
+void _handleError(Object error) {
+  if (_errorHandlers.isEmpty) {
+    print('Error occurred: $error');
+  } else {
+    for (final handler in _errorHandlers) {
+      handler(error);
+    }
+  }
+}`
+      }
+    </Text>
+  );
+}

--- a/packages/templates/clients/websocket/test/integration-test/__snapshots__/integration.test.js.dart.snap
+++ b/packages/templates/clients/websocket/test/integration-test/__snapshots__/integration.test.js.dart.snap
@@ -48,13 +48,7 @@ class HoppscotchClient {
         },
 
           onError: (error) {
-          if (_errorHandlers.isNotEmpty) {
-            for (var handler in _errorHandlers) {
-              handler(error);
-            }
-          } else {
-            print('WebSocket Error: $error');
-          }
+          _handleError(error);
         },
 
           onDone: () {
@@ -175,13 +169,7 @@ class HoppscotchEchoWebSocketClient {
         },
 
           onError: (error) {
-          if (_errorHandlers.isNotEmpty) {
-            for (var handler in _errorHandlers) {
-              handler(error);
-            }
-          } else {
-            print('WebSocket Error: $error');
-          }
+          _handleError(error);
         },
 
           onDone: () {
@@ -303,13 +291,7 @@ class PostmanEchoWebSocketClientClient {
         },
 
           onError: (error) {
-          if (_errorHandlers.isNotEmpty) {
-            for (var handler in _errorHandlers) {
-              handler(error);
-            }
-          } else {
-            print('WebSocket Error: $error');
-          }
+          _handleError(error);
         },
 
           onDone: () {

--- a/packages/templates/clients/websocket/test/integration-test/__snapshots__/integration.test.js.dart.snap
+++ b/packages/templates/clients/websocket/test/integration-test/__snapshots__/integration.test.js.dart.snap
@@ -84,6 +84,18 @@ class HoppscotchClient {
     cb(message is String ? message : message.toString());
   }
 
+  /// Pass the error to all registered error handlers.
+  /// A generic log message is printed if no handlers are registered.
+  void _handleError(Object error) {
+    if (_errorHandlers.isEmpty) {
+      print('Error occurred: $error');
+    } else {
+      for (final handler in _errorHandlers) {
+        handler(error);
+      }
+    }
+  }
+
   /// Method to send an echo message to the server
   void sendEchoMessage(dynamic message) {
     if (_channel == null) {
@@ -197,6 +209,18 @@ class HoppscotchEchoWebSocketClient {
   /// Method to handle message with callback
   void _handleMessage(dynamic message, void Function(String) cb) {
     cb(message is String ? message : message.toString());
+  }
+
+  /// Pass the error to all registered error handlers.
+  /// A generic log message is printed if no handlers are registered.
+  void _handleError(Object error) {
+    if (_errorHandlers.isEmpty) {
+      print('Error occurred: $error');
+    } else {
+      for (final handler in _errorHandlers) {
+        handler(error);
+      }
+    }
   }
 
   /// Method to send an echo message to the server
@@ -313,6 +337,18 @@ class PostmanEchoWebSocketClientClient {
   /// Method to handle message with callback
   void _handleMessage(dynamic message, void Function(String) cb) {
     cb(message is String ? message : message.toString());
+  }
+
+  /// Pass the error to all registered error handlers.
+  /// A generic log message is printed if no handlers are registered.
+  void _handleError(Object error) {
+    if (_errorHandlers.isEmpty) {
+      print('Error occurred: $error');
+    } else {
+      for (final handler in _errorHandlers) {
+        handler(error);
+      }
+    }
   }
 
   /// Method to send an echo message to the server


### PR DESCRIPTION

**Description**
- Added Dart WebSocket template `HandleError` component generating `_handleError(Object error)` for centralized error dispatch (aligned with Python `handle_error`).
- Registered `HandleError` in `ClientClass` after `HandleMessage`.
- Delegated Dart `onError` in shared `OnError.js` to `_handleError(error)` instead of inline handler loops in `connect()`.
- Updated component snapshots (`OnError.test.js.snap`, `Connect.test.js.snap`) and Dart integration snapshots (`integration.test.js.dart.snap`).

**Related issue(s)**

Fixes #1964 

**Screenshots of tests **
<img width="1490" height="1406" alt="image" src="https://github.com/user-attachments/assets/b119f868-4b93-4865-95e1-67effee6d698" />

<img width="1936" height="666" alt="image" src="https://github.com/user-attachments/assets/575b8347-05e7-43bf-9080-8e77bc159fc7" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved error handling in Dart WebSocket client templates with enhanced error propagation to registered handlers.
  * Added comprehensive error-handling component for better error dispatch and automatic fallback messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/generator/pull/2095?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->