### PR TITLE
feat: add query parameters support to Dart WebSocket client

### DIFF
--- a/.changeset/dart-query-params.md
+++ b/.changeset/dart-query-params.md
@@ -1,0 +1,6 @@
+---
+"@asyncapi/generator": minor
+"@asyncapi/generator-components": minor
+---
+
+Add query parameters support to the Dart WebSocket client template and add Dart language config to the shared QueryParamsVariables component.

--- a/packages/components/src/components/QueryParamsVariables.js
+++ b/packages/components/src/components/QueryParamsVariables.js
@@ -3,7 +3,7 @@ import { toCamelCase } from '@asyncapi/generator-helpers';
 import { unsupportedLanguage } from '../utils/ErrorHandling';
 
 /**
- * @typedef {'python' | 'java' | 'javascript'} Language
+ * @typedef {'python' | 'java' | 'javascript' | 'dart'} Language
  * Supported programming languages for query parameter generation.
  */
 
@@ -82,6 +82,30 @@ const queryParamLogicConfig = {
       closing: {
         text: '}',
         indent: 8,
+        newLines: 1,
+      },
+    };
+  },
+  dart: (param) => {
+    const paramName = toCamelCase(param[0]);
+    const capitalizedName = paramName[0].toUpperCase() + paramName.slice(1);
+    const envKey = param[0].toUpperCase();
+    return {
+      variableDefinition: {
+        text: `final resolved${capitalizedName} = ${paramName} ?? Platform.environment['${envKey}'];`,
+        indent: 6,
+      },
+      ifCondition: {
+        text: `if (resolved${capitalizedName} != null) {`,
+        indent: 6,
+      },
+      assignment: {
+        text: `params['${param[0]}'] = resolved${capitalizedName};`,
+        indent: 8,
+      },
+      closing: {
+        text: '}',
+        indent: 6,
         newLines: 1,
       },
     };

--- a/packages/components/test/components/QueryParamsVariables.test.js
+++ b/packages/components/test/components/QueryParamsVariables.test.js
@@ -55,6 +55,19 @@ describe('Testing of QueryParamsVariables component', () => {
     expect(result.trim()).toMatchSnapshot();
   });
 
+  test('renders dart query params correctly with query parameters', () => {
+    const channels = parsedAsyncAPIDocument.channels();
+    const queryParamsObject = getQueryParams(channels);
+    const queryParamsArray = queryParamsObject ? Array.from(queryParamsObject.entries()) : [];
+    const result = render(
+      <QueryParamsVariables 
+        language='dart' 
+        queryParams={queryParamsArray} 
+      />
+    );
+    expect(result.trim()).toMatchSnapshot();
+  });
+
   test('renders python nothing when queryParams is null', () => {
     const result = render(<QueryParamsVariables language='python' queryParams={null} />);
     expect(result.trim()).toMatchSnapshot();

--- a/packages/components/test/components/__snapshots__/QueryParamsVariables.test.js.snap
+++ b/packages/components/test/components/__snapshots__/QueryParamsVariables.test.js.snap
@@ -6,6 +6,25 @@ exports[`Testing of QueryParamsVariables component ignores framework for python 
           params[\\"token\\"] = token"
 `;
 
+exports[`Testing of QueryParamsVariables component renders dart query params correctly with query parameters 1`] = `
+"final resolvedHeartbeat = heartbeat ?? Platform.environment['HEARTBEAT'];
+      if (resolvedHeartbeat != null) {
+        params['heartbeat'] = resolvedHeartbeat;
+      }
+      final resolvedTopOfBook = topOfBook ?? Platform.environment['TOP_OF_BOOK'];
+      if (resolvedTopOfBook != null) {
+        params['top_of_book'] = resolvedTopOfBook;
+      }
+      final resolvedBids = bids ?? Platform.environment['BIDS'];
+      if (resolvedBids != null) {
+        params['bids'] = resolvedBids;
+      }
+      final resolvedOffers = offers ?? Platform.environment['OFFERS'];
+      if (resolvedOffers != null) {
+        params['offers'] = resolvedOffers;
+      }"
+`;
+
 exports[`Testing of QueryParamsVariables component renders java quarkus nothing when queryParams is an empty array 1`] = `""`;
 
 exports[`Testing of QueryParamsVariables component renders java quarkus query params correctly with query parameters 1`] = `

--- a/packages/templates/clients/websocket/dart/components/ClientClass.js
+++ b/packages/templates/clients/websocket/dart/components/ClientClass.js
@@ -3,14 +3,14 @@ import { Constructor } from './Constructor';
 import { CloseConnection, RegisterMessageHandler, RegisterErrorHandler, SendOperations, Connect, HandleMessage, HandleError } from '@asyncapi/generator-components';
 import { ClientFields } from './ClientFields';
 
-export function ClientClass({ clientName, serverUrl, title, sendOperations }) {
+export function ClientClass({ clientName, serverUrl, title, sendOperations, query }) {
   return (
     <Text>
       <Text newLines={2}>
         {`class ${clientName} {`}
       </Text>
       <ClientFields />
-      <Constructor clientName={clientName} serverUrl={serverUrl} />
+      <Constructor clientName={clientName} serverUrl={serverUrl} query={query} />
       <Connect language="dart" title={title} />
       <RegisterMessageHandler 
         language="dart" 

--- a/packages/templates/clients/websocket/dart/components/ClientFields.js
+++ b/packages/templates/clients/websocket/dart/components/ClientFields.js
@@ -3,7 +3,7 @@ import { Text } from '@asyncapi/generator-react-sdk';
 export function ClientFields() {
   return (
     <Text indent={2} newLines={2}>
-      {`final String _url;
+      {`late String _url;
 WebSocketChannel? _channel;
 final List<void Function(String)> _messageHandlers = [];
 final List<void Function(Object)> _errorHandlers = [];`}

--- a/packages/templates/clients/websocket/dart/components/Constructor.js
+++ b/packages/templates/clients/websocket/dart/components/Constructor.js
@@ -1,16 +1,61 @@
 import { Text } from '@asyncapi/generator-react-sdk';
+import { QueryParamsVariables } from '@asyncapi/generator-components';
+import { toCamelCase } from '@asyncapi/generator-helpers';
 
-export function Constructor({ clientName, serverUrl }) {
-  return (
-    <Text newLines={2} indent={2}>
-      {
-        `
+export function Constructor({ clientName, serverUrl, query }) {
+  const queryParamsArray = query && Array.from(query.entries());
+
+  if (!queryParamsArray || queryParamsArray.length === 0) {
+    return (
+      <Text newLines={2} indent={2}>
+        {`
 /// Constructor to initialize the WebSocket client
 /// 
 /// [url] - The WebSocket server URL. Use it if the server URL is different from the default one taken from the AsyncAPI document.
 ${clientName}({String? url})
   : _url = url ?? '${serverUrl}';
 `}
-    </Text>
+      </Text>
+    );
+  }
+
+  const queryParamsSignature = queryParamsArray.map((param) => {
+    const paramName = toCamelCase(param[0]);
+    const paramDefaultValue = param[1];
+    const defaultValue = paramDefaultValue ? `'${paramDefaultValue}'` : 'null';
+    return `String? ${paramName} = ${defaultValue}`;
+  }).join(', ');
+
+  const queryParamsDocs = queryParamsArray.map((param) => {
+    const paramName = toCamelCase(param[0]);
+    return `/// [${paramName}] - If provided (or if ${param[0].toUpperCase()} environment variable is set), added as ?${param[0]}=… to URL`;
+  }).join('\n');
+
+  return (
+    <>
+      <Text indent={2} newLines={2}>
+        {`
+/// Constructor to initialize the WebSocket client
+/// 
+/// [url] - The WebSocket server URL. Use it if the server URL is different from the default one taken from the AsyncAPI document.
+${queryParamsDocs}
+${clientName}({String? url, ${queryParamsSignature}}) {
+    _url = url ?? '${serverUrl}';
+    final params = <String, String>{};`}
+      </Text>
+      <QueryParamsVariables
+        language="dart"
+        queryParams={queryParamsArray}
+      />
+      <Text indent={6} newLines={2}>
+        {`if (params.isNotEmpty) {
+        final qs = params.entries.map((e) => '\${Uri.encodeComponent(e.key)}=\${Uri.encodeComponent(e.value)}').join('&');
+        _url = '\${_url}\${_url.contains('?') ? '&' : '?'}\$qs';
+      }`}
+      </Text>
+      <Text indent={2}>
+        {'}'}
+      </Text>
+    </>
   );
 }

--- a/packages/templates/clients/websocket/dart/components/Constructor.js
+++ b/packages/templates/clients/websocket/dart/components/Constructor.js
@@ -22,7 +22,9 @@ ${clientName}({String? url})
   const queryParamsSignature = queryParamsArray.map((param) => {
     const paramName = toCamelCase(param[0]);
     const paramDefaultValue = param[1];
-    const defaultValue = paramDefaultValue ? `'${paramDefaultValue}'` : 'null';
+    const defaultValue = paramDefaultValue !== null
+      ? `'${String(paramDefaultValue).replace(/'/g, '\\\'')}'`
+      : 'null';
     return `String? ${paramName} = ${defaultValue}`;
   }).join(', ');
 

--- a/packages/templates/clients/websocket/dart/template/client.dart.js
+++ b/packages/templates/clients/websocket/dart/template/client.dart.js
@@ -1,5 +1,5 @@
 import { File } from '@asyncapi/generator-react-sdk';
-import { getClientName, getServerUrl, getServer, getInfo, getTitle } from '@asyncapi/generator-helpers';
+import { getClientName, getServerUrl, getServer, getInfo, getTitle, getQueryParams } from '@asyncapi/generator-helpers';
 import { FileHeaderInfo, DependencyProvider } from '@asyncapi/generator-components';
 import { ClientClass } from '../components/ClientClass';
 
@@ -10,6 +10,8 @@ export default function ({ asyncapi, params }) {
   const clientName = getClientName(asyncapi, params.appendClientSuffix, params.customClientName);
   const serverUrl = getServerUrl(server);
   const sendOperations = asyncapi.operations().filterBySend();
+  const queryParams = getQueryParams(asyncapi.channels());
+  const additionalDependencies = queryParams ? ["import 'dart:io';"] : [];
   return (  
     // The clientFileName default values can be found and modified under the package.json
     <File name={params.clientFileName}>
@@ -18,8 +20,8 @@ export default function ({ asyncapi, params }) {
         server={server}
         language="dart"
       />
-      <DependencyProvider language="dart" />
-      <ClientClass clientName={clientName} serverUrl={serverUrl} title={title} sendOperations={sendOperations} />
+      <DependencyProvider language="dart" additionalDependencies={additionalDependencies} />
+      <ClientClass clientName={clientName} serverUrl={serverUrl} title={title} sendOperations={sendOperations} query={queryParams} />
     </File>
   );
 }

--- a/packages/templates/clients/websocket/dart/template/client.dart.js
+++ b/packages/templates/clients/websocket/dart/template/client.dart.js
@@ -11,7 +11,7 @@ export default function ({ asyncapi, params }) {
   const serverUrl = getServerUrl(server);
   const sendOperations = asyncapi.operations().filterBySend();
   const queryParams = getQueryParams(asyncapi.channels());
-  const additionalDependencies = queryParams ? ["import 'dart:io';"] : [];
+  const additionalDependencies = queryParams ? ['import \'dart:io\';'] : [];
   return (  
     // The clientFileName default values can be found and modified under the package.json
     <File name={params.clientFileName}>

--- a/packages/templates/clients/websocket/test/integration-test/__snapshots__/integration.test.js.dart.snap
+++ b/packages/templates/clients/websocket/test/integration-test/__snapshots__/integration.test.js.dart.snap
@@ -13,7 +13,7 @@ import 'dart:convert';
 import 'package:web_socket_channel/web_socket_channel.dart';
 class HoppscotchClient {
 
-  final String _url;
+  late String _url;
   WebSocketChannel? _channel;
   final List<void Function(String)> _messageHandlers = [];
   final List<void Function(Object)> _errorHandlers = [];
@@ -134,7 +134,7 @@ import 'dart:convert';
 import 'package:web_socket_channel/web_socket_channel.dart';
 class HoppscotchEchoWebSocketClient {
 
-  final String _url;
+  late String _url;
   WebSocketChannel? _channel;
   final List<void Function(String)> _messageHandlers = [];
   final List<void Function(Object)> _errorHandlers = [];
@@ -256,7 +256,7 @@ import 'dart:convert';
 import 'package:web_socket_channel/web_socket_channel.dart';
 class PostmanEchoWebSocketClientClient {
 
-  final String _url;
+  late String _url;
   WebSocketChannel? _channel;
   final List<void Function(String)> _messageHandlers = [];
   final List<void Function(Object)> _errorHandlers = [];


### PR DESCRIPTION
Adds query parameter support to the Dart WebSocket client template, bringing it
in line with the JavaScript, Python, and Java/Quarkus clients that already handle
query params.

When an AsyncAPI document defines query parameters on a WebSocket channel, the
generated Dart client now:

1. Accepts optional named constructor parameters (with defaults from the spec)
2. Resolves each param at runtime via the constructor argument or the corresponding
   environment variable (`Platform.environment`)
3. Appends non-null params to the server URL as a query string

Fixes #1958 
Generated-by: Claude Opus 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Dart WebSocket clients now support URL query parameters derived from the AsyncAPI document.
  * Generated Dart clients can accept optional query values and automatically append an encoded query string to the connection URL.

* **Bug Fixes**
  * Query parameters are generated with correct initialization and encoding behavior.

* **Tests**
  * Added snapshot coverage for Dart query-parameter generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->