### PR TITLE
test(generator): add unit tests for conditional generation and config…

### DIFF
--- a/.changeset/add-conditional-generation-tests.md
+++ b/.changeset/add-conditional-generation-tests.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/generator": patch
+---
+
+Add dedicated unit tests for `conditionalGeneration` logic and template configuration validator.

--- a/apps/generator/lib/conditionalGeneration.js
+++ b/apps/generator/lib/conditionalGeneration.js
@@ -9,8 +9,9 @@ const jmespath = require('jmespath');
  * @param {Object} templateConfig - The template configuration containing conditional logic.
  * @param {string} matchedConditionPath - The matched path used to find applicable conditions.
  * @param {Object} templateParams - Parameters passed to the template.
- * @param {AsyncAPIDocument} asyncapiDocument - The AsyncAPI document used for evaluating conditions.
+ * @param {AsyncAPIDocument | Object} asyncapiDocument - The AsyncAPI document used for evaluating conditions.
  * @returns {Promise<boolean>} A promise that resolves to `true` if the condition is met, allowing the file or folder to render; otherwise, resolves to `false`. 
+ * @throws {Error} When errors occur during condition evaluation or validation.
  */
 async function isGenerationConditionMet (
   templateConfig,
@@ -48,7 +49,9 @@ async function isGenerationConditionMet (
     }
     return conditionalParameterGeneration(templateConfig,matchedConditionPath,templateParams);
   }
