### PR TITLE
docs: mark baked-in template metadata as auto-generated and document it in the baked-in templates guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ The guidelines below cross-reference the following authoritative docs. If a path
 - [Hooks guide](apps/generator/docs/hooks.md) — lifecycle hook order and signatures (`generate:before`, `generate:after`, `setFileTemplateName`)
 - [Keeper README](apps/keeper/README.md) — `@asyncapi/keeper` public API surface
 - [React SDK README](apps/react-sdk/README.md) — rendering architecture, restrictions, and component examples
-- [Baked-in Templates guide](apps/generator/docs/baked-in-templates.md) — directory layout, required files, package-name convention
+- [Baked-in Templates guide](apps/generator/docs/baked-in-templates.md) — directory layout, required files, package-name convention, and how the build derives template metadata from the folder path and rewrites `.ageneratorrc` / `package.json` `name`
 - [WebSocket test README](packages/templates/clients/websocket/test/README.md) — `TEST_CLIENT` scoping, snapshot layout, Microcks setup
 
 ---
@@ -154,6 +154,7 @@ Template development inside the generator is an experimental effort. All its arc
 
 **Conventions:**
 - The directory layout (`{type}/[protocol]/[target]/[stack]`), required files (`.ageneratorrc`, `package.json`), metadata normalization, the `core-template-*` package-name rule, and the "how to add a new template" flow — live in the [Baked-in Templates guide](apps/generator/docs/baked-in-templates.md).
+- **The `metadata` block in `.ageneratorrc` and the `name` in `package.json` are build-generated from the template's folder path** — `apps/generator/scripts/build-templates.js` overwrites both on every `npm run build` (and `pretest`). Flag any PR that hand-edits them or strips the injected auto-generated comment; metadata changes must come from renaming/moving the template directory instead. See "Metadata and naming conventions" in the [Baked-in Templates guide](apps/generator/docs/baked-in-templates.md).
 - **Template-local component tests are conditional-only, and share one protocol fixture.** A component under `<client>/components/` gets a dedicated snapshot test **only when it has conditional rendering or variant logic** (per-server branches, query-param shape, operation-type switches); purely presentational components are covered by integration + acceptance tests. Each protocol keeps a single AsyncAPI fixture under `test/__fixtures__/` that exercises the full component surface — reuse it across clients of the same protocol and extend it (updating dependent snapshots) only when a new variant genuinely isn't expressible against the existing spec.
 - **Integration and acceptance tests are protocol-shared** Each protocol owns one integration suite (snapshot-driven, common helpers, per-client isolation) and one Microcks-based acceptance suite (language-native tests against a mocked server). For the full mechanics — per-client `TEST_CLIENT` scoping, snapshot layout, Microcks setup, and the checklist for onboarding a new client — see the [WebSocket test README](packages/templates/clients/websocket/test/README.md).
 

