### PR TITLE
ci: limit release workflow to master branch only

### DIFF
--- a/.github/workflows/release-with-changesets.yml
+++ b/.github/workflows/release-with-changesets.yml
@@ -5,13 +5,6 @@ on:
   push:
     branches:
       - master
-        # The below lines are not enough to have release supported for these branches
-      - next-spec
-      - next-major
-      - next-major-spec
-      - beta
-      - alpha
-      - next
 
 jobs:
   test-nodejs:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- Restrict the `release-with-changesets` workflow to trigger only on pushes to `master`.
- Remove unused pre-release branch triggers: `next-spec`, `next-major`, `next-major-spec`, `beta`, `alpha`, and `next`.

**Related issue(s)**
https://github.com/asyncapi/generator/issues/2184

**AI assistance**
<!-- See our AI Usage Policy: https://github.com/asyncapi/generator/blob/master/AI-POLICY.md
Check exactly one box. If this PR was materially AI-assisted, keep the Generated-by line and fill in the tool + model version. -->

- [x] This PR was created with AI assistance — `Generated-by: Cursor Composer`
- [ ] No AI assistance was used
