### PR TITLE
chore(react-sdk): use new Array() constructor instead of Array()

### DIFF
--- a/.changeset/sweet-donuts-repeat.md
+++ b/.changeset/sweet-donuts-repeat.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/generator-react-sdk": patch
+---
+
+Use the `new Array()` constructor form in the react-sdk string utilities instead of calling `Array()` without `new`, as flagged by SonarCloud. Behaviour is unchanged.

--- a/apps/react-sdk/src/utils/withIndendation.ts
+++ b/apps/react-sdk/src/utils/withIndendation.ts
@@ -43,5 +43,5 @@ export function withIndendation(content: string = '', size: number, type: Indent
  */
 function getIndentation(size: number = 0, type: IndentationTypes = IndentationTypes.SPACES): string {
   const whitespaceChar = type === IndentationTypes.SPACES ? ' ' : '\t';
-  return Array(size).fill(whitespaceChar).join("");
+  return new Array(size).fill(whitespaceChar).join("");
 }

--- a/apps/react-sdk/src/utils/withNewLines.ts
+++ b/apps/react-sdk/src/utils/withNewLines.ts
@@ -6,6 +6,6 @@
  * @returns {string}
  */
 export function withNewLines(content: string = '', number: number = 0): string {
-  const newLines = Array(number).fill('\n').join('');
+  const newLines = new Array(number).fill('\n').join('');
   return content + newLines;
 }


### PR DESCRIPTION
## Description

SonarCloud flags both call sites for calling `Array()` without `new`. Both take a single numeric argument, so the constructor form is behaviour preserving:

- `apps/react-sdk/src/utils/withNewLines.ts:9`
- `apps/react-sdk/src/utils/withIndendation.ts:46`

I grepped the whole repo for `Array(` not preceded by `new` and outside `node_modules`; these two are the only remaining occurrences in scope, so this closes the issue rather than partially addressing it.

Equivalence checked rather than assumed — `Array(n).fill(x).join('')` vs `new Array(n).fill(x).join('')` for `n = 0, 1, 5`, both the space and the tab/newline fill characters, identical output in every case (`Array(n)` and `new Array(n)` produce the same sparse array; `.fill()` then densifies it). The two forms differ only in that the call form is shadowable by a local binding named `Array`, which is what the rule guards against.

A changeset is included (`@asyncapi/generator-react-sdk`, patch).

**What I have not done:** I did not run the full monorepo build or test suite locally, so I am relying on CI for that rather than claiming a green run I did not observe. There are no existing unit tests covering these two utilities. The behavioural check above was run directly in Node v22.

## Related issue(s)

Fixes #1915

## AI assistance

Generated-by: Claude Code (Claude Opus, model `claude-opus-5`)

Disclosing per [AI-POLICY.md](https://github.com/asyncapi/generator/blob/master/AI-POLICY.md). I read the policy after opening this PR and am editing the description to add the required line — the original description disclosed the AI assistance in prose but not in the machine-checkable form the policy asks for, which is my mistake, not the check's.

On the accountability point the policy makes ("AI tools are instruments; humans are the only authors"): this account is operated by an AI-assisted lab with the account owner's authorisation, and we take responsibility for every line here as if hand-written. The diff is two lines, the equivalence argument is verifiable in a Node REPL in seconds, and I can justify any part of it on request. If maintainers would rather not take AI-assisted contributions from a non-human-typed workflow regardless of disclosure, say so and I will close this myself without argument.