### PR TITLE
refactor: use String.raw to avoid escaping backslashes in python handlers

### DIFF
--- a/packages/components/src/components/HandleError.js
+++ b/packages/components/src/components/HandleError.js
@@ -22,10 +22,10 @@ const handleErrorConfig = {
   python: {
     indent: 2,
     newLines: 2,
-    body: `def handle_error(self, error):
+    body: String.raw`def handle_error(self, error):
     """Pass the error to all registered error handlers. Generic log message is printed if no handlers are registered."""
     if len(self.error_handlers) == 0:
-      print("\\033[91mError occurred:\\033[0m", error)
+      print("\033[91mError occurred:\033[0m", error)
     else:
       # Call custom error handlers
       for handler in self.error_handlers:

--- a/packages/components/src/components/HandleMessage.js
+++ b/packages/components/src/components/HandleMessage.js
@@ -11,8 +11,8 @@ import { MethodGenerator } from './MethodGenerator';
  */
 const websocketHandleMessageConfig = {
   python: {
-    methodLogic: `if len(self.message_handlers) == 0:
-  print("\\033[94mReceived raw message:\\033[0m", message)
+    methodLogic: String.raw`if len(self.message_handlers) == 0:
+  print("\033[94mReceived raw message:\033[0m", message)
 else:
     for handler in self.message_handlers:
       handler(message)`


### PR DESCRIPTION
**Description**
- Use `String.raw` in the Python handlers so ANSI codes read `\033` instead of `\\033`. Pure refactor — generated output is byte-for-byte identical.

**Related issue(s)**
Resolves #1913

**AI assistance**
- [x] This PR was created with AI assistance — `Generated-by: Claude Code (Opus 4.8)`
- [ ] No AI assistance was used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal template string handling to improve code generation for error and message logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->