### PR TITLE
fix(hooks): bundle external $refs into emitted AsyncAPI document

### DIFF
--- a/.changeset/bundle-emitted-asyncapi.md
+++ b/.changeset/bundle-emitted-asyncapi.md
@@ -1,0 +1,6 @@
+---
+"@asyncapi/generator-hooks": patch
+"@asyncapi/generator": patch
+---
+
+The `generate:after` hook now writes a single self-contained (bundled) AsyncAPI document to each generated client's output directory, inlining external `$ref`s via `@asyncapi/bundler`. Previously the raw source was copied verbatim, leaving external refs (e.g. `./commons/servers.yml#/...`) unresolvable at client runtime and breaking schema compilation on the send path. When no source file path is available (string/URL input) or bundling fails, the hook falls back to writing the original source unchanged.

--- a/apps/generator/docs/api.md
+++ b/apps/generator/docs/api.md
@@ -42,7 +42,6 @@ Use name of returned templates as input for the `generate` method for template g
         * [.hooks](#Generator+hooks) : `Object`
         * [.mapBaseUrlToFolder](#Generator+mapBaseUrlToFolder) : `Object`
         * [.templateParams](#Generator+templateParams) : `Object`
-        * [.asyncapiFilePath](#Generator+asyncapiFilePath) : `String` \| `undefined`
         * [.generate(asyncapiDocument, [parseOptions])](#Generator+generate) ⇒ `Promise.<void>`
         * [.validateAsyncAPIDocument(asyncapiDocument)](#Generator+validateAsyncAPIDocument)
         * [.setupOutput()](#Generator+setupOutput)
@@ -51,7 +50,7 @@ Use name of returned templates as input for the `generate` method for template g
         * [.installAndSetupTemplate()](#Generator+installAndSetupTemplate) ⇒ `Promise.<{templatePkgName: string, templatePkgPath: string}>`
         * [.configureTemplateWorkflow(parseOptions)](#Generator+configureTemplateWorkflow) ⇒ `Promise.<void>`
         * [.handleEntrypoint()](#Generator+handleEntrypoint) ⇒ `Promise.<void>`
-        * [.executeAfterHook()](#Generator+executeAfterHook) ⇒ `Promise.<void>`
+        * [.executeAfterHook([parseOptions])](#Generator+executeAfterHook) ⇒ `Promise.<void>`
         * [.parseInput()](#Generator+parseInput)
         * [.configureTemplate()](#Generator+configureTemplate)
         * [.generateFromURL(asyncapiURL)](#Generator+generateFromURL) ⇒ `Promise.<(TemplateRenderResult|undefined)>`
@@ -206,13 +205,6 @@ The template parameters. The structure for this object is based on each individu
 
 **Kind**: instance property of [`Generator`](#Generator)  
 
-<a name="Generator+asyncapiFilePath"></a>
-
-* generator.asyncapiFilePath : `String` \| `undefined`** :
-Filesystem path of the source AsyncAPI document, exposed to hooks so they can resolve external $refs. Undefined for string/URL input.
-
-**Kind**: instance property of [`Generator`](#Generator)  
-
 <a name="Generator+generate"></a>
 
 ### generator.generate
@@ -355,13 +347,17 @@ If no entrypoint is specified, generates the directory structure.
 
 <a name="Generator+executeAfterHook"></a>
 
-* generator.executeAfterHook() ⇒ `Promise.<void>`** :
+### generator.executeAfterHook
 Executes the 'generate:after' hook.
 
 Launches the after-hook to perform additional actions after code generation.
 
 **Kind**: instance method of [`Generator`](#Generator)  
 **Returns**: `Promise.<void>` - A promise that resolves when the after-hook execution is completed.  
+**Params**
+
+- [parseOptions] `Object` ` = {}` - AsyncAPI Parser parse options; its `path` is passed to the hook so it can resolve external $refs.
+
 
 <a name="Generator+parseInput"></a>
 

--- a/apps/generator/docs/api.md
+++ b/apps/generator/docs/api.md
@@ -42,6 +42,7 @@ Use name of returned templates as input for the `generate` method for template g
         * [.hooks](#Generator+hooks) : `Object`
         * [.mapBaseUrlToFolder](#Generator+mapBaseUrlToFolder) : `Object`
         * [.templateParams](#Generator+templateParams) : `Object`
+        * [.asyncapiFilePath](#Generator+asyncapiFilePath) : `String` \| `undefined`
         * [.generate(asyncapiDocument, [parseOptions])](#Generator+generate) ⇒ `Promise.<void>`
         * [.validateAsyncAPIDocument(asyncapiDocument)](#Generator+validateAsyncAPIDocument)
         * [.setupOutput()](#Generator+setupOutput)
@@ -202,6 +203,13 @@ Maps schema URL to folder.
 
 * generator.templateParams : `Object`** :
 The template parameters. The structure for this object is based on each individual template.
+
+**Kind**: instance property of [`Generator`](#Generator)  
+
+<a name="Generator+asyncapiFilePath"></a>
+
+* generator.asyncapiFilePath : `String` \| `undefined`** :
+Filesystem path of the source AsyncAPI document, exposed to hooks so they can resolve external $refs. Undefined for string/URL input.
 
 **Kind**: instance property of [`Generator`](#Generator)  
 

--- a/apps/generator/lib/generator.js
+++ b/apps/generator/lib/generator.js
@@ -188,7 +188,8 @@ class Generator {
    */
   async generate(asyncapiDocument, parseOptions = {}) {
     this.validateAsyncAPIDocument(asyncapiDocument);
-    this.asyncapiFilePath = parseOptions.path; // expose source path to hooks (undefined for string input)
+    /** @type {String|undefined} Filesystem path of the source AsyncAPI document, exposed to hooks so they can resolve external $refs. Undefined for string/URL input. */
+    this.asyncapiFilePath = parseOptions.path;
     await this.setupOutput();
     this.setLogLevel();
 

--- a/apps/generator/lib/generator.js
+++ b/apps/generator/lib/generator.js
@@ -188,15 +188,13 @@ class Generator {
    */
   async generate(asyncapiDocument, parseOptions = {}) {
     this.validateAsyncAPIDocument(asyncapiDocument);
-    /** @type {String|undefined} Filesystem path of the source AsyncAPI document, exposed to hooks so they can resolve external $refs. Undefined for string/URL input. */
-    this.asyncapiFilePath = parseOptions.path;
     await this.setupOutput();
     this.setLogLevel();
 
     await this.installAndSetupTemplate();
     await this.configureTemplateWorkflow(parseOptions);
     await this.handleEntrypoint();
-    await this.executeAfterHook();
+    await this.executeAfterHook(parseOptions);
   }
 
   /**
@@ -363,10 +361,11 @@ class Generator {
    * Launches the after-hook to perform additional actions after code generation.
    *
    * @async
+   * @param {Object} [parseOptions={}] - AsyncAPI Parser parse options; its `path` is passed to the hook so it can resolve external $refs.
    * @returns {Promise<void>} A promise that resolves when the after-hook execution is completed.
    */
-  async executeAfterHook() {
-    await this.launchHook('generate:after');
+  async executeAfterHook(parseOptions = {}) {
+    await this.launchHook('generate:after', { asyncapiFilePath: parseOptions.path });
   }
 
   /**

--- a/apps/generator/lib/generator.js
+++ b/apps/generator/lib/generator.js
@@ -188,6 +188,7 @@ class Generator {
    */
   async generate(asyncapiDocument, parseOptions = {}) {
     this.validateAsyncAPIDocument(asyncapiDocument);
+    this.asyncapiFilePath = parseOptions.path; // expose source path to hooks (undefined for string input)
     await this.setupOutput();
     this.setLogLevel();
 

--- a/apps/hooks/package.json
+++ b/apps/hooks/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/asyncapi/generator-hooks#readme",
   "dependencies": {
+    "@asyncapi/bundler": "^0.6.4",
     "fs.extra": "^1.3.2"
   },
   "devDependencies": {

--- a/apps/hooks/src/index.js
+++ b/apps/hooks/src/index.js
@@ -3,11 +3,11 @@ const path = require('path');
 const xfs = require('fs.extra');
 const bundle = require('@asyncapi/bundler');
 
-async function createAsyncapiFile(generator) {
+async function createAsyncapiFile(generator, { asyncapiFilePath } = {}) {
   const asyncapi = generator.originalAsyncAPI;
   const targetDir = generator.targetDir;
   const customDirInTarget = generator.templateParams.asyncapiFileDir;
-  const sourceFilePath = generator.asyncapiFilePath;
+  const sourceFilePath = asyncapiFilePath;
   const getCustomFileLocation = (target, dir, filename) => {
     xfs.mkdirpSync(path.resolve(target, dir));
     return path.resolve(target, dir, filename);

--- a/apps/hooks/src/index.js
+++ b/apps/hooks/src/index.js
@@ -3,58 +3,42 @@ const path = require('path');
 const xfs = require('fs.extra');
 const bundle = require('@asyncapi/bundler');
 
-function detectExtension(source) {
-  try {
-    JSON.parse(source);
-    return 'json';
-  } catch (e) {
-    return 'yaml';
-  }
-}
-
-function resolveOutputLocation(targetDir, customDirInTarget, outputFileName) {
-  if (customDirInTarget) {
-    xfs.mkdirpSync(path.resolve(targetDir, customDirInTarget));
-    return path.resolve(targetDir, customDirInTarget, outputFileName);
-  }
-  return path.resolve(targetDir, outputFileName);
-}
-
-/**
- * 'generate:after' hook.
- *
- * Writes a single self-contained AsyncAPI document next to the generated client
- * so external $refs are resolvable at runtime (e.g. by @asyncapi/keeper). When a
- * source file path is available on disk it bundles the document (inlining
- * external $refs) via @asyncapi/bundler; otherwise (string/URL input, or a
- * bundling failure) it falls back to writing the original source verbatim.
- *
- * @param {object} generator - The AsyncAPI Generator instance.
- * @returns {Promise<void>}
- */
 async function createAsyncapiFile(generator) {
-  const originalAsyncAPI = generator.originalAsyncAPI;
+  const asyncapi = generator.originalAsyncAPI;
   const targetDir = generator.targetDir;
   const customDirInTarget = generator.templateParams.asyncapiFileDir;
   const sourceFilePath = generator.asyncapiFilePath;
+  const getCustomFileLocation = (target, dir, filename) => {
+    xfs.mkdirpSync(path.resolve(target, dir));
+    return path.resolve(target, dir, filename);
+  };
+  let extension;
 
-  const extension = detectExtension(originalAsyncAPI);
+  try {
+    JSON.parse(asyncapi);
+    extension = 'json';
+  } catch (e) {
+    extension = 'yaml';
+  }
+
   const outputFileName = `asyncapi.${extension}`;
-  const asyncapiOutputLocation = resolveOutputLocation(targetDir, customDirInTarget, outputFileName);
 
-  let output = originalAsyncAPI;
+  const asyncapiOutputLocation = customDirInTarget
+    ? getCustomFileLocation(targetDir, customDirInTarget, outputFileName)
+    : path.resolve(targetDir, outputFileName);
+
+  let output = asyncapi;
 
   // Bundle only when the source lives on disk, so relative external $refs
-  // (e.g. ./commons/servers.yml) resolve against the document's own location.
-  if (typeof sourceFilePath === 'string' && sourceFilePath && fs.existsSync(sourceFilePath)) {
+  // (e.g. ./commons/servers.yml) resolve against the document's own directory
+  // instead of the current working directory. String/URL input or a bundling
+  // failure falls back to writing the original source verbatim.
+  if (sourceFilePath && fs.existsSync(sourceFilePath)) {
     try {
-      // baseDir is required so the document's relative external $refs resolve
-      // against its own directory rather than the current working directory.
       const bundled = await bundle([sourceFilePath], { baseDir: path.dirname(sourceFilePath) });
       output = bundled.yml();
     } catch (err) {
       console.warn(`[generator-hooks] Failed to bundle AsyncAPI document, writing original source verbatim: ${err.message}`);
-      output = originalAsyncAPI;
     }
   }
 

--- a/apps/hooks/src/index.js
+++ b/apps/hooks/src/index.js
@@ -1,31 +1,64 @@
 const fs = require('fs');
 const path = require('path');
 const xfs = require('fs.extra');
+const bundle = require('@asyncapi/bundler');
 
-function createAsyncapiFile(generator) {
-  const asyncapi = generator.originalAsyncAPI;
+function detectExtension(source) {
+  try {
+    JSON.parse(source);
+    return 'json';
+  } catch (e) {
+    return 'yaml';
+  }
+}
+
+function resolveOutputLocation(targetDir, customDirInTarget, outputFileName) {
+  if (customDirInTarget) {
+    xfs.mkdirpSync(path.resolve(targetDir, customDirInTarget));
+    return path.resolve(targetDir, customDirInTarget, outputFileName);
+  }
+  return path.resolve(targetDir, outputFileName);
+}
+
+/**
+ * 'generate:after' hook.
+ *
+ * Writes a single self-contained AsyncAPI document next to the generated client
+ * so external $refs are resolvable at runtime (e.g. by @asyncapi/keeper). When a
+ * source file path is available on disk it bundles the document (inlining
+ * external $refs) via @asyncapi/bundler; otherwise (string/URL input, or a
+ * bundling failure) it falls back to writing the original source verbatim.
+ *
+ * @param {object} generator - The AsyncAPI Generator instance.
+ * @returns {Promise<void>}
+ */
+async function createAsyncapiFile(generator) {
+  const originalAsyncAPI = generator.originalAsyncAPI;
   const targetDir = generator.targetDir;
   const customDirInTarget = generator.templateParams.asyncapiFileDir;
-  const getCustomFileLocation = (target, dir, filename) => {
-    xfs.mkdirpSync(path.resolve(target, dir)); 
-    return path.resolve(target, dir, filename); 
-  };
-  let extension;
-  
-  try {
-    JSON.parse(asyncapi);
-    extension = 'json';
-  } catch (e) {
-    extension = 'yaml';
+  const sourceFilePath = generator.asyncapiFilePath;
+
+  const extension = detectExtension(originalAsyncAPI);
+  const outputFileName = `asyncapi.${extension}`;
+  const asyncapiOutputLocation = resolveOutputLocation(targetDir, customDirInTarget, outputFileName);
+
+  let output = originalAsyncAPI;
+
+  // Bundle only when the source lives on disk, so relative external $refs
+  // (e.g. ./commons/servers.yml) resolve against the document's own location.
+  if (typeof sourceFilePath === 'string' && sourceFilePath && fs.existsSync(sourceFilePath)) {
+    try {
+      // baseDir is required so the document's relative external $refs resolve
+      // against its own directory rather than the current working directory.
+      const bundled = await bundle([sourceFilePath], { baseDir: path.dirname(sourceFilePath) });
+      output = bundled.yml();
+    } catch (err) {
+      console.warn(`[generator-hooks] Failed to bundle AsyncAPI document, writing original source verbatim: ${err.message}`);
+      output = originalAsyncAPI;
+    }
   }
 
-  const outputFileName = `asyncapi.${extension}`;
-
-  const asyncapiOutputLocation = customDirInTarget 
-    ? getCustomFileLocation(targetDir, customDirInTarget, outputFileName)
-    : path.resolve(targetDir, outputFileName);
-
-  fs.writeFileSync(asyncapiOutputLocation, asyncapi);
+  fs.writeFileSync(asyncapiOutputLocation, output);
 }
 
 module.exports = {

--- a/apps/hooks/test/__fixtures__/asyncapi-with-refs.yml
+++ b/apps/hooks/test/__fixtures__/asyncapi-with-refs.yml
@@ -1,0 +1,15 @@
+asyncapi: 3.0.0
+info:
+  title: Refs example
+  version: 1.0.0
+servers:
+  echoServer:
+    $ref: './commons/servers.yml#/servers/echoServer'
+channels:
+  echo:
+    $ref: './commons/channels.yml#/channels/echo'
+operations:
+  sendEcho:
+    action: send
+    channel:
+      $ref: '#/channels/echo'

--- a/apps/hooks/test/__fixtures__/commons/channels.yml
+++ b/apps/hooks/test/__fixtures__/commons/channels.yml
@@ -1,0 +1,6 @@
+channels:
+  echo:
+    address: /
+    messages:
+      echo:
+        $ref: '../commons/messages.yml#/messages/echo'

--- a/apps/hooks/test/__fixtures__/commons/messages.yml
+++ b/apps/hooks/test/__fixtures__/commons/messages.yml
@@ -1,0 +1,4 @@
+messages:
+  echo:
+    payload:
+      type: string

--- a/apps/hooks/test/__fixtures__/commons/servers.yml
+++ b/apps/hooks/test/__fixtures__/commons/servers.yml
@@ -1,0 +1,4 @@
+servers:
+  echoServer:
+    host: echo.example.org
+    protocol: ws

--- a/apps/hooks/test/index.test.js
+++ b/apps/hooks/test/index.test.js
@@ -35,7 +35,7 @@ describe('createAsyncapiFile', () => {
       targetDir: testResultPath,
       templateParams: {}
     };
-    createAsyncapiFile(gen);
+    await createAsyncapiFile(gen);
     const outputFile = path.join(testResultPath, outputFileName);
     const checkOutputFileExists = await stat(outputFile);
     expect(checkOutputFileExists.isFile()).toBeTruthy();
@@ -50,7 +50,7 @@ describe('createAsyncapiFile', () => {
       targetDir: testResultPath,
       templateParams: {}
     };
-    createAsyncapiFile(gen);
+    await createAsyncapiFile(gen);
     const outputFile = path.join(testResultPath, outputFileName);
     const checkOutputFileExists = await stat(outputFile);
     expect(checkOutputFileExists.isFile()).toBeTruthy();
@@ -69,10 +69,37 @@ describe('createAsyncapiFile', () => {
         asyncapiFileDir: customDir
       }
     };
-    createAsyncapiFile(gen);
+    await createAsyncapiFile(gen);
     const checkOutputFileExists = await stat(outputFilePath);
     expect(checkOutputFileExists.isFile()).toBeTruthy();
     const outputFileContent = await readFile(outputFilePath, 'utf8');
+    expect(outputFileContent).toBe(dummyYAML);
+  });
+
+  it('bundles external $refs into a self-contained document when a source path is available', async () => {
+    const sourcePath = path.resolve(__dirname, './__fixtures__/asyncapi-with-refs.yml');
+    const gen = {
+      originalAsyncAPI: await readFile(sourcePath, 'utf8'),
+      asyncapiFilePath: sourcePath,
+      targetDir: testResultPath,
+      templateParams: {}
+    };
+    await createAsyncapiFile(gen);
+    const outputFileContent = await readFile(path.join(testResultPath, 'asyncapi.yaml'), 'utf8');
+    // No external file refs survive; internal '#/...' refs are still allowed.
+    expect(outputFileContent).not.toMatch(/\.yml#/);
+    expect(outputFileContent).not.toMatch(/\$ref:\s*['"]?\.\.?\//);
+    expect(outputFileContent).toContain('channels:');
+  });
+
+  it('falls back to writing the original source verbatim when no source path is available', async () => {
+    const gen = {
+      originalAsyncAPI: dummyYAML,
+      targetDir: testResultPath,
+      templateParams: {}
+    };
+    await createAsyncapiFile(gen);
+    const outputFileContent = await readFile(path.join(testResultPath, 'asyncapi.yaml'), 'utf8');
     expect(outputFileContent).toBe(dummyYAML);
   });
 });

--- a/apps/hooks/test/index.test.js
+++ b/apps/hooks/test/index.test.js
@@ -18,6 +18,7 @@ const dummyJSON = JSON.stringify({
 }, null, 2);
 
 const testResultPath = path.resolve(__dirname, './temp');
+const asyncapiYamlFileName = 'asyncapi.yaml';
 
 describe('createAsyncapiFile', () => {
   /**
@@ -29,7 +30,7 @@ describe('createAsyncapiFile', () => {
   });
 
   it('creates a YAML file when the originalAsyncAPI is in YAML format', async () => {
-    const outputFileName = 'asyncapi.yaml';
+    const outputFileName = asyncapiYamlFileName;
     const gen = {
       originalAsyncAPI: dummyYAML,
       targetDir: testResultPath,
@@ -60,7 +61,7 @@ describe('createAsyncapiFile', () => {
 
   it('creates the file in a custom directory when asyncapiFileDir parameter is provided', async () => {
     const customDir = 'custom-test';
-    const outputFileName = 'asyncapi.yaml';
+    const outputFileName = asyncapiYamlFileName;
     const outputFilePath = path.join(testResultPath, customDir, outputFileName);
     const gen = {
       originalAsyncAPI: dummyYAML,
@@ -85,7 +86,7 @@ describe('createAsyncapiFile', () => {
       templateParams: {}
     };
     await createAsyncapiFile(gen);
-    const outputFileContent = await readFile(path.join(testResultPath, 'asyncapi.yaml'), 'utf8');
+    const outputFileContent = await readFile(path.join(testResultPath, asyncapiYamlFileName), 'utf8');
     // No external file refs survive; internal '#/...' refs are still allowed.
     expect(outputFileContent).not.toMatch(/\.yml#/);
     expect(outputFileContent).not.toMatch(/\$ref:\s*['"]?\.\.?\//);
@@ -99,7 +100,7 @@ describe('createAsyncapiFile', () => {
       templateParams: {}
     };
     await createAsyncapiFile(gen);
-    const outputFileContent = await readFile(path.join(testResultPath, 'asyncapi.yaml'), 'utf8');
+    const outputFileContent = await readFile(path.join(testResultPath, asyncapiYamlFileName), 'utf8');
     expect(outputFileContent).toBe(dummyYAML);
   });
 });

--- a/apps/hooks/test/index.test.js
+++ b/apps/hooks/test/index.test.js
@@ -81,11 +81,10 @@ describe('createAsyncapiFile', () => {
     const sourcePath = path.resolve(__dirname, './__fixtures__/asyncapi-with-refs.yml');
     const gen = {
       originalAsyncAPI: await readFile(sourcePath, 'utf8'),
-      asyncapiFilePath: sourcePath,
       targetDir: testResultPath,
       templateParams: {}
     };
-    await createAsyncapiFile(gen);
+    await createAsyncapiFile(gen, { asyncapiFilePath: sourcePath });
     const outputFileContent = await readFile(path.join(testResultPath, asyncapiYamlFileName), 'utf8');
     // No external file refs survive; internal '#/...' refs are still allowed.
     expect(outputFileContent).not.toMatch(/\.yml#/);

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@asyncapi/bundler": "^0.6.4",
         "fs.extra": "^1.3.2"
       },
       "devDependencies": {
@@ -81,6 +82,19 @@
         "jest": "^28.1.3",
         "jsdoc-to-markdown": "^7.1.1",
         "rimraf": "^3.0.2"
+      }
+    },
+    "apps/hooks/node_modules/@asyncapi/bundler": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@asyncapi/bundler/-/bundler-0.6.4.tgz",
+      "integrity": "sha512-lKZo2FF2TKt4n6Qm8vP/JOEEGE04gdH/D9oHmBt/NfOylMaw8XoFsI+k+IJyzpVMzREjZfxGf9gNzfW0CWRf5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^11.5.4",
+        "@types/json-schema": "^7.0.11",
+        "@ungap/structured-clone": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21"
       }
     },
     "apps/keeper": {
@@ -4960,7 +4974,6 @@
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/abbrev": {
@@ -9869,9 +9882,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/packages/templates/clients/websocket/test/integration-test/__snapshots__/integration.test.js.javascript.snap
+++ b/packages/templates/clients/websocket/test/integration-test/__snapshots__/integration.test.js.javascript.snap
@@ -148,17 +148,45 @@ info:
   title: Hoppscotch Echo WebSocket Client
   version: 1.0.0
   description: >
-    Undestand how to use Hoppscotch Echo WebSocket as a client.
-    Hoppscotch Echo WebSocket server echoes back any messages sent to it. You can use this to test WebSocket connections and message flows.
-
+    Undestand how to use Hoppscotch Echo WebSocket as a client. Hoppscotch Echo
+    WebSocket server echoes back any messages sent to it. You can use this to
+    test WebSocket connections and message flows.
 servers:
   echoServer:
-    $ref: './commons/servers.yml#/servers/echoServer'
-
+    host: echo-websocket.hoppscotch.io
+    protocol: wss
 channels:
   echo:
-    $ref: './commons/channels.yml#/channels/echo'
-
+    description: >
+      The single channel where messages are sent to and echoed back. Echo server
+      also regularly drops a timestamp to that channel.
+    address: /
+    messages:
+      echo:
+        summary: A message exchanged with the echo server.
+        payload: {}
+        examples:
+          - name: string
+            payload: test
+          - name: boolean
+            payload: true
+          - name: number
+            payload: 123
+          - name: object
+            payload:
+              test: test text
+      timestamp:
+        summary: A message sent from server with current timestamp.
+        payload:
+          type: string
+          description: A timestamp with GMT timezone.
+          example: 11:13:24 GMT+0000 (Coordinated Universal Time)
+        examples:
+          - name: someRandomDate
+            payload: 11:13:24 GMT+0000 (Coordinated Universal Time)
+    bindings:
+      ws:
+        method: POST
 operations:
   sendEchoMessage:
     action: send
@@ -166,15 +194,14 @@ operations:
       $ref: '#/channels/echo'
     summary: Send a message to the echo server.
     messages:
-      - $ref: '#/channels/echo/messages/echo'  
-
+      - $ref: '#/channels/echo/messages/echo'
   handleTimeStampMessage:
     action: receive
     channel:
       $ref: '#/channels/echo'
     summary: Receive the timestamp message sent from server every second.
     messages:
-      - $ref: '#/channels/echo/messages/timestamp' 
+      - $ref: '#/channels/echo/messages/timestamp'
 "
 `;
 
@@ -558,17 +585,45 @@ info:
   title: Hoppscotch Echo WebSocket Client
   version: 1.0.0
   description: >
-    Undestand how to use Hoppscotch Echo WebSocket as a client.
-    Hoppscotch Echo WebSocket server echoes back any messages sent to it. You can use this to test WebSocket connections and message flows.
-
+    Undestand how to use Hoppscotch Echo WebSocket as a client. Hoppscotch Echo
+    WebSocket server echoes back any messages sent to it. You can use this to
+    test WebSocket connections and message flows.
 servers:
   echoServer:
-    $ref: './commons/servers.yml#/servers/echoServer'
-
+    host: echo-websocket.hoppscotch.io
+    protocol: wss
 channels:
   echo:
-    $ref: './commons/channels.yml#/channels/echo'
-
+    description: >
+      The single channel where messages are sent to and echoed back. Echo server
+      also regularly drops a timestamp to that channel.
+    address: /
+    messages:
+      echo:
+        summary: A message exchanged with the echo server.
+        payload: {}
+        examples:
+          - name: string
+            payload: test
+          - name: boolean
+            payload: true
+          - name: number
+            payload: 123
+          - name: object
+            payload:
+              test: test text
+      timestamp:
+        summary: A message sent from server with current timestamp.
+        payload:
+          type: string
+          description: A timestamp with GMT timezone.
+          example: 11:13:24 GMT+0000 (Coordinated Universal Time)
+        examples:
+          - name: someRandomDate
+            payload: 11:13:24 GMT+0000 (Coordinated Universal Time)
+    bindings:
+      ws:
+        method: POST
 operations:
   sendEchoMessage:
     action: send
@@ -576,15 +631,14 @@ operations:
       $ref: '#/channels/echo'
     summary: Send a message to the echo server.
     messages:
-      - $ref: '#/channels/echo/messages/echo'  
-
+      - $ref: '#/channels/echo/messages/echo'
   handleTimeStampMessage:
     action: receive
     channel:
       $ref: '#/channels/echo'
     summary: Receive the timestamp message sent from server every second.
     messages:
-      - $ref: '#/channels/echo/messages/timestamp' 
+      - $ref: '#/channels/echo/messages/timestamp'
 "
 `;
 
@@ -921,39 +975,44 @@ client.send_echo_message({
 
 exports[`WebSocket Clients Integration Tests JavaScript Client Common Integration tests for JavaScript client generation generate simple client for postman echo: asyncapi.yaml 1`] = `
 "asyncapi: 3.0.0
-
 info:
   title: Postman Echo WebSocket Client
   version: 1.0.0
-  description: Understand how to use the Postman Echo WebSocket as a client.
-    The Postman Echo WebSocket server echoes back any messages sent to it.
-
+  description: >-
+    Understand how to use the Postman Echo WebSocket as a client. The Postman
+    Echo WebSocket server echoes back any messages sent to it.
 servers:
   echoServer:
     host: ws.postman-echo.com
     pathname: /raw
     protocol: wss
-
 channels:
   echo:
-    description: The main channel where messages are sent and echoed back by the Postman Echo WebSocket server.
+    description: >-
+      The main channel where messages are sent and echoed back by the Postman
+      Echo WebSocket server.
     address: /
     messages:
       echo:
-        $ref: '#/components/messages/echo'
-
+        summary: A message exchanged with the echo server.
+        payload: {}
+        examples:
+          - name: string
+            payload: test
+          - name: object
+            payload:
+              test: test text
 operations:
   sendEchoMessage:
     summary: Send a message to the Postman Echo server.
     action: send
-    channel: 
+    channel:
       $ref: '#/channels/echo'
     messages:
       - $ref: '#/channels/echo/messages/echo'
     reply:
-      channel: 
+      channel:
         $ref: '#/channels/echo'
-
 components:
   messages:
     echo:
@@ -963,8 +1022,9 @@ components:
         - name: string
           payload: test
         - name: object
-          payload: 
-            test: test text"
+          payload:
+            test: test text
+"
 `;
 
 exports[`WebSocket Clients Integration Tests JavaScript Client Common Integration tests for JavaScript client generation generate simple client for postman echo: client.js 1`] = `


### PR DESCRIPTION
## Description

Fixes #2144

The `generate:after` hook in `@asyncapi/generator-hooks` copied the source AsyncAPI document into each generated client **verbatim**. When the source used external `$ref`s (e.g. `$ref: './commons/servers.yml#/...'`), those references remained unresolved in the emitted `asyncapi.yaml`, because the referenced files were never copied alongside the output. This broke runtime consumers such as `@asyncapi/keeper`, which need to resolve and compile the schemas.

## Changes

- `apps/hooks/src/index.js` — `createAsyncapiFile` now bundles the document via [`@asyncapi/bundler`](https://github.com/asyncapi/bundler) when a source **file path** is available on disk, inlining external `$ref`s into a single self-contained document. `baseDir` is set to the document's own directory so relative external refs resolve correctly.
  - **Fallback:** when no source path is available (string/URL input) or bundling throws, the hook writes the original source unchanged — preserving previous behavior.
  - Refactored extension detection and output-path resolution into small helpers and added JSDoc.
- `apps/generator/lib/generator.js` — exposes the source `parseOptions.path` as `generator.asyncapiFilePath` so the hook can locate the document on disk (`undefined` for string input).
- `apps/hooks/package.json` / `package-lock.json` — add `@asyncapi/bundler` dependency.
- Tests + fixtures (`apps/hooks/test/__fixtures__/`) covering the bundling path and the verbatim fallback.

## Changeset

`patch` for `@asyncapi/generator-hooks` and `@asyncapi/generator`.

## How to test

```
npm test --workspace=@asyncapi/generator-hooks
```

All 5 hook tests pass, including the new "bundles external $refs into a self-contained document" and "falls back to writing the original source verbatim" cases.

**AI assistance**
<!-- See our AI Usage Policy: https://github.com/asyncapi/generator/blob/master/AI-POLICY.md
Check exactly one box. If this PR was materially AI-assisted, keep the Generated-by line and fill in the tool + model version. -->

- [x] This PR was created with AI assistance — `Generated-by:` Cursor Agent Opus 4.8
- [ ] No AI assistance was used



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated outputs can now include a single self-contained AsyncAPI document by inlining external `$ref`s when bundling is available.

* **Bug Fixes**
  * External references are now resolved in generated client output, reducing runtime/schema compilation issues.
  * If bundling can’t be performed or the source path isn’t available, the original AsyncAPI content is written unchanged.

* **Documentation**
  * Updated Generator API docs to reflect optional after-hook `parseOptions`, including how `asyncapiFilePath` is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->