### PR TITLE
fix: preserve JSON AsyncAPI path in websocket client

### DIFF
--- a/.changeset/fix-websocket-json-asyncapi-path.md
+++ b/.changeset/fix-websocket-json-asyncapi-path.md
@@ -1,0 +1,5 @@
+---
+"@asyncapi/generator": patch
+---
+
+Fix the JavaScript WebSocket client template to reference `asyncapi.json` when the input AsyncAPI document is JSON.

--- a/packages/templates/clients/websocket/javascript/template/client.js.js
+++ b/packages/templates/clients/websocket/javascript/template/client.js.js
@@ -3,6 +3,17 @@ import { getClientName, getServerUrl, getServer, getInfo, getTitle } from '@asyn
 import { FileHeaderInfo, DependencyProvider } from '@asyncapi/generator-components';
 import { ClientClass } from '../components/ClientClass';
 
+/**
+ * Generates the JavaScript WebSocket client file.
+ *
+ * @param {object} args Template arguments.
+ * @param {object} args.asyncapi Parsed AsyncAPI document used to build the client.
+ * @param {object} args.params Template parameters, including output paths and client options.
+ * @param {string} args.originalAsyncAPI Original document text; valid JSON selects asyncapi.json,
+ * otherwise the generated client references asyncapi.yaml.
+ * @returns {import('@asyncapi/generator-react-sdk').File} Generated client file component.
+ * @throws {Error} If the parsed AsyncAPI document or required template parameters are invalid.
+ */
 export default function ({ asyncapi, params, originalAsyncAPI }) {
   const server = getServer(asyncapi.servers(), params.server);
   const info = getInfo(asyncapi);

--- a/packages/templates/clients/websocket/javascript/template/client.js.js
+++ b/packages/templates/clients/websocket/javascript/template/client.js.js
@@ -3,14 +3,22 @@ import { getClientName, getServerUrl, getServer, getInfo, getTitle } from '@asyn
 import { FileHeaderInfo, DependencyProvider } from '@asyncapi/generator-components';
 import { ClientClass } from '../components/ClientClass';
 
-export default function ({ asyncapi, params }) {
+export default function ({ asyncapi, params, originalAsyncAPI }) {
   const server = getServer(asyncapi.servers(), params.server);
   const info = getInfo(asyncapi);
   const title = getTitle(asyncapi);
   const clientName = getClientName(asyncapi, params.appendClientSuffix, params.customClientName);
   const serverUrl = getServerUrl(server);
   const sendOperations = asyncapi.operations().filterBySend();
-  const asyncapiFilepath = `${params.asyncapiFileDir}/asyncapi.yaml`;
+  const asyncapiFileExtension = (() => {
+    try {
+      JSON.parse(originalAsyncAPI);
+      return 'json';
+    } catch {
+      return 'yaml';
+    }
+  })();
+  const asyncapiFilepath = `${params.asyncapiFileDir}/asyncapi.${asyncapiFileExtension}`;
   return (
     <File name={params.clientFileName}>
       <FileHeaderInfo

--- a/packages/templates/clients/websocket/test/__fixtures__/asyncapi-postman-echo.json
+++ b/packages/templates/clients/websocket/test/__fixtures__/asyncapi-postman-echo.json
@@ -1,0 +1,65 @@
+{
+  "asyncapi": "3.0.0",
+  "info": {
+    "title": "Postman Echo WebSocket Client",
+    "version": "1.0.0",
+    "description": "Understand how to use the Postman Echo WebSocket as a client."
+  },
+  "servers": {
+    "echoServer": {
+      "host": "ws.postman-echo.com",
+      "pathname": "/raw",
+      "protocol": "wss"
+    }
+  },
+  "channels": {
+    "echo": {
+      "description": "The main channel where messages are sent and echoed back by the Postman Echo WebSocket server.",
+      "address": "/",
+      "messages": {
+        "echo": {
+          "$ref": "#/components/messages/echo"
+        }
+      }
+    }
+  },
+  "operations": {
+    "sendEchoMessage": {
+      "summary": "Send a message to the Postman Echo server.",
+      "action": "send",
+      "channel": {
+        "$ref": "#/channels/echo"
+      },
+      "messages": [
+        {
+          "$ref": "#/channels/echo/messages/echo"
+        }
+      ],
+      "reply": {
+        "channel": {
+          "$ref": "#/channels/echo"
+        }
+      }
+    }
+  },
+  "components": {
+    "messages": {
+      "echo": {
+        "summary": "A message exchanged with the echo server.",
+        "payload": {},
+        "examples": [
+          {
+            "name": "string",
+            "payload": "test"
+          },
+          {
+            "name": "object",
+            "payload": {
+              "test": "test text"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/packages/templates/clients/websocket/test/integration-test/integration.test.js
+++ b/packages/templates/clients/websocket/test/integration-test/integration.test.js
@@ -117,8 +117,10 @@ describe('WebSocket Clients Integration Tests', () => {
             }
           });
           await generator.generateFromFile(asyncapi_v3_json_path);
-          const client = await readFile(path.join(outputPath, 'client.js'), 'utf8');
+          const asyncapiOutputFile = await stat(path.join(outputPath, 'asyncapi.json'));
+          expect(asyncapiOutputFile.isFile()).toBeTruthy();
 
+          const client = await readFile(path.join(outputPath, 'client.js'), 'utf8');
           expect(client).toContain('path.resolve(__dirname, \'./asyncapi.json\')');
         }, 30000);
       });

--- a/packages/templates/clients/websocket/test/integration-test/integration.test.js
+++ b/packages/templates/clients/websocket/test/integration-test/integration.test.js
@@ -1,9 +1,10 @@
 const path = require('path');
-const { stat } = require('fs').promises;
+const { readFile, stat } = require('fs').promises;
 const Generator = require('@asyncapi/generator');
 const { cleanTestResultPaths } = require('@asyncapi/generator-helpers');
 const { runCommonTests, runCommonSlackTests } = require('./common-test.js');
 const asyncapi_v3_path_hoppscotch = path.resolve(__dirname, '../__fixtures__/asyncapi-hoppscotch-client.yml');
+const asyncapi_v3_json_path = path.resolve(__dirname, '../__fixtures__/asyncapi-postman-echo.json');
 
 /**
  * Configuration for different target languages.
@@ -105,6 +106,20 @@ describe('WebSocket Clients Integration Tests', () => {
           const clientOutputFile = path.join(config.testResultPath, defaultOutputFile);
           const checkClientOutputFileExists = await stat(clientOutputFile);
           expect(checkClientOutputFileExists.isFile()).toBeTruthy();
+        }, 30000);
+
+        it('references the generated JSON AsyncAPI file for JSON input', async () => {
+          const outputPath = path.join(config.testResultPath, 'json_input');
+          const generator = new Generator(config.template, outputPath, {
+            forceWrite: true,
+            templateParams: {
+              server: 'echoServer'
+            }
+          });
+          await generator.generateFromFile(asyncapi_v3_json_path);
+          const client = await readFile(path.join(outputPath, 'client.js'), 'utf8');
+
+          expect(client).toContain('path.resolve(__dirname, \'./asyncapi.json\')');
         }, 30000);
       });
     });


### PR DESCRIPTION
## Description

- Fix the JavaScript WebSocket client template to derive the generated AsyncAPI filename from the input format.
- JSON inputs now use `asyncapi.json`, matching the file created by `createAsyncapiFile`; YAML inputs retain `asyncapi.yaml`.
- Add an end-to-end regression test and JSON fixture.

## Related issue(s)

Fixes #1903

## Validation

- `npm run build` in `apps/react-sdk`
- `npm run build` in `apps/generator`
- `npm run test:javascript -- --runInBand` in `packages/templates/clients/websocket/test/integration-test` — 6 passed, 12 snapshots passed
- ESLint on changed JavaScript files
- `git diff --check`

## AI assistance

Generated-by: Codex (GPT-5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JavaScript WebSocket clients now correctly reference `asyncapi.json` when generated from JSON AsyncAPI documents.
  * YAML-based AsyncAPI documents continue to use the appropriate `.yaml` reference.
  * Generated clients now preserve the source specification format when resolving the referenced AsyncAPI document.

* **Tests**
  * Added coverage for generating WebSocket clients from JSON AsyncAPI input.
  * Added validation that the expected specification file is created and referenced correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->