### PR TITLE
fix: run changeset version through a shell so release pipeline works

### DIFF
--- a/.github/workflows/release-with-changesets.yml
+++ b/.github/workflows/release-with-changesets.yml
@@ -118,7 +118,9 @@ jobs:
           # `changeset version` only rewrites package.json/CHANGELOG files; it never runs an
           # install, so the root package-lock.json drifts out of sync with the bumped manifests.
           # Refresh the lockfile (lockfile-only, no scripts) so the release PR carries it too.
-          version: npx -p @changesets/cli@2.27.7 changeset version && npm install --package-lock-only --ignore-scripts
+          # Why: changesets/action runs this via @actions/exec, not a shell, so `&&` would be
+          # passed to `changeset` as an argument instead of chaining. `bash -c` gives it a shell.
+          version: bash -c "npx -p @changesets/cli@2.27.7 changeset version && npm install --package-lock-only --ignore-scripts"
           commit: "chore(release): release and bump versions of packages"
           title: "chore(release): release and bump versions of packages"
           publish: npx -p @changesets/cli@2.27.7 changeset publish


### PR DESCRIPTION
Fixes the release pipeline.

`changesets/action` runs the `version:` input through `@actions/exec`, not a shell, so the `&&` was never an operator — `changeset` received `version && npm install --package-lock-only --ignore-scripts` as arguments and errored with `Too many arguments`. No version bump happened, so the release PR could not be created.

`bash -c` puts a real shell in front, so `&&` chains as intended.

Broken since #2124. Failed runs: [30483813835](https://github.com/asyncapi/generator/actions/runs/30483813835), [30638263158](https://github.com/asyncapi/generator/actions/runs/30638263158).

`fix:` prefix is intentional — merging this needs to retrigger the release so the pending changesets finally ship.

**AI assistance**

- [x] This PR was created with AI assistance — `Generated-by:` Claude Code (Opus 5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release process to reliably run version updates and lockfile-only installations as a chained shell command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->