### PR TITLE
fix: correct generator-hooks repository url for npm provenance

### DIFF
--- a/apps/hooks/package.json
+++ b/apps/hooks/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/asyncapi/generator-hooks.git"
+    "url": "https://github.com/asyncapi/generator.git",
+    "directory": "apps/hooks"
   },
   "keywords": [
     "asyncapi",
@@ -21,12 +22,12 @@
   "author": "Lukasz Gornicki <lpgornicki@gmail.com>",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/asyncapi/generator-hooks/issues"
+    "url": "https://github.com/asyncapi/generator/issues"
   },
   "publishConfig": {
     "access": "public"
   },
-  "homepage": "https://github.com/asyncapi/generator-hooks#readme",
+  "homepage": "https://github.com/asyncapi/generator/tree/master/apps/hooks#readme",
   "dependencies": {
     "fs.extra": "^1.3.2"
   },


### PR DESCRIPTION


<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines and make sure PR title follows Conventional Commits specification -> https://github.com/asyncapi/generator/blob/master/CONTRIBUTING.md
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- `@asyncapi/generator@3.4.0` is uninstallable because it depends on `@asyncapi/generator-hooks@0.1.1`, which never reached npm. The release workflow publishes with npm trusted publishing (OIDC + sigstore provenance), which requires `repository.url` to match the repository that produced the build. [`apps/hooks/package.json`](https://github.com/asyncapi/generator/blob/master/apps/hooks/package.json) still pointed at the pre-monorepo `asyncapi/generator-hooks` repo, so the registry rejected the tarball ([release run](https://github.com/asyncapi/generator/actions/runs/30999138157)):
	```
 	E422 ... Error verifying sigstore provenance bundle: "repository.url" is
	"git+https://github.com/asyncapi/generator-hooks.git", expected to match
	"https://github.com/asyncapi/generator" from provenance
	```
- Points `repository.url` at the monorepo and adds `repository.directory: apps/hooks`, matching `packages/components` and `packages/helpers`. Stale `bugs.url` and `homepage` are corrected too. `apps/hooks` was the only workspace still pointing at its old repo, which is why `@asyncapi/generator@3.4.0` and `@asyncapi/generator-components@0.8.0` published fine in that same run.
- **No changeset, on purpose**. `apps/hooks` stays at `0.1.1`, so `changeset publish` takes its "publish any unpublished packages" path and ships the exact version the already-published `3.4.0` asks for, repairing it in place. Bumping to `0.1.2` would leave `3.4.0` permanently broken and need a follow-up generator patch. The `fix:` title triggers the release workflow on merge.

**Testing**

Metadata-only change with no affected code path, so no tests were run and no docs needed regenerating (`apps/hooks` is not scanned by `jsdoc2md`). Verified the file is valid JSON, `version` is still `0.1.1`, and no other stale repo URLs remain. End-to-end verification is only possible on merge, since the failure comes from the registry's provenance check during release.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, othewise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The 3rd option will not automatically close the issue after the merge. -->

Fixes: #2201 

**AI assistance**
<!-- See our AI Usage Policy: https://github.com/asyncapi/generator/blob/master/AI-POLICY.md
Check exactly one box. If this PR was materially AI-assisted, keep the Generated-by line and fill in the tool + model version. -->

- [x] This PR was created with AI assistance — `Generated-by: Claude Opus 5`
- [ ] No AI assistance was used


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package links to point to the main AsyncAPI Generator repository.
  * Corrected the package homepage and issue tracker URLs for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->