-};
+
+  return true;
+}
 
 /**
  * Evaluates whether a template path should be conditionally generated 

--- a/apps/generator/test/conditionalGeneration.test.js
+++ b/apps/generator/test/conditionalGeneration.test.js
@@ -1,0 +1,319 @@
+const { isGenerationConditionMet } = require('../lib/conditionalGeneration');
+const { parse } = require('../lib/parser');
+const fs = require('fs');
+const path = require('path');
+const Ajv = require('ajv');
+const ajv = new Ajv({ allErrors: true });
+
+const dummyYAML = fs.readFileSync(path.resolve(__dirname, './docs/dummy.yml'), 'utf8');
+
+describe('conditionalGeneration unit tests', () => {
+  const testFeaturePath = 'feature/file.js';
+  const testUnconditionedPath = 'some/path.js';
+  const testSupportDocPath = 'docs/support.html';
+  const contactNameSubject = 'info.contact.name';
+  const infoTitleSubject = 'info.title';
+  const serverProtocolSubject = 'server.protocol';
+  const dummyKafkaServer = 'dummy-kafka';
+
+  let asyncapiDocument;
+
+  beforeAll(async () => {
+    const { document } = await parse(dummyYAML, {}, { templateConfig: { apiVersion: 'v2' } });
+    asyncapiDocument = document;
+  });
+
+  it('should return true when no conditional rules are configured', async () => {
+    const templateConfig = {};
+    const result = await isGenerationConditionMet(
+      templateConfig,
+      testUnconditionedPath,
+      {},
+      asyncapiDocument
+    );
+    expect(result).toBe(true);
+  });
+
+  it('should return true when matched path is not in conditional rules', async () => {
+    const templateConfig = {
+      conditionalGeneration: {
+        'other/path.js': {
+          parameter: 'generateOther',
+          validate: ajv.compile({ const: true })
+        }
+      }
+    };
+    const result = await isGenerationConditionMet(
+      templateConfig,
+      testUnconditionedPath,
+      {},
+      asyncapiDocument
+    );
+    expect(result).toBe(true);
+  });
+
+  it('should return true when matched path is not in legacy conditionalFiles rules', async () => {
+    const templateConfig = {
+      conditionalFiles: {
+        'other/legacy/path.js': {
+          subject: infoTitleSubject,
+          validate: ajv.compile({ const: 'Dummy example with all spec features included' })
+        }
+      }
+    };
+    const result = await isGenerationConditionMet(
+      templateConfig,
+      testUnconditionedPath,
+      {},
+      asyncapiDocument
+    );
+    expect(result).toBe(true);
+  });
+
+  describe('conditionalGeneration - parameter-based condition', () => {
+    it('should return true when parameter satisfies validation', async () => {
+      const templateConfig = {
+        conditionalGeneration: {
+          [testFeaturePath]: {
+            parameter: 'enableFeature',
+            validate: ajv.compile({ const: true })
+          }
+        }
+      };
+      const templateParams = { enableFeature: true };
+      const result = await isGenerationConditionMet(
+        templateConfig,
+        testFeaturePath,
+        templateParams,
+        asyncapiDocument
+      );
+      expect(result).toBe(true);
+    });
+
+    it('should return false when parameter fails validation', async () => {
+      const templateConfig = {
+        conditionalGeneration: {
+          [testFeaturePath]: {
+            parameter: 'enableFeature',
+            validate: ajv.compile({ const: true })
+          }
+        }
+      };
+      const templateParams = { enableFeature: false };
+      const result = await isGenerationConditionMet(
+        templateConfig,
+        testFeaturePath,
+        templateParams,
+        asyncapiDocument
+      );
+      expect(result).toBe(false);
+    });
+
+    it('should return false when parameter is missing and validation requires it', async () => {
+      const templateConfig = {
+        conditionalGeneration: {
+          [testFeaturePath]: {
+            parameter: 'enableFeature',
+            validate: ajv.compile({ type: 'boolean', const: true })
+          }
+        }
+      };
+      const templateParams = {};
+      const result = await isGenerationConditionMet(
+        templateConfig,
+        testFeaturePath,
+        templateParams,
+        asyncapiDocument
+      );
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('conditionalGeneration - subject-based condition', () => {
+    it('should return true when subject query matches document and satisfies validation', async () => {
+      const templateConfig = {
+        conditionalGeneration: {
+          [testSupportDocPath]: {
+            subject: contactNameSubject,
+            validate: ajv.compile({ const: 'API Support' })
+          }
+        }
+      };
+      const result = await isGenerationConditionMet(
+        templateConfig,
+        testSupportDocPath,
+        {},
+        asyncapiDocument
+      );
+      expect(result).toBe(true);
+    });
+
+    it('should return false when subject query matches document but fails validation', async () => {
+      const templateConfig = {
+        conditionalGeneration: {
+          [testSupportDocPath]: {
+            subject: contactNameSubject,
+            validate: ajv.compile({ const: 'Other Team' })
+          }
+        }
+      };
+      const result = await isGenerationConditionMet(
+        templateConfig,
+        testSupportDocPath,
+        {},
+        asyncapiDocument
+      );
+      expect(result).toBe(false);
+    });
+
+    it('should return false when subject is not found in document', async () => {
+      const templateConfig = {
+        conditionalGeneration: {
+          'docs/nonexistent.html': {
+            subject: 'info.nonexistentField',
+            validate: ajv.compile({ type: 'string' })
+          }
+        }
+      };
+      const result = await isGenerationConditionMet(
+        templateConfig,
+        'docs/nonexistent.html',
+        {},
+        asyncapiDocument
+      );
+      expect(result).toBe(false);
+    });
+
+    it('should throw error when subject has malformed JMESPath syntax', async () => {
+      const templateConfig = {
+        conditionalGeneration: {
+          [testSupportDocPath]: {
+            subject: 'info.[unclosed',
+            validate: ajv.compile({ type: 'string' })
+          }
+        }
+      };
+      await expect(
+        isGenerationConditionMet(
+          templateConfig,
+          testSupportDocPath,
+          {},
+          asyncapiDocument
+        )
+      ).rejects.toThrow();
+    });
+
+    it('should correctly query server when server param is provided', async () => {
+      const templateConfig = {
+        conditionalGeneration: {
+          'kafka/client.js': {
+            subject: serverProtocolSubject,
+            validate: ajv.compile({ const: 'kafka' })
+          }
+        }
+      };
+      const templateParams = { server: dummyKafkaServer };
+      const result = await isGenerationConditionMet(
+        templateConfig,
+        'kafka/client.js',
+        templateParams,
+        asyncapiDocument
+      );
+      expect(result).toBe(true);
+    });
+
+    it('should return false when queried server protocol does not match validation', async () => {
+      const templateConfig = {
+        conditionalGeneration: {
+          'mqtt/client.js': {
+            subject: serverProtocolSubject,
+            validate: ajv.compile({ const: 'mqtt' })
+          }
+        }
+      };
+      const templateParams = { server: dummyKafkaServer };
+      const result = await isGenerationConditionMet(
+        templateConfig,
+        'mqtt/client.js',
+        templateParams,
+        asyncapiDocument
+      );
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('conditionalFiles (backward compatibility) - subject-based condition', () => {
+    const testLegacyPath = 'legacy/file.js';
+
+    it('should return true when legacy conditionalFiles subject satisfies validation', async () => {
+      const templateConfig = {
+        conditionalFiles: {
+          [testLegacyPath]: {
+            subject: infoTitleSubject,
+            validate: ajv.compile({ const: 'Dummy example with all spec features included' })
+          }
+        }
+      };
+      const result = await isGenerationConditionMet(
+        templateConfig,
+        testLegacyPath,
+        {},
+        asyncapiDocument
+      );
+      expect(result).toBe(true);
+    });
+
+    it('should return false when legacy conditionalFiles subject fails validation', async () => {
+      const templateConfig = {
+        conditionalFiles: {
+          [testLegacyPath]: {
+            subject: infoTitleSubject,
+            validate: ajv.compile({ const: 'Different API' })
+          }
+        }
+      };
+      const result = await isGenerationConditionMet(
+        templateConfig,
+        testLegacyPath,
+        {},
+        asyncapiDocument
+      );
+      expect(result).toBe(false);
+    });
+
+    it('should return false when legacy conditionalFiles subject is not in document', async () => {
+      const templateConfig = {
+        conditionalFiles: {
+          [testLegacyPath]: {
+            subject: 'info.unknownProperty',
+            validate: ajv.compile({ const: 'val' })
+          }
+        }
+      };
+      const result = await isGenerationConditionMet(
+        templateConfig,
+        testLegacyPath,
+        {},
+        asyncapiDocument
+      );
+      expect(result).toBe(false);
+    });
+  });
+
+  it('should return false when validate function is missing', async () => {
+    const templateConfig = {
+      conditionalGeneration: {
+        'file.js': {
+          parameter: 'flag'
+        }
+      }
+    };
+    const result = await isGenerationConditionMet(
+      templateConfig,
+      'file.js',
+      { flag: true },
+      asyncapiDocument
+    );
+    expect(result).toBe(false);
+  });
+});

--- a/apps/generator/test/templateConfigValidator.test.js
+++ b/apps/generator/test/templateConfigValidator.test.js
@@ -169,6 +169,109 @@ describe('Template Configuration Validator', () => {
     expect(templateConfig.conditionalFiles['my/path/to/file.js']).toBeDefined();
   });
 
+  it('Validation throw error if subject in conditionalGeneration is not string', () => {
+    const templateParams = {};
+    const templateConfig = {
+      conditionalGeneration: {
+        'my/path/to/file.js': {
+          subject: ['server.protocol'],
+          validation: {
+            const: 'myprotocol'
+          }
+        }
+      }
+    };
+
+    expect(() => validateTemplateConfig(templateConfig, templateParams)).toThrow('Invalid \'subject\' for my/path/to/file.js: server.protocol');
+  });
+
+  it('Validation throw error if parameter in conditionalGeneration is not string', () => {
+    const templateParams = {};
+    const templateConfig = {
+      conditionalGeneration: {
+        'my/path/to/file.js': {
+          parameter: ['singleFile'],
+          validation: {
+            const: 'true'
+          }
+        }
+      }
+    };
+
+    expect(() => validateTemplateConfig(templateConfig, templateParams)).toThrow('Invalid \'parameter\' for my/path/to/file.js: singleFile');
+  });
+
+  it('Validation throw error if both subject and parameter are defined in conditionalGeneration', () => {
+    const templateParams = {};
+    const templateConfig = {
+      conditionalGeneration: {
+        'my/path/to/file.js': {
+          subject: 'server.protocol',
+          parameter: 'singleFile',
+          validation: {
+            const: 'myprotocol'
+          }
+        }
+      }
+    };
+
+    expect(() => validateTemplateConfig(templateConfig, templateParams)).toThrow('Both \'subject\' and \'parameter\' cannot be defined for my/path/to/file.js');
+  });
+
+  it('Validation throw error if validation in conditionalGeneration is not object', () => {
+    const templateParams = {};
+    const templateConfig = {
+      conditionalGeneration: {
+        'my/path/to/file.js': {
+          subject: 'server.url',
+          validation: 'http://example.com'
+        }
+      }
+    };
+
+    expect(() => validateTemplateConfig(templateConfig, templateParams)).toThrow('Invalid \'validation\' object for my/path/to/file.js: http://example.com');
+  });
+
+  it('Validation enrich conditionalGeneration object with validate object', () => {
+    const templateParams = {};
+    const templateConfig = {
+      conditionalGeneration: {
+        'my/path/to/file.js': {
+          subject: 'server.protocol',
+          validation: {
+            const: 'myprotocol'
+          }
+        }
+      }
+    };
+    validateTemplateConfig(templateConfig, templateParams);
+
+    const validateFn = templateConfig.conditionalGeneration['my/path/to/file.js'].validate;
+    expect(typeof validateFn).toBe('function');
+    expect(validateFn('myprotocol')).toBe(true);
+    expect(validateFn('differentprotocol')).toBe(false);
+  });
+
+  it('Validation enrich conditionalGeneration object with validate object if the subject is info', () => {
+    const templateParams = {};
+    const templateConfig = {
+      conditionalGeneration: {
+        'my/path/to/file.js': {
+          subject: 'info.title',
+          validation: {
+            const: 'asyncapi'
+          }
+        }
+      }
+    };
+    validateTemplateConfig(templateConfig, templateParams);
+
+    const validateFn = templateConfig.conditionalGeneration['my/path/to/file.js'].validate;
+    expect(typeof validateFn).toBe('function');
+    expect(validateFn('asyncapi')).toBe(true);
+    expect(validateFn('differenttitle')).toBe(false);
+  });
+
   it('Validation throw error if specified server is not in asyncapi document', () => {
     const templateParams = {
       server: 'myserver'


### PR DESCRIPTION
Resolves [#1553 ](https://github.com/asyncapi/generator/issues/1553)
Related to [#1970 ](https://github.com/asyncapi/generator/issues/1970)

This PR adds comprehensive unit test coverage for conditional file and folder generation in @asyncapi/generator.
- Created a dedicated unit test suite in apps/generator/test/conditionalGeneration.test.js covering default generation, parameter-based conditions, subject-based JMESPath conditions (including server lookups), legacy conditionalFiles
backward compatibility, and missing validation handlers.
- Added test cases in apps/generator/test/templateConfigValidator.test.js to validate conditionalGeneration configuration entries (type checks for subject, parameter, mutual exclusivity, and Ajv schema compilation).
- Added a default return true fallback in isGenerationConditionMet for unconditioned paths.

**File Changes:**
```
M	apps/generator/lib/conditionalGeneration.js
D	apps/generator/test/conditionalGeneration.test.js
M	apps/generator/test/templateConfigValidator.test.js
```

**AI assistance**
- [X] This PR was created with AI assistance — Generated-by: Antigravity
- [ ] No AI assistance was used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Conditional generation now proceeds when no configured rule matches, preventing unexpected generation failures.

- **Tests**
  - Expanded coverage for configured and unmatched conditions, parameters, document fields, server protocols, legacy conditions, malformed queries, and missing validation.
  - Added validation coverage for invalid configurations and successful matching and non-matching values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->