### PR TITLE
ci: sync lockfile in release PRs and skip AI disclosure on bot PRs

### DIFF
--- a/.github/workflows/release-with-changesets.yml
+++ b/.github/workflows/release-with-changesets.yml
@@ -122,7 +122,10 @@ jobs:
         uses: changesets/action@v1
         id: release
         with:
-          version: npx -p @changesets/cli@2.27.7 changeset version
+          # `changeset version` only rewrites package.json/CHANGELOG files; it never runs an
+          # install, so the root package-lock.json drifts out of sync with the bumped manifests.
+          # Refresh the lockfile (lockfile-only, no scripts) so the release PR carries it too.
+          version: npx -p @changesets/cli@2.27.7 changeset version && npm install --package-lock-only --ignore-scripts
           commit: "chore(release): release and bump versions of packages"
           title: "chore(release): release and bump versions of packages"
           publish: npx -p @changesets/cli@2.27.7 changeset publish

--- a/.github/workflows/verify-ai-disclosure.yml
+++ b/.github/workflows/verify-ai-disclosure.yml
@@ -31,6 +31,11 @@ permissions:
 
 jobs:
   verify-ai-disclosure:
+    # it runs only if PR actor is not a bot, at least not a bot that we know
+    if: |
+      (github.event.pull_request.user.login != 'asyncapi-bot' && 
+      github.event.pull_request.user.login != 'dependabot[bot]' && 
+      github.event.pull_request.user.login != 'dependabot-preview[bot]') 
     runs-on: ubuntu-latest
     steps:
       - name: Check PR body for AI-assistance disclosure

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
     },
     "apps/generator": {
       "name": "@asyncapi/generator",
-      "version": "3.2.1",
+      "version": "3.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/generator-components": "*",
@@ -14543,7 +14543,7 @@
     },
     "packages/components": {
       "name": "@asyncapi/generator-components",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@asyncapi/generator-helpers": "*",
@@ -14838,7 +14838,7 @@
       "name": "core-template-client-websocket-dart",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-components": "0.6.0",
+        "@asyncapi/generator-components": "0.7.0",
         "@asyncapi/generator-helpers": "1.1.0",
         "@asyncapi/generator-react-sdk": "*"
       },
@@ -14858,7 +14858,7 @@
       "name": "core-template-client-websocket-java-quarkus",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-components": "0.6.0",
+        "@asyncapi/generator-components": "0.7.0",
         "@asyncapi/generator-helpers": "1.1.0",
         "@asyncapi/generator-react-sdk": "^1.1.2"
       },
@@ -14880,7 +14880,7 @@
       "name": "core-template-client-websocket-javascript",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-components": "0.6.0",
+        "@asyncapi/generator-components": "0.7.0",
         "@asyncapi/generator-helpers": "1.1.0",
         "@asyncapi/generator-react-sdk": "*",
         "@asyncapi/keeper": "0.5.0",
@@ -14902,7 +14902,7 @@
       "name": "core-template-client-websocket-python",
       "license": "Apache-2.0",
       "dependencies": {
-        "@asyncapi/generator-components": "0.6.0",
+        "@asyncapi/generator-components": "0.7.0",
         "@asyncapi/generator-helpers": "1.1.0",
         "@asyncapi/generator-react-sdk": "*"
       },


### PR DESCRIPTION
## Description

Fixes two CI workflow issues described in #2123.

### Problem 1 — Release PRs leave `package-lock.json` stale

The Changesets release PR runs only `changeset version`, which rewrites `package.json`/`CHANGELOG.md` files but never runs an install, so the root `package-lock.json` drifts out of sync with the bumped manifests (both the package's own `version` entry and the internal dependency pins in consumers). This makes `npm ci` fail and produces noisy lockfile diffs on later PRs.

Fix: append `npm install --package-lock-only --ignore-scripts` to the `changesets/action` `version` command in `release-with-changesets.yml` so the release PR regenerates the lockfile alongside the manifests. `--package-lock-only` avoids a full reinstall (node_modules is already present from the earlier `npm ci`) and `--ignore-scripts` keeps it side-effect-free.

### Problem 2 — `verify-ai-disclosure.yml` runs on bot PRs

The AI-disclosure check ran on every PR, including machine-generated ones (e.g. the Changesets release PR from `asyncapi-bot`, and `dependabot`), adding noise on PRs no human authored.

Fix: add a job-level actor guard that skips the check for known bot authors, consistent with how other PR-triggered workflows in this repo (e.g. `pr-review-checklist.yml`) treat bots.

## Related issue(s)

Fixes #2123

Generated-by: Cursor Agent (Claude Opus 4.8)
