### PR TITLE
chore: add concurrency control to docs preview workflow

### DIFF
--- a/.github/workflows/manual-netlify-preview.yml
+++ b/.github/workflows/manual-netlify-preview.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - 'apps/generator/docs/**'
 
+concurrency:
+  group: docs-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+  
 jobs:
   preview:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Adds workflow-level concurrency control to the Netlify docs preview workflow.

### Changes

- Added a concurrency group scoped to the pull request number.
- Enabled `cancel-in-progress: true`.


Related #1996 


### Benefit

When multiple commits are pushed to the same PR in quick succession, older preview deployments are automatically cancelled and only the latest run continues.

This prevents unnecessary CI usage and avoids generating preview deployments for outdated commits.

**AI assistance**
<!-- See our AI Usage Policy: https://github.com/asyncapi/generator/blob/master/AI-POLICY.md
Check exactly one box. If this PR was materially AI-assisted, keep the Generated-by line and fill in the tool + model version. -->

- [ ] This PR was created with AI assistance — `Generated-by:` <!-- e.g. Generated-by: Claude Code 1.x -->
- [x] No AI assistance was used


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced preview deployment workflow to limit concurrent deployments to one per pull request, automatically canceling redundant in-progress runs to improve efficiency and reduce unnecessary resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->