### PR TITLE
test: add ConnectorFields component tests

### DIFF
--- a/packages/templates/clients/websocket/java/quarkus/test/components/ConnectorFields.test.js
+++ b/packages/templates/clients/websocket/java/quarkus/test/components/ConnectorFields.test.js
@@ -1,0 +1,62 @@
+import path from 'path';
+import { render } from '@asyncapi/generator-react-sdk';
+import { Parser, fromFile } from '@asyncapi/parser';
+import { getQueryParams } from '@asyncapi/generator-helpers';
+import { ConnectorFields } from '../../components/ConnectorFields.js';
+
+const parser = new Parser();
+const asyncapiFilePath = path.resolve(__dirname, '../../../../test/__fixtures__/asyncapi-websocket-components.yml');
+
+describe('ConnectorFields component (integration with AsyncAPI document)', () => {
+  let parsedAsyncAPIDocument;
+  let channels;
+  let queryParamsArray;
+
+  beforeAll(async () => {
+    const parseResult = await fromFile(parser, asyncapiFilePath).parse();
+    parsedAsyncAPIDocument = parseResult.document;
+    channels = parsedAsyncAPIDocument.channels();
+
+    const queryParams = getQueryParams(channels);
+    queryParamsArray = queryParams ? Array.from(queryParams.entries()) : null;
+  });
+
+  test('renders connector field without base URI config when queryParamsArray is null', () => {
+    const result = render(
+      <ConnectorFields
+        clientName="WebSocketClient"
+        queryParamsArray={null}
+      />
+    );
+    expect(result.trim()).toMatchSnapshot();
+  });
+
+  test('renders connector field without base URI config when queryParamsArray is undefined', () => {
+    const result = render(
+      <ConnectorFields
+        clientName="WebSocketClient"
+      />
+    );
+    expect(result.trim()).toMatchSnapshot();
+  });
+
+  test('renders connector field without base URI config when queryParamsArray is empty array', () => {
+    const result = render(
+      <ConnectorFields
+        clientName="WebSocketClient"
+        queryParamsArray={[]}
+      />
+    );
+    expect(result.trim()).toMatchSnapshot();
+  });
+
+  test('renders connector field with base URI config when queryParamsArray has data from fixture', () => {
+    const result = render(
+      <ConnectorFields
+        clientName="WebSocketClient"
+        queryParamsArray={queryParamsArray}
+      />
+    );
+    expect(result.trim()).toMatchSnapshot();
+  });
+});

--- a/packages/templates/clients/websocket/java/quarkus/test/components/ConnectorFields.test.js
+++ b/packages/templates/clients/websocket/java/quarkus/test/components/ConnectorFields.test.js
@@ -51,6 +51,9 @@ describe('ConnectorFields component (integration with AsyncAPI document)', () =>
   });
 
   test('renders connector field with base URI config when queryParamsArray has data from fixture', () => {
+    expect(Array.isArray(queryParamsArray)).toBe(true);
+    expect(queryParamsArray.length).toBeGreaterThan(0);
+
     const result = render(
       <ConnectorFields
         clientName="WebSocketClient"

--- a/packages/templates/clients/websocket/java/quarkus/test/components/__snapshots__/ConnectorFields.test.js.snap
+++ b/packages/templates/clients/websocket/java/quarkus/test/components/__snapshots__/ConnectorFields.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConnectorFields component (integration with AsyncAPI document) renders connector field with base URI config when queryParamsArray has data from fixture 1`] = `
+"@Inject
+  WebSocketConnector<WebSocketClient> connector;
+
+
+  @Inject
+  @ConfigProperty(name = \\"com.asyncapi.WebSocketClient.base-uri\\")
+  String baseURI;"
+`;
+
+exports[`ConnectorFields component (integration with AsyncAPI document) renders connector field without base URI config when queryParamsArray is empty array 1`] = `
+"@Inject
+  WebSocketConnector<WebSocketClient> connector;"
+`;
+
+exports[`ConnectorFields component (integration with AsyncAPI document) renders connector field without base URI config when queryParamsArray is null 1`] = `
+"@Inject
+  WebSocketConnector<WebSocketClient> connector;"
+`;
+
+exports[`ConnectorFields component (integration with AsyncAPI document) renders connector field without base URI config when queryParamsArray is undefined 1`] = `
+"@Inject
+  WebSocketConnector<WebSocketClient> connector;"
+`;


### PR DESCRIPTION
## Description

Adds component test coverage for the Java Quarkus WebSocket template `ConnectorFields` component.

The new tests verify that the component renders the injected `WebSocketConnector` field in all cases and only renders the `@ConfigProperty` base URI field when query parameters are present.

Closes #2014

## Validation

- `npm test` from `packages/templates/clients/websocket/java/quarkus`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration test suite for the ConnectorFields React component that validates rendering across four query-parameter scenarios (null, omitted/undefined, empty array, and a populated derived array). The suite precomputes query parameters once and uses snapshot comparisons to ensure consistent output across these cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/generator/pull/2103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->