### PR TITLE
fix: use public React JSX runtime entrypoint

### DIFF
--- a/.changeset/quiet-bugs-cheer.md
+++ b/.changeset/quiet-bugs-cheer.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/generator-react-sdk": patch
+---
+
+Use the public React JSX runtime entrypoint in the transpiler.

--- a/apps/react-sdk/src/transpiler/__tests__/__snapshots__/transpiler.spec.tsx.snap
+++ b/apps/react-sdk/src/transpiler/__tests__/__snapshots__/transpiler.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`Transpiler should keep names of files, even if special chars with a sim
 
 require('source-map-support/register');
 var path = require('path');
-var jsxRuntime = require('/full/path/to/react/cjs/react-jsx-runtime.production.min.js');
+var jsxRuntime = require('/full/path/to/react/jsx-runtime.js');
 
 function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
 
@@ -33,7 +33,7 @@ exports[`Transpiler should transpile CommonJS files with a simple setup and impo
 "'use strict';
 
 require('source-map-support/register');
-var jsxRuntime = require('/full/path/to/react/cjs/react-jsx-runtime.production.min.js');
+var jsxRuntime = require('/full/path/to/react/jsx-runtime.js');
 
 /* eslint-disable no-undef */
 const path = require('path');
@@ -62,7 +62,7 @@ exports[`Transpiler should transpile ES5 files with a simple setup and import co
 
 require('source-map-support/register');
 var path = require('path');
-var jsxRuntime = require('/full/path/to/react/cjs/react-jsx-runtime.production.min.js');
+var jsxRuntime = require('/full/path/to/react/jsx-runtime.js');
 
 function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
 
@@ -93,7 +93,7 @@ exports[`Transpiler should transpile ES6 files with a simple setup and import co
 
 require('source-map-support/register');
 var path = require('path');
-var jsxRuntime = require('/full/path/to/react/cjs/react-jsx-runtime.production.min.js');
+var jsxRuntime = require('/full/path/to/react/jsx-runtime.js');
 
 function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
 

--- a/apps/react-sdk/src/transpiler/__tests__/transpiler.spec.tsx
+++ b/apps/react-sdk/src/transpiler/__tests__/transpiler.spec.tsx
@@ -118,6 +118,6 @@ function switchToUnixLinebreaks(str: string) {
   We need to replace this in snapshots with something that will be stable across developer environments.
 */
 function stripAbsolutePathToReactLib(str: string) {
-  const reactPath = require.resolve('react/cjs/react-jsx-runtime.production.min').replace(/\\/g, '/')
-  return str.replace(reactPath, "/full/path/to/react/cjs/react-jsx-runtime.production.min.js")
+  const reactPath = require.resolve('react/jsx-runtime').replace(/\\/g, '/')
+  return str.replace(reactPath, "/full/path/to/react/jsx-runtime.js")
 }

--- a/apps/react-sdk/src/transpiler/transpiler.ts
+++ b/apps/react-sdk/src/transpiler/transpiler.ts
@@ -52,7 +52,7 @@ export async function transpileFiles(directory: string, outputDir: string, optio
             dir: outputDir,
             exports: "auto",
             paths: {
-              'react/jsx-runtime': require.resolve('react/cjs/react-jsx-runtime.production.min').replace(/\\/g, '/'),
+              'react/jsx-runtime': require.resolve('react/jsx-runtime').replace(/\\/g, '/'),
             },
             sanitizeFileName: false,
         })


### PR DESCRIPTION
**Description**

- Resolves React JSX runtime through the public `react/jsx-runtime` entrypoint.
- Updates transpiler snapshots for the resolved path.

**Related issue**

Fixes #2090

Checks:
- `npm run test --workspace=@asyncapi/generator-react-sdk -- --runTestsByPath src/transpiler/__tests__/transpiler.spec.tsx`
- `npm run lint --workspace=@asyncapi/generator-react-sdk`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved React JSX runtime module resolution so the transpiler bundles the correct runtime variant.

* **Tests**
  * Updated test utilities and snapshots to normalize React runtime module paths in transpiler output.

* **Chores**
  * Added a patch changeset recording the update to use the public React JSX runtime entrypoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asyncapi/generator/pull/2105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->