### PR TITLE
docs: clarified local generator installation and docker host address in tutorial (#2107)

### DIFF
--- a/apps/generator/docs/generator-template.md
+++ b/apps/generator/docs/generator-template.md
@@ -87,15 +87,22 @@ components:
 
 1. Create a new directory for your template named **python-mqtt-client-template**.
 2. Install the AsyncAPI CLI using the command `npm install -g @asyncapi/cli`.
-3. Create a new folder **test/fixtures** with a file named **asyncapi.yml** in your fixtures directory. This file is used to define the **structure** of your template. You can copy the above example and paste it in your **asyncapi.yml** document.
-4. Create a new file named **package.json** in your **python-mqtt-client-template** directory. This file is used to define the **dependencies** for your template.
-5. Create a new folder **python-mqtt-client-template/template**. Create a new file named **index.js** in your **template** directory. This file is used to define the **logic** for your template.
-6. Create a **test.py** file to validate the logic of your application. Don't worry about this file for now. The tutorial will tell you how to create it later.
+3. While inside your template directory, install the Generator locally:
+
+```bash
+cd python-mqtt-client-template
+npm install @asyncapi/generator
+```
+
+4. Create a new folder **test/fixtures** with a file named **asyncapi.yml** in your fixtures directory. This file is used to define the **structure** of your template.
+5. Create a new file named **package.json** in your **python-mqtt-client-template** directory. This file is used to define the **dependencies** for your template.
+6. Create a new folder **python-mqtt-client-template/template**. Create a new file named **index.js** in your **template** directory. This file is used to define the **logic** for your template.
+7. Create a **test.py** file to validate the logic of your application. Don't worry about this file for now. The tutorial will tell you how to create it later.
 
 Now your directory should look like this:
 
-```
-python-mqtt-client-template 
+```text
+python-mqtt-client-template
 ├── template
 │   └── index.js
 ├── test
@@ -285,6 +292,12 @@ New temperature detected 72955029 sent to temperature/changed
 ```
 
 To make sure your **test.py** and client code works check if the broker really receives temperature-related messages. You can do it using an [MQTT CLI](https://hivemq.github.io/mqtt-cli/) using docker. Run the command `docker run hivemq/mqtt-cli sub -t temperature/changed -h test.mosquitto.org` in your terminal. It will download the image if you don't have it locally, then the CLI will connect to the broker, subscribe to the `temperature/changed` topic and then output the temperature ids on the terminal.
+
+> For testing against a local Docker broker, route to the host machine:
+
+```bash
+docker run hivemq/mqtt-cli sub -t temperature/changed -h host.docker.internal
+```
 
 ### 3. Update the template with client code
 

--- a/apps/generator/docs/generator-template.md
+++ b/apps/generator/docs/generator-template.md
@@ -83,22 +83,17 @@ components:
           type: string
 ```
 
-## Overview of steps
+ ## Overview of steps
 
 1. Create a new directory for your template named **python-mqtt-client-template**.
 2. Install the AsyncAPI CLI using the command `npm install -g @asyncapi/cli`.
-3. While inside your template directory, install the Generator locally:
-
-```bash
-cd python-mqtt-client-template
-npm install @asyncapi/generator
-```
-
-4. Create a new folder **test/fixtures** with a file named **asyncapi.yml** in your fixtures directory. This file is used to define the **structure** of your template.
-5. Create a new file named **package.json** in your **python-mqtt-client-template** directory. This file is used to define the **dependencies** for your template.
-6. Create a new folder **python-mqtt-client-template/template**. Create a new file named **index.js** in your **template** directory. This file is used to define the **logic** for your template.
-7. Create a **test.py** file to validate the logic of your application. Don't worry about this file for now. The tutorial will tell you how to create it later.
-
+3. Create a new folder **test/fixtures** with a file named **asyncapi.yml** in your fixtures directory. This file is used to define the **structure** of your template. You can copy the above example and paste it in your **asyncapi.yml** document.
+4. Create a new file named **package.json** in your **python-mqtt-client-template** directory. This file is used to define the **dependencies** for your template. Make sure to include `@asyncapi/generator` alongside your other dependencies here.
+5. Create a new folder **python-mqtt-client-template/template**. Create a new file named **index.js** in your **template** directory. This file is used to define the **logic** for your template.
+6. Navigate into your template directory and run a single installation command to install all defined dependencies locally (this is required for the CLI to execute template commands):
+   ```bash
+   cd python-mqtt-client-template
+   npm install
 Now your directory should look like this:
 
 ```text

--- a/apps/generator/docs/generator-template.md
+++ b/apps/generator/docs/generator-template.md
@@ -83,7 +83,7 @@ components:
           type: string
 ```
 
- ## Overview of steps
+## Overview of steps
 
 1. Create a new directory for your template named **python-mqtt-client-template**.
 2. Install the AsyncAPI CLI using the command `npm install -g @asyncapi/cli`.


### PR DESCRIPTION
### Description
This PR addresses issue #2107 by adding two clarifying updates to the **"Creating a Template - Python"** tutorial to improve the onboarding experience for first-time users:

1. **Local Generator Installation:** Added a step to navigate into the newly created template directory and install `@asyncapi/generator` locally. This ensures the CLI commands executed later in the tutorial function as expected.
2. **Local Docker Networking Tip:** Added a troubleshooting note for users running an alternative local Mosquitto broker via Docker (especially on macOS/Windows), instructing them to use `host.docker.internal` so the HiveMQ MQTT-CLI container can successfully reach the host machine.

Generated-by: ChatGPT

### Related Issues
Closes #2107

### Checklist
- [x] I have followed the project's contribution guidelines.
- [x] My changes are limited strictly to documentation updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the generator tutorial with a new local installation step, including adding the generator dependency, running installation in the generated template, and refreshing the directory example; removed an unrelated step during that phase.
  * Improved the MQTT CLI testing section with guidance for testing against a local Docker broker using `host.docker.internal`.
  * Reordered steps and refined wording for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->