--- a/Development.md
+++ b/Development.md
@@ -3,6 +3,7 @@
 The development guide is now part of the official documentation and is published at **[asyncapi.com/docs/tools/generator](https://www.asyncapi.com/docs/tools/generator)**. This file is a short index. The canonical, up-to-date content lives on the website.
 
 - **[Development setup](https://www.asyncapi.com/docs/tools/generator/development-setup)** — onboarding webinar, fork/clone/install, additional commands, troubleshooting.
+- **[Baked-in templates](https://www.asyncapi.com/docs/tools/generator/baked-in-templates)** — template types and directory structure, plus how the build derives template metadata from the folder structure and rewrites `.ageneratorrc` and `package.json`.
 - **[Testing](https://www.asyncapi.com/docs/tools/generator/development-testing)** — running and adding tests, Docker isolated testing, manual testing with test templates.
 - **[Release process](https://www.asyncapi.com/docs/tools/generator/release-process)** — Conventional Commits, PR title rules, changesets, release flow.
 - **[AI tooling](https://www.asyncapi.com/docs/tools/generator/ai-tooling)** — CodeRabbit and Dosu: what the project's AI tools do and how to work with them.

--- a/apps/generator/docs/baked-in-templates.md
+++ b/apps/generator/docs/baked-in-templates.md
@@ -55,7 +55,7 @@ Every template directory **must include**:
 Generator build runs a script that normalizes metadata for baked-in templates and their naming:
 - Adds/updates metadata in `.ageneratorrc` file. You do not have to maintain it manually.
 - Validates/updates template name in `package.json` file of given template. The name always starts with `core-template-` prefix.
-- Generates JSON file with list of baked in templates and stores the list inside the generator: `apps/generator/lib/templates/BakedInTemplatesList.json`
+- Generates JSON file with list of baked-in templates and stores the list inside the generator: `apps/generator/lib/templates/BakedInTemplatesList.json`
 
 The script lives at [`apps/generator/scripts/build-templates.js`](https://github.com/asyncapi/generator/blob/master/apps/generator/scripts/build-templates.js) and runs on `npm run build` and automatically before every test run (as the `pretest` hook), locally and in CI.
 

--- a/apps/generator/docs/baked-in-templates.md
+++ b/apps/generator/docs/baked-in-templates.md
@@ -57,7 +57,8 @@ Generator build runs a script that normalizes metadata for baked-in templates an
 - Validates/updates template name in `package.json` file of given template. The name always starts with `core-template-` prefix.
 - Generates JSON file with list of baked-in templates and stores the list inside the generator: `apps/generator/lib/templates/BakedInTemplatesList.json`
 
-The script lives at [`apps/generator/scripts/build-templates.js`](https://github.com/asyncapi/generator/blob/master/apps/generator/scripts/build-templates.js) and runs on `npm run build` and automatically before every test run (as the `pretest` hook), locally and in CI.
+> **Note:**
+> The `metadata` block in `.ageneratorrc` and the `name` in `package.json` are auto-generated from the template's folder path by [`apps/generator/scripts/build-templates.js`](https://github.com/asyncapi/generator/blob/master/apps/generator/scripts/build-templates.js), which runs on every `npm run build` and automatically before tests. Do not edit them manually — the build overwrites them, and any other comments you add to `.ageneratorrc` are dropped when the file is re-serialized. To change a template's metadata, rename or move its directory and run `npm run build`.
 
 #### Example
 
@@ -84,27 +85,6 @@ Resulting entry in `apps/generator/lib/templates/BakedInTemplatesList.json`:
     "stack": "express"
   }
 ```
-
-### What is auto-generated vs. maintained by you
-
-The build derives the metadata from the template's folder path following the `{type}/[protocol]/[target]/[stack]` convention and rewrites the files listed below. Everything else is left exactly as you wrote it — with one exception: `.ageneratorrc` is re-serialized from YAML on every build, so any comments you add to it are dropped.
-
-| File | Auto-generated — never edit | Maintained by you |
-|---|---|---|
-| `.ageneratorrc` | the `metadata` block and the comment above it | everything else: `apiVersion`, `parameters`, `hooks`, `conditionalGeneration`, ... |
-| `package.json` | the `name` field | everything else: dependencies, description, ... |
-| `lib/templates/BakedInTemplatesList.json` | the entire file | nothing |
-
-If you edit the `metadata` block or the package `name` by hand, the change disappears on the next build or test run — that is by design, so the path, the package name, and the metadata can never drift apart. Custom keys inside `metadata` are not supported. The generated values are committed so that reviewers, the website, and tooling can see a template's identity without running the build.
-
-### How to change a template's metadata
-
-The folder structure is the single source of truth, so change the path:
-
-- Want `stack: express` for the JavaScript WebSocket client? Move the template to `packages/templates/clients/websocket/javascript/express/`.
-- Want a new protocol or target? Create the directory in the right place following the [directory structure convention](#template-directory-structure).
-
-Then run `npm run build` and commit the resulting changes to `.ageneratorrc`, `package.json`, and `BakedInTemplatesList.json` together with the move.
 
 ## How to add a new baked-in template
 

--- a/apps/generator/docs/baked-in-templates.md
+++ b/apps/generator/docs/baked-in-templates.md
@@ -52,10 +52,12 @@ Every template directory **must include**:
 
 ## Metadata and naming conventions
 
-Generator build runs a script that normalize metadata for baked-in templates and their naming:
+Generator build runs a script that normalizes metadata for baked-in templates and their naming:
 - Adds/updates metadata in `.ageneratorrc` file. You do not have to maintain it manually.
 - Validates/updates template name in `package.json` file of given template. The name always starts with `core-template-` prefix.
 - Generates JSON file with list of baked in templates and stores the list inside the generator: `apps/generator/lib/templates/BakedInTemplatesList.json`
+
+The script lives at [`apps/generator/scripts/build-templates.js`](https://github.com/asyncapi/generator/blob/master/apps/generator/scripts/build-templates.js) and runs on `npm run build` and automatically before every test run (as the `pretest` hook), locally and in CI.
 
 #### Example
 
@@ -82,6 +84,27 @@ Resulting entry in `apps/generator/lib/templates/BakedInTemplatesList.json`:
     "stack": "express"
   }
 ```
+
+### What is auto-generated vs. maintained by you
+
+The build derives the metadata from the template's folder path following the `{type}/[protocol]/[target]/[stack]` convention and rewrites the files listed below. Everything else is left exactly as you wrote it — with one exception: `.ageneratorrc` is re-serialized from YAML on every build, so any comments you add to it are dropped.
+
+| File | Auto-generated — never edit | Maintained by you |
+|---|---|---|
+| `.ageneratorrc` | the `metadata` block and the comment above it | everything else: `apiVersion`, `parameters`, `hooks`, `conditionalGeneration`, ... |
+| `package.json` | the `name` field | everything else: dependencies, description, ... |
+| `lib/templates/BakedInTemplatesList.json` | the entire file | nothing |
+
+If you edit the `metadata` block or the package `name` by hand, the change disappears on the next build or test run — that is by design, so the path, the package name, and the metadata can never drift apart. Custom keys inside `metadata` are not supported. The generated values are committed so that reviewers, the website, and tooling can see a template's identity without running the build.
+
+### How to change a template's metadata
+
+The folder structure is the single source of truth, so change the path:
+
+- Want `stack: express` for the JavaScript WebSocket client? Move the template to `packages/templates/clients/websocket/javascript/express/`.
+- Want a new protocol or target? Create the directory in the right place following the [directory structure convention](#template-directory-structure).
+
+Then run `npm run build` and commit the resulting changes to `.ageneratorrc`, `package.json`, and `BakedInTemplatesList.json` together with the move.
 
 ## How to add a new baked-in template
 

--- a/apps/generator/scripts/build-templates.js
+++ b/apps/generator/scripts/build-templates.js
@@ -16,6 +16,9 @@ const IGNORED_DIRS = ['test', '__tests__', '__fixtures__', '__snapshots__', 'com
 // Templates structure inside generator/packages/templates must follow this opinionated naming convention:
 const ALLOWED_TYPE_PATHS = ['docs', 'clients', 'sdks', 'configs'];
 
+// Comment injected above the metadata block of every baked-in template's .ageneratorrc.
+const METADATA_COMMENT = '# The metadata block below is auto-generated from the template folder structure - do not edit it manually. Learn more: https://www.asyncapi.com/docs/tools/generator/baked-in-templates';
+
 async function main() {
   const allTemplatesInfo = [];
   /*
@@ -232,7 +235,8 @@ async function collectTemplates(dir, relPath = [], result = []) {
 }
 
 /**
- * Reads, updates, and writes the .ageneratorrc YAML file with the new metadata.
+ * Reads, updates, and writes the .ageneratorrc YAML file with the new metadata,
+ * injecting a comment above the metadata block that marks it as auto-generated.
  * @param {string} ageneratorrcPath - Path to the .ageneratorrc file.
  * @param {Object} meta - Metadata object to set.
  */
@@ -250,7 +254,8 @@ async function updateAGeneratorRc(ageneratorrcPath, meta) {
     target: meta.target,
     ...(meta.stack && { stack: meta.stack }),
   };
-  const newAgeneratorrcContent = yaml.dump(ageneratorrc, { lineWidth: 120 });
+  // Why: yaml.dump cannot emit comments, so the notice is re-added above metadata on every build.
+  const newAgeneratorrcContent = yaml.dump(ageneratorrc, { lineWidth: 120 }).replace(/^metadata:/m, `${METADATA_COMMENT}\nmetadata:`);
   await writeFile(ageneratorrcPath, newAgeneratorrcContent);
 }
 

--- a/apps/generator/scripts/build-templates.js
+++ b/apps/generator/scripts/build-templates.js
@@ -237,8 +237,11 @@ async function collectTemplates(dir, relPath = [], result = []) {
 /**
  * Reads, updates, and writes the .ageneratorrc YAML file with the new metadata,
  * injecting a comment above the metadata block that marks it as auto-generated.
+ * @async
  * @param {string} ageneratorrcPath - Path to the .ageneratorrc file.
  * @param {Object} meta - Metadata object to set.
+ * @returns {Promise<void>}
+ * @throws {Error} When the .ageneratorrc file cannot be read or parsed, or when writing it back fails.
  */
 async function updateAGeneratorRc(ageneratorrcPath, meta) {
   let ageneratorrc;

--- a/packages/templates/clients/kafka/java/quarkus/.ageneratorrc
+++ b/packages/templates/clients/kafka/java/quarkus/.ageneratorrc
@@ -24,6 +24,7 @@ nonRenderableFiles:
   - .mvn/**
   - mvnw
   - mvnw.cmd
+# The metadata block below is auto-generated from the template folder structure - do not edit it manually. Learn more: https://www.asyncapi.com/docs/tools/generator/baked-in-templates
 metadata:
   type: client
   protocol: kafka

--- a/packages/templates/clients/websocket/dart/.ageneratorrc
+++ b/packages/templates/clients/websocket/dart/.ageneratorrc
@@ -18,6 +18,7 @@ parameters:
   customClientName:
     description: The custom name for the generated client class
     required: false
+# The metadata block below is auto-generated from the template folder structure - do not edit it manually. Learn more: https://www.asyncapi.com/docs/tools/generator/baked-in-templates
 metadata:
   type: client
   protocol: websocket

--- a/packages/templates/clients/websocket/java/quarkus/.ageneratorrc
+++ b/packages/templates/clients/websocket/java/quarkus/.ageneratorrc
@@ -16,6 +16,7 @@ nonRenderableFiles:
   - .mvn/**
   - mvnw
   - mvnw.cmd
+# The metadata block below is auto-generated from the template folder structure - do not edit it manually. Learn more: https://www.asyncapi.com/docs/tools/generator/baked-in-templates
 metadata:
   type: client
   protocol: websocket

--- a/packages/templates/clients/websocket/javascript/.ageneratorrc
+++ b/packages/templates/clients/websocket/javascript/.ageneratorrc
@@ -24,6 +24,7 @@ parameters:
       root of the output directory
     required: false
     default: .
+# The metadata block below is auto-generated from the template folder structure - do not edit it manually. Learn more: https://www.asyncapi.com/docs/tools/generator/baked-in-templates
 metadata:
   type: client
   protocol: websocket

--- a/packages/templates/clients/websocket/python/.ageneratorrc
+++ b/packages/templates/clients/websocket/python/.ageneratorrc
@@ -18,6 +18,7 @@ parameters:
   customClientName:
     description: The custom name for the generated client class
     required: false
+# The metadata block below is auto-generated from the template folder structure - do not edit it manually. Learn more: https://www.asyncapi.com/docs/tools/generator/baked-in-templates
 metadata:
   type: client
   protocol: websocket


### PR DESCRIPTION
**Description**

- `build-templates.js` now injects a comment above the auto-generated `metadata` block in every baked-in template's `.ageneratorrc`, stating it is derived from the folder structure and must not be edited manually. The comment links to the [Baked-in Templates guide](https://www.asyncapi.com/docs/tools/generator/baked-in-templates) and is re-injected on every build (idempotent — a second build produces no diff). Verified locally: the template build runs clean and lint passes.
- Instead of adding a new doc page, the existing [`baked-in-templates.md`](https://github.com/asyncapi/generator/blob/master/apps/generator/docs/baked-in-templates.md) guide gets a short note in its "Metadata and naming conventions" section: the metadata and package name are auto-generated from the folder path, hand edits are overwritten by the build (which also runs before tests), and changing metadata means renaming/moving the template directory.
- `Development.md` index and `AGENTS.md` ("Referenced documents" list + the §4.7 review rule) point to the guide, which keeps it visible to CodeRabbit through the existing `code_guidelines` file patterns — no `.coderabbit.yaml` change needed.
- No runtime behavior change, so no changeset (non-release `docs:`/`chore:` commits).

**Related issue(s)**

Fixes #1897 

**AI assistance**

- [x] This PR was created with AI assistance — `Generated-by:` Claude Code (Sonnet 5)
- [ ] No AI assistance was used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for baked-in template metadata, including its relationship to template folder paths and build processes.
  * Added documentation links and clarified which configuration values are generated automatically.
  * Added warnings that generated metadata should not be manually edited.

* **Chores**
  * Standardized generated-metadata comments across template configuration files.
  * Clarified that metadata is refreshed during builds and manual changes may be overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
