### PR TITLE
fix(security): restrict manual-netlify-preview to same-repo PRs

### DIFF
--- a/.github/workflows/manual-netlify-preview.yml
+++ b/.github/workflows/manual-netlify-preview.yml
@@ -7,6 +7,12 @@ on:
 
 jobs:
   preview:
+    # Security: only run for PRs from the same repository (asyncapi/generator).
+    # Without this guard, a fork PR could checkout untrusted code with a
+    # write-scoped GITHUB_TOKEN and gain access to NETLIFY_AUTH_TOKEN,
+    # allowing arbitrary modification of the production docs site.
+    # See https://github.com/asyncapi/generator/issues/2097
+    if: github.event.pull_request.head.repo.full_name == 'asyncapi/generator'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Security fix for the `pull_request_target` RCE pattern (issue #2097)

Thanks @Raffa-jarrl for the report — your scanner was right. The
`manual-netlify-preview.yml` workflow uses the classic dangerous combination
of `pull_request_target` + `actions/checkout` of `${{ github.event.pull_request.head.sha }}`,
and then runs `npm ci` (with `NETLIFY_AUTH_TOKEN` in env). A fork PR with a
malicious postinstall script could run arbitrary code with write-scoped
tokens and modify the production docs site on Netlify.

This PR adds a one-line guard: only run the job when the PR comes from
`asyncapi/generator` itself. Fork PRs are skipped entirely, eliminating
the attack surface.

```diff
 jobs:
   preview:
+    # Security: only run for PRs from the same repository (asyncapi/generator).
+    # Without this guard, a fork PR could checkout untrusted code with a
+    # write-scoped GITHUB_TOKEN and gain access to NETLIFY_AUTH_TOKEN,
+    # allowing arbitrary modification of the production docs site.
+    # See https://github.com/asyncapi/generator/issues/2097
+    if: github.event.pull_request.head.repo.full_name == 'asyncapi/generator'
     runs-on: ubuntu-latest
```

### Verification

- After this change, a fork PR like `https://github.com/evil/generator/pull/1`
  will NOT trigger the workflow (the `if` evaluates to `false`).
- Only branch-based PRs from the upstream `asyncapi/generator` repo
  (i.e. the normal maintainer + approved-contributor flow) will run.

### Follow-up suggestions (not in this PR)

- Pin the `actions/checkout` action to a commit SHA (currently `@v5`).
- Add `persist-credentials: false` to both checkout steps.
- Consider whether Netlify preview can be moved to a separate
  `pull_request` (not `pull_request_target`) workflow that builds without
  write tokens, and only deploy from a trusted branch.

But the immediate RCE window is closed with the same-repo guard.

Fixes #2097

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added security protection to the preview deployment workflow, restricting execution to authorized repositories only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->