### PR TITLE
fix: added RegisterOutgoingProcessor to websocket client for dart

### DIFF
--- a/packages/templates/clients/websocket/dart/components/ClientClass.js
+++ b/packages/templates/clients/websocket/dart/components/ClientClass.js
@@ -4,7 +4,7 @@ import { SendEchoMessage } from './SendEchoMessage';
 import { CloseConnection, RegisterMessageHandler, RegisterErrorHandler, Connect, HandleMessage } from '@asyncapi/generator-components';
 import { ClientFields } from './ClientFields';
 import { HandleError } from './HandleError';
-
+import { RegisterOutgoingProcessor } from './RegisterOutgoingProcessor';
 export function ClientClass({ clientName, serverUrl, title }) {
   return (
     <Text>
@@ -22,6 +22,7 @@ export function ClientClass({ clientName, serverUrl, title }) {
         language="dart"
         methodParams={['void Function(Object) handler']}
       />
+      <RegisterOutgoingProcessor /> 
       <HandleMessage
         language="dart" 
         methodName="_handleMessage"

--- a/packages/templates/clients/websocket/dart/components/ClientFields.js
+++ b/packages/templates/clients/websocket/dart/components/ClientFields.js
@@ -6,7 +6,8 @@ export function ClientFields() {
       {`final String _url;
 WebSocketChannel? _channel;
 final List<void Function(String)> _messageHandlers = [];
-final List<void Function(Object)> _errorHandlers = [];`}
+final List<void Function(Object)> _errorHandlers = [];
+final List<Function> _outgoingProcessors = [];`}
     </Text>
   );
 }

--- a/packages/templates/clients/websocket/dart/components/RegisterOutgoingProcessor.js
+++ b/packages/templates/clients/websocket/dart/components/RegisterOutgoingProcessor.js
@@ -1,0 +1,14 @@
+import { Text } from '@asyncapi/generator-react-sdk';
+
+export function RegisterOutgoingProcessor() {
+  return (
+    <Text newLines={2} indent={2}>
+      {`
+/// Register a function that processes outgoing messages automatically.
+void registerOutgoingProcessor(Function processor) {
+  _outgoingProcessors.add(processor);
+}
+      `}
+    </Text>
+  );
+}

--- a/packages/templates/clients/websocket/dart/components/SendEchoMessage.js
+++ b/packages/templates/clients/websocket/dart/components/SendEchoMessage.js
@@ -10,7 +10,14 @@ void sendEchoMessage(dynamic message) {
     print('Error: WebSocket is not connected.');
     return;
   }
-  final payload = message is String ? message : jsonEncode(message);
+  
+  // Run all outgoing processors sequentially
+  for (var processor in _outgoingProcessors) {
+      processedMessage = processor(message);
+  }
+
+
+  final payload = processedMessage is String ? processedMessage : jsonEncode(processedMessage);
   _channel!.sink.add(payload);
   print('Sent message to echo server: $payload');
 }`

--- a/packages/templates/clients/websocket/dart/components/SendEchoMessage.js
+++ b/packages/templates/clients/websocket/dart/components/SendEchoMessage.js
@@ -13,7 +13,7 @@ void sendEchoMessage(dynamic message) {
   
   // Run all outgoing processors sequentially
   for (var processor in _outgoingProcessors) {
-      processedMessage = processor(message);
+      processedMessage = processor(processedMessage);
   }
 
 

--- a/packages/templates/clients/websocket/test/integration-test/__snapshots__/integration.test.js.dart.snap
+++ b/packages/templates/clients/websocket/test/integration-test/__snapshots__/integration.test.js.dart.snap
@@ -17,6 +17,7 @@ class HoppscotchClient {
   WebSocketChannel? _channel;
   final List<void Function(String)> _messageHandlers = [];
   final List<void Function(Object)> _errorHandlers = [];
+  final List<Function> _outgoingProcessors = [];
 
   /// Constructor to initialize the WebSocket client
   /// 
@@ -73,6 +74,12 @@ class HoppscotchClient {
     _errorHandlers.add(handler);
   }
 
+  /// Register a function that processes outgoing messages automatically.
+  void registerOutgoingProcessor(Function processor) {
+    _outgoingProcessors.add(processor);
+  }
+      
+
   /// Method to handle message with callback
   void _handleMessage(dynamic message, void Function(String) cb) {
     cb(message is String ? message : message.toString());
@@ -96,7 +103,14 @@ class HoppscotchClient {
       print('Error: WebSocket is not connected.');
       return;
     }
-    final payload = message is String ? message : jsonEncode(message);
+  
+    // Run all outgoing processors sequentially
+    for (var processor in _outgoingProcessors) {
+        processedMessage = processor(message);
+    }
+
+
+    final payload = processedMessage is String ? processedMessage : jsonEncode(processedMessage);
     _channel!.sink.add(payload);
     print('Sent message to echo server: $payload');
   }
@@ -138,6 +152,7 @@ class HoppscotchEchoWebSocketClient {
   WebSocketChannel? _channel;
   final List<void Function(String)> _messageHandlers = [];
   final List<void Function(Object)> _errorHandlers = [];
+  final List<Function> _outgoingProcessors = [];
 
   /// Constructor to initialize the WebSocket client
   /// 
@@ -194,6 +209,12 @@ class HoppscotchEchoWebSocketClient {
     _errorHandlers.add(handler);
   }
 
+  /// Register a function that processes outgoing messages automatically.
+  void registerOutgoingProcessor(Function processor) {
+    _outgoingProcessors.add(processor);
+  }
+      
+
   /// Method to handle message with callback
   void _handleMessage(dynamic message, void Function(String) cb) {
     cb(message is String ? message : message.toString());
@@ -217,7 +238,14 @@ class HoppscotchEchoWebSocketClient {
       print('Error: WebSocket is not connected.');
       return;
     }
-    final payload = message is String ? message : jsonEncode(message);
+  
+    // Run all outgoing processors sequentially
+    for (var processor in _outgoingProcessors) {
+        processedMessage = processor(message);
+    }
+
+
+    final payload = processedMessage is String ? processedMessage : jsonEncode(processedMessage);
     _channel!.sink.add(payload);
     print('Sent message to echo server: $payload');
   }
@@ -260,6 +288,7 @@ class PostmanEchoWebSocketClientClient {
   WebSocketChannel? _channel;
   final List<void Function(String)> _messageHandlers = [];
   final List<void Function(Object)> _errorHandlers = [];
+  final List<Function> _outgoingProcessors = [];
 
   /// Constructor to initialize the WebSocket client
   /// 
@@ -316,6 +345,12 @@ class PostmanEchoWebSocketClientClient {
     _errorHandlers.add(handler);
   }
 
+  /// Register a function that processes outgoing messages automatically.
+  void registerOutgoingProcessor(Function processor) {
+    _outgoingProcessors.add(processor);
+  }
+      
+
   /// Method to handle message with callback
   void _handleMessage(dynamic message, void Function(String) cb) {
     cb(message is String ? message : message.toString());
@@ -339,7 +374,14 @@ class PostmanEchoWebSocketClientClient {
       print('Error: WebSocket is not connected.');
       return;
     }
-    final payload = message is String ? message : jsonEncode(message);
+  
+    // Run all outgoing processors sequentially
+    for (var processor in _outgoingProcessors) {
+        processedMessage = processor(message);
+    }
+
+
+    final payload = processedMessage is String ? processedMessage : jsonEncode(processedMessage);
     _channel!.sink.add(payload);
     print('Sent message to echo server: $payload');
   }


### PR DESCRIPTION
This PR implements the `registerOutgoingProcessor` feature for the Dart WebSocket client.

With this addition, users can now register custom middleware functions to intercept and process messages right before they are sent to the WebSocket server. This is highly useful for adding logging, attaching auth tokens, or modifying the payload globally before dispatch.

## Example usage:

```dart
// Users can now register a function to run before a message is sent
client.registerOutgoingProcessor((message) {
  print('Logging outgoing message: $message');
  // You can also modify the payload or add headers here
});
```

## Implementation details:

- **Created `RegisterOutgoingProcessor.js`**: Added this new component to take a function and append it to an `_outgoingProcessors` list.

- **Updated `ClientFields.js`**: Declared the `_outgoingProcessors` list here to match the existing pattern used for `_messageHandlers` and `_errorHandlers`.

- **Updated `ClientClass.js`**: Rendered the new component alongside the other handler components.

- **Updated `SendEchoMessage.js`**: Added a `for` loop right before the payload is sent to the server. This ensures the message is processed by all registered outgoing functions before it is dispatched.

## Related issue(s)

Fixes #1976

## AI assistance

- [x] This PR Description Markdown and Paraphrasing was done with AI assistance — `Generated-by: Google Gemini,chatgpt`
- [ ] No AI assistance was used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for registering outgoing message processors in generated WebSocket Dart clients.
  * Outgoing messages can now be transformed before being sent via registered processors.

* **Bug Fixes**
  * Improved generated client wiring to ensure outgoing message processing is included alongside existing connection lifecycle and message/error handling.
  * Outgoing payload generation now reflects the final processed message (including sequential processor updates).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->